### PR TITLE
[fix] Modify unique constraints from PortRequests entity

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/portRequests/entity/PortRequests.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/portRequests/entity/PortRequests.java
@@ -1,6 +1,7 @@
 package DGU_AI_LAB.admin_be.domain.portRequests.entity;
 
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
 import DGU_AI_LAB.admin_be.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
@@ -8,7 +9,9 @@ import jakarta.validation.constraints.Min;
 import lombok.*;
 
 @Entity
-@Table(name = "port_requests")
+@Table(name = "port_requests", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"port_number", "rsgroup_id"})
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -20,7 +23,7 @@ public class PortRequests extends BaseTimeEntity {
     @Column(name = "port_request_id")
     private Long portRequestId;
 
-    @Column(name = "port_number", nullable = false, unique = true)
+    @Column(name = "port_number", nullable = false)
     @Min(1)
     @Max(65535)
     private Integer portNumber;
@@ -35,5 +38,9 @@ public class PortRequests extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "request_id", nullable = false)
     private Request request;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "rsgroup_id", nullable = false)
+    private ResourceGroup resourceGroup;
 
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #118 

## 🌱 작업 사항
- 다른 서버 도메인이더라도 (LAB/FARM이 다르더라도) port_number의 unique constraint에 의해 같은 포트를 기록할 수 없는 데이터베이스 구조 수정
- rsgroup_id를 외래키로 가져와서 (rsgroup_id, port_number)를 composite unique constraint로 구성
