### PR TITLE
[hotfix] jpa auditing 추가

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/AdminBeApplication.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/AdminBeApplication.java
@@ -2,8 +2,10 @@ package DGU_AI_LAB.admin_be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class AdminBeApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #30 

## 🌱 작업 사항
- jpa auditing 추가
- Spring Data JPA가 admins 테이블에 데이터를 저장할 때 created_at 값이 null이라서 MySQL의 NOT NULL 제약 조건 위반으로 인해 insert가 실패함

## 🌱 참고 사항
JpaAuditing 빠질 때 오류
```
Column 'created_at' cannot be null
```