### PR TITLE
[refactor] 사용 신청 username 예외 처리, ssh 로그인 경로 수정

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestService.java
@@ -68,6 +68,10 @@ public class RequestService {
         ResourceGroup rg = resourceGroupRepository.findById(dto.resourceGroupId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
+        if (requestRepository.existsByUbuntuUsername(dto.ubuntuUsername())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_USERNAME);
+        }
+
         ContainerImage img = containerImageRepository.findById(dto.imageId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/controller/AuthController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/controller/AuthController.java
@@ -43,7 +43,7 @@ public class AuthController implements AuthApi {
     }
 
     /** ssh 로그인 */
-    @PostMapping("/users")
+    @PostMapping("/users/password")
     public ResponseEntity<UserAuthResponseDTO> userAuth(@RequestBody @Valid UserAuthRequestDTO dto) {
         return ResponseEntity.ok(userService.userAuth(dto));
     }

--- a/src/main/java/DGU_AI_LAB/admin_be/error/ErrorCode.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/error/ErrorCode.java
@@ -86,6 +86,7 @@ public enum ErrorCode {
     INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "올바르지 않은 인증 코드입니다."),
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "지정된 그룹을 찾을 수 없습니다."),
     UID_ALLOCATION_FAILED(HttpStatus.BAD_REQUEST, "UID를 할당에 실패했습니다."),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "이미 사용하고 있는 username입니다. 같은 사용자이더라도 다른 username을 입력해주세요."),
 
     SLACK_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "Slack 사용자를 찾을 수 없습니다."),
     SLACK_USER_EMAIL_NOT_MATCH(HttpStatus.NOT_FOUND, "이메일이 일치하는 Slack 사용자를 찾을 수 없습니다."),


### PR DESCRIPTION
## 🌱 관련 이슈
#102 

## 🌱 작업 사항
- 사용 신청 시, 같은 사용자(user)이더라도 복수 개 신청 시에 다른 username(ubuntu username)을 입력해야 합니다. 
- 이전에는 500에러로 반환하고 있었습니다. (서버 책임)
- 예외 처리를 추가하고, 409(conflict)를 반환하도록 (클라이언트 측 입력값 오류 나타내기 위해) 수정했습니다.
- BusinessException 사용, ErrorCode 추가!
- ssh 로그인 경로 /api/auth/users/password로 수정 (인프라팀과 합의된 경로)
