### PR TITLE
[feat] resource 관련 사용자 API 개발

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/dashboard/controller/DashboardController.java
@@ -1,0 +1,44 @@
+package DGU_AI_LAB.admin_be.domain.dashboard.controller;
+
+import DGU_AI_LAB.admin_be.domain.dashboard.service.DashboardService;
+import DGU_AI_LAB.admin_be.domain.gpus.dto.response.GpuTypeResponseDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.UserServerResponseDTO;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import DGU_AI_LAB.admin_be.global.auth.CustomUserDetails;
+import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/dashboard")
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+
+    /**
+     * 사용자 신청 현황 서버 목록 조회 API -> 다른 곳으로 옮겨야 함 (Request)
+     * GET /api/dashboard/me/servers
+     *
+     * @param principal 현재 로그인한 사용자의 인증 정보 (CustomUserDetails)
+     * @param status    조회할 서버 요청의 상태 (필수 값: PENDING, FULFILLED, DENIED 등)
+     * 사용자의 승인받은 서버 목록 또는 승인 대기중인 신청 목록을 필터링하여 반환합니다.
+     */
+    @GetMapping("/me/servers")
+    public ResponseEntity<SuccessResponse<?>> getUserServers(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @RequestParam(name = "status") Status status
+    ) {
+        // 현재 로그인한 사용자의 ID와 요청 상태를 기반으로 서버 목록을 조회합니다.
+        log.info("[getUserServers] 사용자 서버 목록 조회 API 호출 - userId: {}, status: {}", principal.getUserId(), status);
+        List<UserServerResponseDTO> userServers = dashboardService.getUserServers(principal.getUserId(), status);
+        return SuccessResponse.ok(userServers);
+    }
+}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/dashboard/service/DashboardService.java
@@ -1,0 +1,66 @@
+package DGU_AI_LAB.admin_be.domain.dashboard.service;
+
+import DGU_AI_LAB.admin_be.domain.nodes.entity.Node;
+import DGU_AI_LAB.admin_be.domain.nodes.repository.NodeRepository;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.UserServerResponseDTO;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DashboardService {
+
+    private final RequestRepository requestRepository;
+    private final NodeRepository nodeRepository;
+
+    /**
+     * 사용자 대시보드 서버 목록 조회
+     * 승인받은 서버 및 승인 대기중인 신청 목록을 필터링하여 반환합니다.
+     */
+    public List<UserServerResponseDTO> getUserServers(Long userId, Status status) {
+        log.info("[getUserServers] userId={}의 status={} 서버 목록 조회 시작", userId, status);
+
+        List<Request> requests = requestRepository.findByUserUserIdAndStatus(userId, status);
+
+        return requests.stream()
+                .map(request -> {
+                    String serverAddress = (request.getStatus() == Status.FULFILLED) ? "TBD (서버 할당 후 표시)" : null;
+
+                    Integer cpuCoreCount = null;
+                    Integer memoryGB = null;
+                    String resourceGroupName = null;
+
+                    ResourceGroup resourceGroup = request.getResourceGroup();
+                    if (resourceGroup != null) {
+                        resourceGroupName = resourceGroup.getDescription();
+
+                        List<Node> nodesInGroup = nodeRepository.findByRsgroupId(resourceGroup.getRsgroupId());
+                        if (!nodesInGroup.isEmpty()) {
+                            Node representativeNode = nodesInGroup.get(0);
+                            cpuCoreCount = representativeNode.getCpuCoreCount();
+                            memoryGB = representativeNode.getMemorySizeGB();
+                        }
+                    }
+
+                    return UserServerResponseDTO.fromEntity(
+                            request,
+                            serverAddress,
+                            cpuCoreCount,
+                            memoryGB,
+                            resourceGroupName
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/gpus/dto/response/GpuTypeResponseDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/gpus/dto/response/GpuTypeResponseDTO.java
@@ -1,0 +1,12 @@
+package DGU_AI_LAB.admin_be.domain.gpus.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record GpuTypeResponseDTO(
+        String gpuModel,
+        Integer ramGb,
+        String resourceGroupName,
+        Long availableNodes,
+        Boolean isAvailable // TODO: 현재는 항상 true로 가정, 이후에 논의 후 수정 필요
+) {}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/gpus/entity/Gpu.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/gpus/entity/Gpu.java
@@ -14,6 +14,7 @@ import lombok.*;
 public class Gpu {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "gpu_id", nullable = false)
     private Long gpuId;
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/gpus/repository/GpuRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/gpus/repository/GpuRepository.java
@@ -1,0 +1,21 @@
+package DGU_AI_LAB.admin_be.domain.gpus.repository;
+
+import DGU_AI_LAB.admin_be.domain.gpus.entity.Gpu;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GpuRepository extends JpaRepository<Gpu, Long> {
+
+    @Query("SELECT g.gpuModel, g.ramGb, rg.description, COUNT(DISTINCT n.nodeId) " +
+            "FROM Gpu g JOIN g.node n JOIN ResourceGroup rg ON n.rsgroupId = rg.rsgroupId " +
+            "GROUP BY g.gpuModel, g.ramGb, rg.description")
+    List<Object[]> findGpuSummary();
+    @Query("SELECT DISTINCT n.cpuCoreCount, n.memorySizeGB " +
+            "FROM Gpu g JOIN g.node n " +
+            "WHERE g.gpuModel = :gpuModel")
+    List<Object[]> findNodeSpecsByGpuModel(String gpuModel);
+}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/nodes/repository/NodeRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/nodes/repository/NodeRepository.java
@@ -4,6 +4,9 @@ import DGU_AI_LAB.admin_be.domain.nodes.entity.Node;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface NodeRepository extends JpaRepository<Node, String> {
+    List<Node> findByRsgroupId(Integer rsgroupId);
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/UserServerResponseDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/UserServerResponseDTO.java
@@ -1,0 +1,34 @@
+package DGU_AI_LAB.admin_be.domain.requests.dto.response;
+
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record UserServerResponseDTO(
+        Long requestId,
+        String serverAddress,
+        LocalDateTime expiresAt,
+        Long volumeSizeGB,
+        String cudaVersion,
+        Integer cpuCoreCount,
+        Integer memoryGB,
+        String resourceGroupName,
+        Status status
+) {
+    public static UserServerResponseDTO fromEntity(Request request, String serverAddress, Integer cpuCoreCount, Integer memoryGB, String resourceGroupName) {
+        return UserServerResponseDTO.builder()
+                .requestId(request.getRequestId())
+                .serverAddress(serverAddress)
+                .expiresAt(request.getExpiresAt())
+                .volumeSizeGB(request.getVolumeSizeByte() / (1024L * 1024 * 1024)) // Byte를 GB로 변환
+                .cudaVersion(request.getCudaVersion())
+                .cpuCoreCount(cpuCoreCount)
+                .memoryGB(memoryGB)
+                .resourceGroupName(resourceGroupName)
+                .status(request.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/repository/RequestRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/repository/RequestRepository.java
@@ -13,5 +13,5 @@ public interface RequestRepository extends JpaRepository<Request, Long> {
     List<Request> findAllByUser(User user);
     List<Request> findAllByUser_UserId(Long userId);
     List<Request> findAllByStatus(Status status);
-
+    List<Request> findByUserUserIdAndStatus(Long userId, Status status);
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/resourceGroups/controller/ResourceGroupController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/resourceGroups/controller/ResourceGroupController.java
@@ -1,0 +1,35 @@
+package DGU_AI_LAB.admin_be.domain.resourceGroups.controller;
+
+import DGU_AI_LAB.admin_be.domain.gpus.dto.response.GpuTypeResponseDTO;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.service.ResourceGroupService;
+import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/resources")
+public class ResourceGroupController {
+
+    private final ResourceGroupService resourceGroupService;
+
+    /**
+     * GPU 기종별(리소스그룹) 리소스 정보 조회 API
+     * GET /api/dashboard/gpu-types
+     *
+     * 우선 모든 노드는 현재 사용 가능하다고 가정합니다.
+     */
+    @GetMapping("/gpu-types")
+    public ResponseEntity<SuccessResponse<?>> getGpuTypeResources() {
+        List<GpuTypeResponseDTO> gpuTypes = resourceGroupService.getGpuTypeResources();
+        return SuccessResponse.ok(gpuTypes);
+    }
+
+}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/resourceGroups/dto/response/ResourceGroupResponseDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/resourceGroups/dto/response/ResourceGroupResponseDTO.java
@@ -1,0 +1,17 @@
+package DGU_AI_LAB.admin_be.domain.resourceGroups.dto.response;
+
+import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
+import lombok.Builder;
+
+@Builder
+public record ResourceGroupResponseDTO(
+        Integer rsgroupId,
+        String description
+) {
+    public static ResourceGroupResponseDTO fromEntity(ResourceGroup resourceGroup) {
+        return ResourceGroupResponseDTO.builder()
+                .rsgroupId(resourceGroup.getRsgroupId())
+                .description(resourceGroup.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/resourceGroups/service/ResourceGroupService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/resourceGroups/service/ResourceGroupService.java
@@ -1,0 +1,53 @@
+package DGU_AI_LAB.admin_be.domain.resourceGroups.service;
+
+import DGU_AI_LAB.admin_be.domain.gpus.dto.response.GpuTypeResponseDTO;
+import DGU_AI_LAB.admin_be.domain.gpus.repository.GpuRepository;
+import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ResourceGroupService {
+
+    private final GpuRepository gpuRepository;
+
+    /**
+     * GPU 기종별 리소스 정보 조회
+     * 모든 노드가 사용 가능하다는 가정 하에, 각 GPU 모델의 리소스 그룹 내 노드 개수를 반환합니다.
+     */
+    public List<GpuTypeResponseDTO> getGpuTypeResources() {
+        log.info("[getGpuTypeResources] GPU 기종별 리소스 정보 조회 시작");
+
+        List<Object[]> gpuSummaries = gpuRepository.findGpuSummary();
+
+        List<GpuTypeResponseDTO> response = gpuSummaries.stream()
+                .map(obj -> {
+                    String gpuModel = (String) obj[0];
+                    Integer ramGb = (Integer) obj[1];
+                    String resourceGroupName = (String) obj[2];
+                    Long availableNodes = ((Number) obj[3]).longValue();
+
+                    return GpuTypeResponseDTO.builder()
+                            .gpuModel(gpuModel)
+                            .ramGb(ramGb)
+                            .resourceGroupName(resourceGroupName)
+                            .availableNodes(availableNodes)
+                            .isAvailable(true)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        log.info("[getGpuTypeResources] GPU 기종별 리소스 정보 조회 완료. {}개 기종", response.size());
+        return response;
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #73 

## 🌱 작업 사항
- GPU 기종별 리소스 정보 반환 : `GET /api/resources/gpu-types`
- 사용자 대시보드 승인받은 서버 목록 : `GET /api/dashboard/me/servers`

## 🌱 참고 사항
- 서버 주소 & 사용 가능 노드 조회 여부는 어떻게 해야할 지 모르겠어서, 우선 전부 사용 가능하다고 가정하고 만들었습니다. 생각해보고 추가해두겠습니다.
- 노션에 우선 response를 정리해놓았습니다! @kwdahun 확인하시면 됩니다.
- 배포 이후에 DB에 더미데이터를 넣어둬야 합니다.