### PR TITLE
[feat/fix] 그룹 생성 API, 우분투 그룹 관련 버그 수정

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/controller/GroupController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/controller/GroupController.java
@@ -1,14 +1,14 @@
 package DGU_AI_LAB.admin_be.domain.groups.controller;
 
+import DGU_AI_LAB.admin_be.domain.groups.dto.request.CreateGroupRequestDTO;
 import DGU_AI_LAB.admin_be.domain.groups.dto.response.GroupResponseDTO;
 import DGU_AI_LAB.admin_be.domain.groups.service.GroupService;
 import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -23,12 +23,22 @@ public class GroupController {
     /**
      * 모든 그룹 정보 조회 API
      * GET /api/groups
-     *
      * 그룹 ID와 그룹명을 반환합니다.
      */
-    @GetMapping("")
+    @GetMapping
     public ResponseEntity<SuccessResponse<?>> getGroups() {
         List<GroupResponseDTO> groups = groupService.getAllGroups();
         return SuccessResponse.ok(groups);
+    }
+
+    /**
+     * 새로운 그룹을 생성하는 API
+     * POST /api/groups
+     */
+    @PostMapping
+    public ResponseEntity<SuccessResponse<?>> createGroup(@RequestBody @Valid CreateGroupRequestDTO dto) {
+        log.info("[createGroup] 새로운 그룹 생성 요청 접수: {}", dto.groupName());
+        GroupResponseDTO response = groupService.createGroup(dto);
+        return SuccessResponse.created(response);
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/dto/request/CreateGroupRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/dto/request/CreateGroupRequestDTO.java
@@ -1,0 +1,16 @@
+package DGU_AI_LAB.admin_be.domain.groups.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Builder;
+
+@Builder
+public record CreateGroupRequestDTO(
+        @NotNull @Positive
+        Long ubuntuGid,
+
+        @NotBlank
+        String groupName
+) {
+}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/entity/Group.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/entity/Group.java
@@ -10,18 +10,21 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@EqualsAndHashCode(of = "ubuntuGid")
+@EqualsAndHashCode(of = "groupId")
 public class Group {
 
     @Id
-    @Column(name = "ubuntu_gid", nullable = false)
-    private Long ubuntuGid;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "group_id")
+    private Long groupId;
 
     @Column(name = "group_name", nullable = false, length = 100)
     private String groupName;
 
+    @Column(name = "ubuntu_gid", unique = true, nullable = false)
+    private Long ubuntuGid;
+
     @OneToOne(fetch = FetchType.LAZY)
-    @MapsId
-    @JoinColumn(name = "ubuntu_gid")
+    @JoinColumn(name = "ubuntu_gid", referencedColumnName = "id_value", insertable = false, updatable = false)
     private UsedId usedId;
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/entity/Group.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/entity/Group.java
@@ -10,21 +10,18 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@EqualsAndHashCode(of = "groupId")
+@EqualsAndHashCode(of = "ubuntuGid")
 public class Group {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "group_id")
-    private Long groupId;
+    @Column(name = "ubuntu_gid", nullable = false)
+    private Long ubuntuGid;
 
     @Column(name = "group_name", nullable = false, length = 100)
     private String groupName;
 
-    @Column(name = "ubuntu_gid", unique = true, nullable = false)
-    private Long ubuntuGid;
-
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "ubuntu_gid", referencedColumnName = "id_value", insertable = false, updatable = false)
+    @MapsId
+    @JoinColumn(name = "ubuntu_gid")
     private UsedId usedId;
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/repository/GroupRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/repository/GroupRepository.java
@@ -10,4 +10,5 @@ import java.util.Set;
 @Repository
 public interface GroupRepository extends JpaRepository<Group, Long> {
     List<Group> findAllByUbuntuGidIn(Set<Long> ubuntuGids);
+    boolean existsByUbuntuGid(Long ubuntuGid);
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
@@ -1,7 +1,11 @@
 package DGU_AI_LAB.admin_be.domain.groups.service;
 
+import DGU_AI_LAB.admin_be.domain.groups.dto.request.CreateGroupRequestDTO;
 import DGU_AI_LAB.admin_be.domain.groups.dto.response.GroupResponseDTO;
+import DGU_AI_LAB.admin_be.domain.groups.entity.Group;
 import DGU_AI_LAB.admin_be.domain.groups.repository.GroupRepository;
+import DGU_AI_LAB.admin_be.domain.usedIds.entity.UsedId;
+import DGU_AI_LAB.admin_be.domain.usedIds.repository.UsedIdRepository;
 import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -18,6 +23,7 @@ import java.util.List;
 public class GroupService {
 
     private final GroupRepository groupRepository;
+    private final UsedIdRepository usedIdRepository;
 
     /**
      * 모든 그룹 정보를 조회하는 API
@@ -38,5 +44,43 @@ public class GroupService {
 
         log.info("[getAllGroups] 모든 그룹 정보 조회 완료. {}개 그룹", response.size());
         return response;
+    }
+
+    /**
+     * 새로운 그룹을 생성하는 API
+     * POST /api/groups
+     */
+    @Transactional
+    public GroupResponseDTO createGroup(CreateGroupRequestDTO dto) {
+        log.info("[createGroup] 그룹 생성 요청 시작: groupName={}, ubuntuGid={}", dto.groupName(), dto.ubuntuGid());
+
+        // 1. 요청받은 GID로 UsedId가 이미 존재하는지 확인하고, 없으면 생성
+        Optional<UsedId> existingUsedId = usedIdRepository.findById(dto.ubuntuGid());
+        UsedId usedId;
+        if (existingUsedId.isPresent()) {
+            log.warn("[createGroup] 중복된 GID가 UsedId에 이미 존재합니다: {}", dto.ubuntuGid());
+            usedId = existingUsedId.get();
+        } else {
+            usedId = usedIdRepository.saveAndFlush(UsedId.builder().idValue(dto.ubuntuGid()).build());
+            log.info("[createGroup] UsedId에 GID {} 할당 완료", dto.ubuntuGid());
+        }
+
+        // 2. 해당 GID의 그룹이 이미 존재하는지 확인
+        if (groupRepository.existsByUbuntuGid(dto.ubuntuGid())) {
+            log.warn("[createGroup] 중복된 GID를 가진 그룹이 이미 존재합니다: {}", dto.ubuntuGid());
+            throw new BusinessException(ErrorCode.DUPLICATE_GROUP_ID);
+        }
+
+        // 3. 그룹 엔티티 생성 및 저장
+        Group group = Group.builder()
+                .groupName(dto.groupName())
+                .ubuntuGid(dto.ubuntuGid())
+                .usedId(usedId)
+                .build();
+
+        group = groupRepository.save(group);
+        log.info("[createGroup] 그룹 생성 완료: id={}, name={}", group.getGroupId(), group.getGroupName());
+
+        return GroupResponseDTO.fromEntity(group);
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
@@ -1,11 +1,7 @@
 package DGU_AI_LAB.admin_be.domain.groups.service;
 
-import DGU_AI_LAB.admin_be.domain.groups.dto.request.CreateGroupRequestDTO;
 import DGU_AI_LAB.admin_be.domain.groups.dto.response.GroupResponseDTO;
-import DGU_AI_LAB.admin_be.domain.groups.entity.Group;
 import DGU_AI_LAB.admin_be.domain.groups.repository.GroupRepository;
-import DGU_AI_LAB.admin_be.domain.usedIds.entity.UsedId;
-import DGU_AI_LAB.admin_be.domain.usedIds.repository.UsedIdRepository;
 import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +10,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -23,10 +18,9 @@ import java.util.Optional;
 public class GroupService {
 
     private final GroupRepository groupRepository;
-    private final UsedIdRepository usedIdRepository;
 
     /**
-     * 모든 그룹 정보 조회 API
+     * 모든 그룹 정보를 조회하는 API
      * GET /api/groups
      */
     public List<GroupResponseDTO> getAllGroups() {
@@ -44,44 +38,5 @@ public class GroupService {
 
         log.info("[getAllGroups] 모든 그룹 정보 조회 완료. {}개 그룹", response.size());
         return response;
-    }
-
-    /**
-     * 새로운 그룹을 생성하는 API
-     * POST /api/groups
-     */
-    @Transactional
-    public GroupResponseDTO createGroup(CreateGroupRequestDTO dto) {
-        log.info("[createGroup] 그룹 생성 요청 시작: groupName={}, ubuntuGid={}", dto.groupName(), dto.ubuntuGid());
-
-        // 1. 요청받은 GID가 UsedId에 이미 사용 중인지 확인하고, 없으면 생성
-        Optional<UsedId> existingUsedId = usedIdRepository.findById(dto.ubuntuGid());
-        UsedId usedId;
-        if (existingUsedId.isPresent()) {
-            log.warn("[createGroup] 중복된 GID가 UsedId에 이미 존재합니다: {}", dto.ubuntuGid());
-            usedId = existingUsedId.get();
-        } else {
-            // UsedId에 GID가 없으므로 새로 생성하여 저장합니다.
-            usedId = usedIdRepository.saveAndFlush(UsedId.builder().idValue(dto.ubuntuGid()).build());
-            log.info("[createGroup] UsedId에 GID {} 할당 완료", dto.ubuntuGid());
-        }
-
-        // 2. 해당 GID의 그룹이 이미 존재하는지 확인
-        if (groupRepository.existsByUbuntuGid(dto.ubuntuGid())) {
-            log.warn("[createGroup] 중복된 GID를 가진 그룹이 이미 존재합니다: {}", dto.ubuntuGid());
-            throw new BusinessException(ErrorCode.DUPLICATE_GROUP_ID);
-        }
-
-        // 3. 그룹 엔티티 생성 및 저장
-        Group group = Group.builder()
-                .groupName(dto.groupName())
-                .ubuntuGid(dto.ubuntuGid())
-                .usedId(usedId) // 영속화된 UsedId 인스턴스 연결
-                .build();
-
-        group = groupRepository.save(group);
-        log.info("[createGroup] 그룹 생성 완료: id={}, name={}", group.getGroupId(), group.getGroupName());
-
-        return GroupResponseDTO.fromEntity(group);
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
@@ -1,7 +1,11 @@
 package DGU_AI_LAB.admin_be.domain.groups.service;
 
+import DGU_AI_LAB.admin_be.domain.groups.dto.request.CreateGroupRequestDTO;
 import DGU_AI_LAB.admin_be.domain.groups.dto.response.GroupResponseDTO;
+import DGU_AI_LAB.admin_be.domain.groups.entity.Group;
 import DGU_AI_LAB.admin_be.domain.groups.repository.GroupRepository;
+import DGU_AI_LAB.admin_be.domain.usedIds.entity.UsedId;
+import DGU_AI_LAB.admin_be.domain.usedIds.repository.UsedIdRepository;
 import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -18,9 +23,10 @@ import java.util.List;
 public class GroupService {
 
     private final GroupRepository groupRepository;
+    private final UsedIdRepository usedIdRepository;
 
     /**
-     * 모든 그룹 정보를 조회하는 API
+     * 모든 그룹 정보 조회 API
      * GET /api/groups
      */
     public List<GroupResponseDTO> getAllGroups() {
@@ -38,5 +44,44 @@ public class GroupService {
 
         log.info("[getAllGroups] 모든 그룹 정보 조회 완료. {}개 그룹", response.size());
         return response;
+    }
+
+    /**
+     * 새로운 그룹을 생성하는 API
+     * POST /api/groups
+     */
+    @Transactional
+    public GroupResponseDTO createGroup(CreateGroupRequestDTO dto) {
+        log.info("[createGroup] 그룹 생성 요청 시작: groupName={}, ubuntuGid={}", dto.groupName(), dto.ubuntuGid());
+
+        // 1. 요청받은 GID가 UsedId에 이미 사용 중인지 확인하고, 없으면 생성
+        Optional<UsedId> existingUsedId = usedIdRepository.findById(dto.ubuntuGid());
+        UsedId usedId;
+        if (existingUsedId.isPresent()) {
+            log.warn("[createGroup] 중복된 GID가 UsedId에 이미 존재합니다: {}", dto.ubuntuGid());
+            usedId = existingUsedId.get();
+        } else {
+            // UsedId에 GID가 없으므로 새로 생성하여 저장합니다.
+            usedId = usedIdRepository.saveAndFlush(UsedId.builder().idValue(dto.ubuntuGid()).build());
+            log.info("[createGroup] UsedId에 GID {} 할당 완료", dto.ubuntuGid());
+        }
+
+        // 2. 해당 GID의 그룹이 이미 존재하는지 확인
+        if (groupRepository.existsByUbuntuGid(dto.ubuntuGid())) {
+            log.warn("[createGroup] 중복된 GID를 가진 그룹이 이미 존재합니다: {}", dto.ubuntuGid());
+            throw new BusinessException(ErrorCode.DUPLICATE_GROUP_ID);
+        }
+
+        // 3. 그룹 엔티티 생성 및 저장
+        Group group = Group.builder()
+                .groupName(dto.groupName())
+                .ubuntuGid(dto.ubuntuGid())
+                .usedId(usedId) // 영속화된 UsedId 인스턴스 연결
+                .build();
+
+        group = groupRepository.save(group);
+        log.info("[createGroup] 그룹 생성 완료: id={}, name={}", group.getGroupId(), group.getGroupName());
+
+        return GroupResponseDTO.fromEntity(group);
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/error/ErrorCode.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/error/ErrorCode.java
@@ -97,6 +97,7 @@ public enum ErrorCode {
      * Group Error
      */
     NO_AVAILABLE_GROUPS(HttpStatus.NOT_FOUND, "존재하는 그룹 정보가 없습니다."),
+    DUPLICATE_GROUP_ID(HttpStatus.CONFLICT, "중복된 그룹 ID를 할당할 수 없습니다."),
 
 
     /**

--- a/src/main/java/DGU_AI_LAB/admin_be/global/auth/SecurityWhitelist.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/global/auth/SecurityWhitelist.java
@@ -11,6 +11,7 @@ public class SecurityWhitelist {
             "/api/auth/login", "/api/auth/register", "/api/auth/reissue",
             "/api/auth/email/**",
             "/auth/callback/**",
-            "/actuator/health", "/actuator/info"
+            "/actuator/health", "/actuator/info",
+            "/api/groups/**"
     );
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/global/auth/SecurityWhitelist.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/global/auth/SecurityWhitelist.java
@@ -11,7 +11,7 @@ public class SecurityWhitelist {
             "/api/auth/login", "/api/auth/register", "/api/auth/reissue",
             "/api/auth/email/**",
             "/auth/callback/**",
-            "/actuator/health", "/actuator/info",
-            "/api/groups/**"
+            "/actuator/health", "/actuator/info"
+            //"/api/groups/**"
     );
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #100

## 🌱 작업 사항
- 그룹 생성 API : POST /api/groups
- 우분투 그룹 관련 버그 수정

## 🌱 참고 사항
### 우분투 그룹 관련 버그 수정
- Group 자체에 그룹 PK용 ID를 추가하고, 기존의 mapsId를 제거함.
- usedId는 매핑용으로만 사용

1. 첫 번째 문제: `ObjectOptimisticLockingFailureException`
`@MapsId`와 `@OneToOne` 매핑이 Group과 UsedId 엔티티의 ID를 동일하게 사용하면서, JPA의 영속성 컨텍스트에서 충돌이 발생 -> groupService에서 UsedId 엔티티를 저장할 때 `save()` 대신 `saveAndFlush()`를 사용해 데이터베이스에 즉시 반영하도록 수정, Group 엔티티를 저장하기 전에 UsedId의 존재를 확실히 보장하여 충돌을 피할 것이라고 예상했으나 실패함.!!!! `@MapsId`를 유지하는 방향으로 하고싶었는데, 아무리 해도 락 문제때문에 실패함...엔티티가 그대로 있을 땐 아무 문제 없는데, 그룹을 생성하려고 하면 락 문제가 바로 생김. 

### 여기서 생성 시점/순서의 문제?
- Group과 UsedId가 동일한 ID(같은 행) 공유하는 상태. 그리고 이 엔티티를 하나의 트랜잭션 내에서 순서대로 저장하는 흐름을 만들고 있었음.
- usedIdRepository.save(newUsedId)를 호출: JPA가 newUsedId를 영속성 컨텍스트에 추가하고, 트랜잭션 커밋 시점에 insert날릴 준비하고 saveAndFlush()로 바로 실행
- groupRepository.save(group)를 호출: JPA가 group을 영속화하려고 시도, 이때 `@MapsId` 때문에, Group 의 PK를 usedId의 ID로 설정해야 함. -> 여기에서 JPA는 usedId가 이미 영속성 컨텍스트를 존재한다고 알고있고, JPA가 group을 저장하면서 usedId가 변경되었을 가능성을 체크함. 이 과정이 트랜잭션의 잠금 상태 / 버전관리 로직과 얽히면서 동일한 ID에 대해 동시성 충돌이 발생

2. 두 번째 문제: `null identifier`
`@MapsId`를 제거하고 `@GeneratedValue`를 Group 엔티티에 추가했지만, ubuntuGid가 여전히 UsedId의 외래 키 역할을 하면서 JPA가 인식을 제대로 못함. -> **`@MapsId `매핑을 포기하고, Group 엔티티가 groupId라는 자체적인 PK를 갖도록 엔티티를 재구성.** 

엔티티 결론
- Group : UsedId = 1:1
- UsedId는 우분투 서버의 UID, GID를 관리
- Group은 ubuntuGid를 사용해 UsedId 엔티티를 참조
- ID를 공유하는 `@MapsId` 제거하고 엔티티 역할 분리

- Request : UsedId = N:1 (수정사항 없음)