### PR TITLE
Feat/#34 request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 	// smtp
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+	// kubernetes
+	implementation 'io.fabric8:kubernetes-client:6.10.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/controller/AlarmController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/controller/AlarmController.java
@@ -1,5 +1,6 @@
 package DGU_AI_LAB.admin_be.domain.alarm.controller;
 
+import DGU_AI_LAB.admin_be.domain.alarm.controller.docs.AlarmApi;
 import DGU_AI_LAB.admin_be.domain.alarm.service.AlarmService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/alert")
-public class AlarmController {
+public class AlarmController implements AlarmApi {
 
     private final AlarmService alarmService;
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/controller/AlarmController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/controller/AlarmController.java
@@ -1,14 +1,14 @@
 package DGU_AI_LAB.admin_be.domain.alarm.controller;
 
 import DGU_AI_LAB.admin_be.domain.alarm.controller.docs.AlarmApi;
+import DGU_AI_LAB.admin_be.domain.alarm.dto.request.CombinedAlertRequestDTO;
+import DGU_AI_LAB.admin_be.domain.alarm.dto.request.EmailRequestDTO;
+import DGU_AI_LAB.admin_be.domain.alarm.dto.request.SlackDMRequestDTO;
 import DGU_AI_LAB.admin_be.domain.alarm.service.AlarmService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,40 +17,26 @@ public class AlarmController implements AlarmApi {
 
     private final AlarmService alarmService;
 
-    @GetMapping("/send")
-    public ResponseEntity<String> sendAlert(@RequestParam("message") String message) {
-        alarmService.sendSlackAlert(message);
-        return ResponseEntity.ok("Alert sent to Slack");
-    }
-
     @PostMapping("/dm")
-    public ResponseEntity<String> sendSlackDMAlert(
-            @RequestParam("username") String username,
-            @RequestParam("email") String email,
-            @RequestParam("message") String message
-    ) {
-        alarmService.sendDMAlert(username, email, message);
+    public ResponseEntity<String> sendSlackDMAlert(@RequestBody @Valid SlackDMRequestDTO request) {
+        alarmService.sendDMAlert(request.username(), request.email(), request.message());
         return ResponseEntity.ok("Alert sent to Slack DM");
     }
 
     @PostMapping("/email")
-    public ResponseEntity<?> sendEmailAlert(
-            @RequestParam String to,
-            @RequestParam String subject,
-            @RequestParam String body
-    ) {
-        alarmService.sendMailAlert(to, subject, body);
+    public ResponseEntity<?> sendEmailAlert(@RequestBody @Valid EmailRequestDTO request) {
+        alarmService.sendMailAlert(request.to(), request.subject(), request.body());
         return ResponseEntity.ok("Alert sent to Email");
     }
 
     @PostMapping
-    public ResponseEntity<String> sendAllAlerts(
-            @RequestParam("username") String username,
-            @RequestParam("email") String email,
-            @RequestParam("subject") String subject,
-            @RequestParam("message") String message
-    ) {
-        alarmService.sendAllAlerts(username, email, subject, message);
-        return ResponseEntity.ok("Slack DM 및 이메일 전송 완료");
+    public ResponseEntity<String> sendAllAlerts(@RequestBody @Valid CombinedAlertRequestDTO request) {
+        alarmService.sendAllAlerts(
+                request.username(),
+                request.email(),
+                request.subject(),
+                request.message()
+        );
+        return ResponseEntity.ok("Alert sent to Slack DM and Email");
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/controller/AlarmController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/controller/AlarmController.java
@@ -30,6 +30,27 @@ public class AlarmController implements AlarmApi {
             @RequestParam("message") String message
     ) {
         alarmService.sendDMAlert(username, email, message);
-        return ResponseEntity.ok("Slack DM 전송 요청 완료");
+        return ResponseEntity.ok("Alert sent to Slack DM");
+    }
+
+    @PostMapping("/email")
+    public ResponseEntity<?> sendEmailAlert(
+            @RequestParam String to,
+            @RequestParam String subject,
+            @RequestParam String body
+    ) {
+        alarmService.sendMailAlert(to, subject, body);
+        return ResponseEntity.ok("Alert sent to Email");
+    }
+
+    @PostMapping
+    public ResponseEntity<String> sendAllAlerts(
+            @RequestParam("username") String username,
+            @RequestParam("email") String email,
+            @RequestParam("subject") String subject,
+            @RequestParam("message") String message
+    ) {
+        alarmService.sendAllAlerts(username, email, subject, message);
+        return ResponseEntity.ok("Slack DM 및 이메일 전송 완료");
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/controller/AlarmController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/controller/AlarmController.java
@@ -4,18 +4,31 @@ import DGU_AI_LAB.admin_be.domain.alarm.service.AlarmService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/alert")
 public class AlarmController {
 
     private final AlarmService alarmService;
 
-    @GetMapping("/api/alert/send")
+    @GetMapping("/send")
     public ResponseEntity<String> sendAlert(@RequestParam("message") String message) {
         alarmService.sendSlackAlert(message);
         return ResponseEntity.ok("Alert sent to Slack");
+    }
+
+    @PostMapping("/dm")
+    public ResponseEntity<String> sendSlackDMAlert(
+            @RequestParam("username") String username,
+            @RequestParam("email") String email,
+            @RequestParam("message") String message
+    ) {
+        alarmService.sendDMAlert(username, email, message);
+        return ResponseEntity.ok("Slack DM 전송 요청 완료");
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/controller/docs/AlarmApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/controller/docs/AlarmApi.java
@@ -32,4 +32,23 @@ public interface AlarmApi {
             @Parameter(description = "전송할 메시지")
             @RequestParam @NotBlank String message
     );
+
+    @Operation(
+            summary = "Email 알림 전송",
+            description = "Email로 알림 메시지를 전송합니다"
+    )
+    @ApiResponse(
+            responseCode = "200", description = "Email 전송 성공",
+            content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+    )
+    ResponseEntity<?> sendEmailAlert(
+            @Parameter(description = "이메일 받을 주소")
+            @RequestParam @NotBlank String to,
+
+            @Parameter(description = "이메일 제목")
+            @RequestParam @Email String subject,
+
+            @Parameter(description = "이메일 내용")
+            @RequestParam @NotBlank String body
+    );
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/controller/docs/AlarmApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/controller/docs/AlarmApi.java
@@ -1,19 +1,21 @@
 package DGU_AI_LAB.admin_be.domain.alarm.controller.docs;
 
+import DGU_AI_LAB.admin_be.domain.alarm.dto.request.CombinedAlertRequestDTO;
+import DGU_AI_LAB.admin_be.domain.alarm.dto.request.EmailRequestDTO;
+import DGU_AI_LAB.admin_be.domain.alarm.dto.request.SlackDMRequestDTO;
 import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Slack 및 E-mail", description = "Slack 및 Email 알림 API")
 public interface AlarmApi {
+
     @Operation(
             summary = "Slack DM 알림 전송",
             description = "Slack 사용자에게 개인 DM으로 알림 메시지를 전송합니다. 이름이 중복될 경우 이메일이 일치하는 사용자에게 전송됩니다."
@@ -23,32 +25,33 @@ public interface AlarmApi {
             content = @Content(schema = @Schema(implementation = SuccessResponse.class))
     )
     ResponseEntity<?> sendSlackDMAlert(
-            @Parameter(description = "Slack 사용자 이름")
-            @RequestParam @NotBlank String username,
-
-            @Parameter(description = "Slack 사용자 이메일")
-            @RequestParam @Email String email,
-
-            @Parameter(description = "전송할 메시지")
-            @RequestParam @NotBlank String message
+            @RequestBody(description = "Slack DM 알림 요청 DTO", required = true)
+            @Valid SlackDMRequestDTO request
     );
 
     @Operation(
             summary = "Email 알림 전송",
-            description = "Email로 알림 메시지를 전송합니다"
+            description = "Email로 알림 메시지를 전송합니다."
     )
     @ApiResponse(
             responseCode = "200", description = "Email 전송 성공",
             content = @Content(schema = @Schema(implementation = SuccessResponse.class))
     )
     ResponseEntity<?> sendEmailAlert(
-            @Parameter(description = "이메일 받을 주소")
-            @RequestParam @NotBlank String to,
+            @RequestBody(description = "이메일 알림 요청 DTO", required = true)
+            @Valid EmailRequestDTO request
+    );
 
-            @Parameter(description = "이메일 제목")
-            @RequestParam @Email String subject,
-
-            @Parameter(description = "이메일 내용")
-            @RequestParam @NotBlank String body
+    @Operation(
+            summary = "Slack DM + Email 통합 알림 전송",
+            description = "Slack DM과 Email을 동시에 전송합니다."
+    )
+    @ApiResponse(
+            responseCode = "200", description = "Slack + Email 알림 전송 성공",
+            content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+    )
+    ResponseEntity<?> sendAllAlerts(
+            @RequestBody(description = "통합 알림 요청 DTO", required = true)
+            @Valid CombinedAlertRequestDTO request
     );
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/controller/docs/AlarmApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/controller/docs/AlarmApi.java
@@ -1,0 +1,35 @@
+package DGU_AI_LAB.admin_be.domain.alarm.controller.docs;
+
+import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Slack 및 E-mail", description = "Slack 및 Email 알림 API")
+public interface AlarmApi {
+    @Operation(
+            summary = "Slack DM 알림 전송",
+            description = "Slack 사용자에게 개인 DM으로 알림 메시지를 전송합니다. 이름이 중복될 경우 이메일이 일치하는 사용자에게 전송됩니다."
+    )
+    @ApiResponse(
+            responseCode = "200", description = "Slack DM 전송 성공",
+            content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+    )
+    ResponseEntity<?> sendSlackDMAlert(
+            @Parameter(description = "Slack 사용자 이름")
+            @RequestParam @NotBlank String username,
+
+            @Parameter(description = "Slack 사용자 이메일")
+            @RequestParam @Email String email,
+
+            @Parameter(description = "전송할 메시지")
+            @RequestParam @NotBlank String message
+    );
+}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/dto/request/CombinedAlertRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/dto/request/CombinedAlertRequestDTO.java
@@ -1,0 +1,21 @@
+package DGU_AI_LAB.admin_be.domain.alarm.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record CombinedAlertRequestDTO(
+        @NotBlank
+        String username,
+
+        @NotBlank
+        @Email
+        String email,
+
+        @NotBlank
+        String subject,
+
+        @NotBlank
+        String message
+) {}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/dto/request/EmailRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/dto/request/EmailRequestDTO.java
@@ -1,0 +1,18 @@
+package DGU_AI_LAB.admin_be.domain.alarm.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record EmailRequestDTO(
+        @NotBlank
+        @Email
+        String to,
+
+        @NotBlank
+        String subject,
+
+        @NotBlank
+        String body
+) {}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/dto/request/SlackDMRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/dto/request/SlackDMRequestDTO.java
@@ -1,0 +1,18 @@
+package DGU_AI_LAB.admin_be.domain.alarm.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record SlackDMRequestDTO(
+        @NotBlank
+        String username,
+
+        @NotBlank
+        @Email
+        String email,
+
+        @NotBlank
+        String message
+) {}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/service/AlarmService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/service/AlarmService.java
@@ -1,18 +1,19 @@
 package DGU_AI_LAB.admin_be.domain.alarm.service;
 
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
-
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+// import java.util.Map;
+import DGU_AI_LAB.admin_be.error.ErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +22,9 @@ public class AlarmService {
 
     @Value("${slack-webhook-url.monitoring}")
     private String defaultWebhookUrl;
+
+    @Value("${slack.bot-token}")
+    private String botToken;
     private final RestTemplate restTemplate = new RestTemplate();
 
     private final JavaMailSender mailSender;
@@ -57,5 +61,106 @@ public class AlarmService {
         message.setText(body);
         mailSender.send(message);
         System.out.printf("메일 전송 성공: 수신자=%s, 제목=%s%n", to, subject);
+    }
+
+    // slack dm 전송
+    public void sendDMAlert(String username, String email, String message) {
+        String userId = getSlackUser(username, email, botToken);
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.SLACK_USER_NOT_FOUND);
+        }
+
+        String channelId = openDMChannel(userId, botToken);
+        if (channelId == null) {
+            throw new BusinessException(ErrorCode.SLACK_DM_CHANNEL_FAILED);
+        }
+
+        try {
+            sendMessageToSlackChannel(channelId, message, botToken);
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.SLACK_SEND_FAILED);
+        }
+    }
+
+    // 이름이 일치하는 사용자에게 dm 전송
+    // 이름이 같은 사용자가 있는 경우 email이 일치하는 사용자에게 dm 전송
+    private String getSlackUser(String username, String email, String token) {
+        String url = "https://slack.com/api/users.list";
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(url, HttpMethod.GET, request, Map.class);
+        if (!Boolean.TRUE.equals(response.getBody().get("ok"))) {
+            throw new BusinessException(ErrorCode.SLACK_USER_NOT_FOUND);
+        }
+
+        List<Map<String, Object>> members = (List<Map<String, Object>>) response.getBody().get("members");
+
+        // 이름이 일치하는 사용자 목록 필터링
+        List<Map<String, Object>> matchedUsers = members.stream()
+                .filter(user -> {
+                    Map<String, Object> profile = (Map<String, Object>) user.get("profile");
+                    String displayName = (String) profile.get("display_name");
+                    String realName = (String) profile.get("real_name");
+                    String name = (String) user.get("name");
+
+                    return username.equals(name) || username.equals(displayName) || username.equals(realName);
+                })
+                .collect(Collectors.toList());
+
+        if (matchedUsers.isEmpty()) {
+            throw new BusinessException(ErrorCode.SLACK_USER_NOT_FOUND);
+        }
+
+        if (matchedUsers.size() == 1) {
+            return (String) matchedUsers.get(0).get("id");
+        }
+
+        Map<String, Object> selectedUser = matchedUsers.stream()
+                .filter(user -> {
+                    Map<String, Object> profile = (Map<String, Object>) user.get("profile");
+                    String userEmail = (String) profile.get("email");
+                    return userEmail != null && userEmail.equalsIgnoreCase(email);
+                })
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ErrorCode.SLACK_USER_EMAIL_NOT_MATCH));
+
+        return (String) selectedUser.get("id");
+    }
+
+    private String openDMChannel(String userId, String token) {
+        String url = "https://slack.com/api/conversations.open";
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> body = Map.of("users", userId);
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<Map> response = restTemplate.postForEntity(url, request, Map.class);
+        if (Boolean.TRUE.equals(response.getBody().get("ok"))) {
+            Map channel = (Map) response.getBody().get("channel");
+            return (String) channel.get("id");
+        }
+        return null;
+    }
+
+    private void sendMessageToSlackChannel(String channelId, String message, String token) {
+        String url = "https://slack.com/api/chat.postMessage";
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, Object> body = Map.of(
+                "channel", channelId,
+                "text", message
+        );
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<Map> response = restTemplate.postForEntity(url, request, Map.class);
+        if (!Boolean.TRUE.equals(response.getBody().get("ok"))) {
+            throw new BusinessException(ErrorCode.SLACK_SEND_FAILED);
+        }
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/service/AlarmService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/service/AlarmService.java
@@ -163,4 +163,9 @@ public class AlarmService {
             throw new BusinessException(ErrorCode.SLACK_SEND_FAILED);
         }
     }
+
+    public void sendAllAlerts(String username, String email, String subject, String message) {
+        sendDMAlert(username, email, message);
+        sendMailAlert(email, subject, message);
+    }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/RequestController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/RequestController.java
@@ -9,6 +9,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/requests")
 @RequiredArgsConstructor
@@ -31,5 +33,11 @@ public class RequestController implements RequestApi {
     @GetMapping("/{id}")
     public ResponseEntity<RequestResponseDTO> getRequest(@PathVariable Long id) {
         return ResponseEntity.ok(requestService.getRequestById(id));
+    }
+
+    // 각 user의 사용 신청 목록 조회
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<RequestResponseDTO>> getRequestsByUser(@PathVariable Long userId) {
+        return ResponseEntity.ok(requestService.getRequestsByUserId(userId));
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/RequestController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/RequestController.java
@@ -2,6 +2,7 @@ package DGU_AI_LAB.admin_be.domain.requests.controller;
 
 import DGU_AI_LAB.admin_be.domain.requests.controller.docs.RequestApi;
 import DGU_AI_LAB.admin_be.domain.requests.dto.request.SaveRequestDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.RequestResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.service.RequestService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +29,7 @@ public class RequestController implements RequestApi {
 
     // 개별 사용 신청 목록 조회
     @GetMapping("/{id}")
-    public ResponseEntity<SaveRequestDTO> getRequest(@PathVariable Long id) {
+    public ResponseEntity<RequestResponseDTO> getRequest(@PathVariable Long id) {
         return ResponseEntity.ok(requestService.getRequestById(id));
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/RequestProcessingController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/RequestProcessingController.java
@@ -31,7 +31,7 @@ public class RequestProcessingController implements RequestProcessingApi {
 
     @PostMapping("/reject")
     public ResponseEntity<?> reject(@RequestBody @Valid RequestRejectDTO request) {
-        requestProcessingService.rejectRequest(request.requestId());
+        requestProcessingService.rejectRequest(request.requestId(), request.reason());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/RequestApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/RequestApi.java
@@ -14,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import java.util.List;
+
 @Tag(name = "사용 신청", description = "서버 사용 신청 등록 및 조회 API")
 public interface RequestApi {
 
@@ -32,5 +34,12 @@ public interface RequestApi {
             content = @Content(schema = @Schema(implementation = SaveRequestDTO.class)))
     ResponseEntity<RequestResponseDTO> getRequest(
             @Parameter(description = "신청 ID", example = "1") @PathVariable Long id
+    );
+
+    @Operation(summary = "사용자별 신청 조회", description = "UserID로 사용자별 신청 내용을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "신청 반환",
+            content = @Content(schema = @Schema(implementation = SaveRequestDTO.class)))
+    ResponseEntity<List<RequestResponseDTO>> getRequestsByUser(
+            @Parameter(description = "USERID", example = "1") @PathVariable Long userId
     );
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/RequestApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/RequestApi.java
@@ -1,6 +1,7 @@
 package DGU_AI_LAB.admin_be.domain.requests.controller.docs;
 
 import DGU_AI_LAB.admin_be.domain.requests.dto.request.SaveRequestDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.RequestResponseDTO;
 import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -29,7 +30,7 @@ public interface RequestApi {
     @Operation(summary = "개별 신청 조회", description = "ID로 특정 신청 내용을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "신청 반환",
             content = @Content(schema = @Schema(implementation = SaveRequestDTO.class)))
-    ResponseEntity<SaveRequestDTO> getRequest(
+    ResponseEntity<RequestResponseDTO> getRequest(
             @Parameter(description = "신청 ID", example = "1") @PathVariable Long id
     );
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/RequestRejectDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/RequestRejectDTO.java
@@ -3,6 +3,7 @@ package DGU_AI_LAB.admin_be.domain.requests.dto.request;
 import jakarta.validation.constraints.NotNull;
 
 public record RequestRejectDTO(
-        @NotNull Long requestId
+        @NotNull Long requestId,
+        String reason
 ) {
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SaveRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SaveRequestDTO.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Answer;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.NotBlank;
 
@@ -12,6 +13,7 @@ public record SaveRequestDTO(
         Long requestId,
         @NotBlank String serverName,
         @NotNull Status status,
+        @NotNull Long userId,
         @NotNull List<RequestAnswerDTO> answers
 ) {
     public static SaveRequestDTO fromEntity(Request request) {
@@ -23,14 +25,16 @@ public record SaveRequestDTO(
                 request.getRequestId(),
                 request.getServerName(),
                 request.getStatus(),
+                request.getUser().getUserId(),
                 answerDTOs
         );
     }
 
-    public Request toEntity() {
+    public Request toEntity(User user) {
         Request request = Request.builder()
                 .serverName(this.serverName)
                 .status(this.status)
+                .user(user)
                 .build();
 
         List<Answer> answerEntities = this.answers.stream()

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/RequestResponseDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/RequestResponseDTO.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 public record RequestResponseDTO (
     Long requestID,
+    Long userID,
     String serverName,
     Status status,
     String reason,
@@ -15,6 +16,7 @@ public record RequestResponseDTO (
     public static RequestResponseDTO fromEntity(Request request) {
         return new RequestResponseDTO(
                 request.getRequestId(),
+                request.getUser().getUserId(),
                 request.getServerName(),
                 request.getStatus(),
                 request.getReason(),

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/RequestResponseDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/RequestResponseDTO.java
@@ -9,6 +9,7 @@ public record RequestResponseDTO (
     Long requestID,
     String serverName,
     Status status,
+    String reason,
     List<AnswerResponseDTO> answers
 ) {
     public static RequestResponseDTO fromEntity(Request request) {
@@ -16,6 +17,7 @@ public record RequestResponseDTO (
                 request.getRequestId(),
                 request.getServerName(),
                 request.getStatus(),
+                request.getReason(),
                 request.getAnswers().stream()
                         .map(AnswerResponseDTO::fromEntity)
                         .toList()

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Request.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Request.java
@@ -26,11 +26,19 @@ public class Request extends BaseTimeEntity  {
     @Builder.Default
     private Status status = Status.HOLD;
 
+    @Column(name = "reason", columnDefinition = "TEXT")
+    private String reason;
+
     @Builder.Default
     @OneToMany(mappedBy = "request", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Answer> answers = new ArrayList<>();
 
     public void updateStatus(Status status) {
         this.status = status;
+    }
+
+    public void reject(Status status, String reason) {
+        this.status = status;
+        this.reason = reason;
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Request.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Request.java
@@ -1,5 +1,6 @@
 package DGU_AI_LAB.admin_be.domain.requests.entity;
 
+import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import DGU_AI_LAB.admin_be.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -28,6 +29,10 @@ public class Request extends BaseTimeEntity  {
 
     @Column(name = "reason", columnDefinition = "TEXT")
     private String reason;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @Builder.Default
     @OneToMany(mappedBy = "request", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/repository/RequestRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/repository/RequestRepository.java
@@ -4,6 +4,9 @@ import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface RequestRepository extends JpaRepository<Request, Long> {
+    List<Request> findAllByUser_UserId(Long userId);
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestProcessingService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestProcessingService.java
@@ -73,10 +73,10 @@ public class RequestProcessingService {
     }
 
     @Transactional
-    public void rejectRequest(Long requestId) {
+    public void rejectRequest(Long requestId, String reason) {
         Request request = requestRepository.findById(requestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
-        request.updateStatus(Status.REJECTED);
+        request.reject(Status.REJECTED, reason);
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestService.java
@@ -1,6 +1,7 @@
 package DGU_AI_LAB.admin_be.domain.requests.service;
 
 import DGU_AI_LAB.admin_be.domain.requests.dto.request.SaveRequestDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.RequestResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
@@ -17,24 +18,24 @@ public class RequestService {
 
     // TODO: saveRequestDTO 메서드가 두개인데, 수정이 필요한 것 같아요!
     @Transactional
-    public SaveRequestDTO saveRequest(SaveRequestDTO UseRequest) {
-        if (UseRequest.answers() == null || UseRequest.answers().isEmpty()) {
+    public RequestResponseDTO saveRequest(SaveRequestDTO requestDto) {
+        if (requestDto.answers() == null || requestDto.answers().isEmpty()) {
             throw new BusinessException(ErrorCode.MISSING_REQUEST_PARAMETER);
         }
 
-        Request saved = requestRepository.save(UseRequest.toEntity());
-        return SaveRequestDTO.fromEntity(saved);
+        Request saved = requestRepository.save(requestDto.toEntity());
+        return RequestResponseDTO.fromEntity(saved);
     }
 
-    public List<SaveRequestDTO> getAllRequests() {
+    public List<RequestResponseDTO> getAllRequests() {
         return requestRepository.findAll().stream()
-                .map(SaveRequestDTO::fromEntity)
+                .map(RequestResponseDTO::fromEntity)
                 .toList();
     }
 
-    public SaveRequestDTO getRequestById(Long id) {
+    public RequestResponseDTO getRequestById(Long id) {
         Request request = requestRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
-        return SaveRequestDTO.fromEntity(request);
+        return RequestResponseDTO.fromEntity(request);
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestService.java
@@ -4,6 +4,9 @@ import DGU_AI_LAB.admin_be.domain.requests.dto.request.SaveRequestDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.RequestResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import DGU_AI_LAB.admin_be.domain.users.entity.User;
+import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
+import DGU_AI_LAB.admin_be.domain.users.service.UserService;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RequestService {
     private final RequestRepository requestRepository;
+    private final UserRepository userRepository;
 
     // TODO: saveRequestDTO 메서드가 두개인데, 수정이 필요한 것 같아요!
     @Transactional
@@ -23,7 +27,10 @@ public class RequestService {
             throw new BusinessException(ErrorCode.MISSING_REQUEST_PARAMETER);
         }
 
-        Request saved = requestRepository.save(requestDto.toEntity());
+        User user = userRepository.findById(requestDto.userId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Request saved = requestRepository.save(requestDto.toEntity(user));
         return RequestResponseDTO.fromEntity(saved);
     }
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestService.java
@@ -45,4 +45,11 @@ public class RequestService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
         return RequestResponseDTO.fromEntity(request);
     }
+
+    public List<RequestResponseDTO> getRequestsByUserId(Long userId) {
+        List<Request> requests = requestRepository.findAllByUser_UserId(userId);
+        return requests.stream()
+                .map(RequestResponseDTO::fromEntity)
+                .toList();
+    }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/entity/User.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/entity/User.java
@@ -1,5 +1,6 @@
 package DGU_AI_LAB.admin_be.domain.users.entity;
 
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
 import DGU_AI_LAB.admin_be.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -44,6 +45,9 @@ public class User extends BaseTimeEntity {
     @Column(name = "is_active", nullable = false)
     @Builder.Default
     private Boolean isActive = true;
+
+    @OneToMany(mappedBy = "user")
+    private List<Request> requests;
 
     public void updateUserInfo(String password, Boolean isActive) {
         this.password = password;

--- a/src/main/java/DGU_AI_LAB/admin_be/error/ErrorCode.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/error/ErrorCode.java
@@ -64,6 +64,16 @@ public enum ErrorCode {
     JSON_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "JSON 파싱에 실패하였습니다."),
 
     /**
+     * 502 Bad Gateway
+     */
+    SLACK_DM_CHANNEL_FAILED(HttpStatus.BAD_GATEWAY, "Slack DM 채널 열기를 실패하였습니다."),
+
+    /**
+     * 503 Service Unavailable
+     */
+    SLACK_SEND_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "Slack 메시지 전송에 실패하였습니다."),
+
+    /**
      * User Error
      */
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "사용자 인증에 실패하였습니다."),
@@ -71,6 +81,8 @@ public enum ErrorCode {
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 사용자입니다."),
     DUPLICATE_NAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),
     INVALID_LOGIN_INFO(HttpStatus.BAD_REQUEST, "잘못된 로그인 입력값입니다."),
+    SLACK_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "Slack 사용자를 찾을 수 없습니다."),
+    SLACK_USER_EMAIL_NOT_MATCH(HttpStatus.NOT_FOUND, "이메일이 일치하는 Slack 사용자를 찾을 수 없습니다."),
 
     /**
      * Approval Error


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #[Issue number]

## 🌱 작업 사항
- slack dm과 email로 메시지 전송 api
- request에 거절 사유를 저장하는 컬럼 추가
- user와 request 연결

## 🌱 참고 사항
- slack에 이름이 같은 사람이 있는 경우 이메일 값까지 일치하는 사용자에게 dm을 전송하도록 구현하였습니다.