### PR TITLE
[feat] 사용 변경 신청 및 관리자 승인/거절, 그룹 생성

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/dashboard/controller/DashboardController.java
@@ -2,7 +2,6 @@ package DGU_AI_LAB.admin_be.domain.dashboard.controller;
 
 import DGU_AI_LAB.admin_be.domain.dashboard.controller.docs.DashBoardApi;
 import DGU_AI_LAB.admin_be.domain.dashboard.service.DashboardService;
-import DGU_AI_LAB.admin_be.domain.requests.dto.response.ChangeRequestResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.UserServerResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
 import DGU_AI_LAB.admin_be.global.auth.CustomUserDetails;

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/controller/GroupController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/controller/GroupController.java
@@ -1,5 +1,6 @@
 package DGU_AI_LAB.admin_be.domain.groups.controller;
 
+import DGU_AI_LAB.admin_be.domain.groups.controller.docs.GroupApi;
 import DGU_AI_LAB.admin_be.domain.groups.dto.request.CreateGroupRequestDTO;
 import DGU_AI_LAB.admin_be.domain.groups.dto.response.GroupResponseDTO;
 import DGU_AI_LAB.admin_be.domain.groups.service.GroupService;
@@ -18,7 +19,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/groups")
-public class GroupController {
+public class GroupController implements GroupApi {
 
     private final GroupService groupService;
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/controller/GroupController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/controller/GroupController.java
@@ -4,11 +4,13 @@ import DGU_AI_LAB.admin_be.domain.groups.controller.docs.GroupApi;
 import DGU_AI_LAB.admin_be.domain.groups.dto.request.CreateGroupRequestDTO;
 import DGU_AI_LAB.admin_be.domain.groups.dto.response.GroupResponseDTO;
 import DGU_AI_LAB.admin_be.domain.groups.service.GroupService;
+import DGU_AI_LAB.admin_be.global.auth.CustomUserDetails;
 import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,7 +19,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/groups")
-public class GroupController implements GroupApi {
+public class GroupController {
 
     private final GroupService groupService;
 
@@ -37,9 +39,12 @@ public class GroupController implements GroupApi {
      * POST /api/groups
      */
     @PostMapping
-    public ResponseEntity<SuccessResponse<?>> createGroup(@RequestBody @Valid CreateGroupRequestDTO dto) {
-        log.info("[createGroup] 새로운 그룹 생성 요청 접수: {}", dto.groupName());
-        GroupResponseDTO response = groupService.createGroup(dto);
+    public ResponseEntity<SuccessResponse<?>> createGroup(
+            @RequestBody @Valid CreateGroupRequestDTO dto,
+            @AuthenticationPrincipal CustomUserDetails principal
+    ) {
+        log.info("[createGroup] 새로운 그룹 생성 요청 접수: groupName={}, ubuntuUsername={}", dto.groupName(), dto.ubuntuUsername());
+        GroupResponseDTO response = groupService.createGroup(dto, principal.getUserId());
         return SuccessResponse.created(response);
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/controller/GroupController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/controller/GroupController.java
@@ -1,6 +1,5 @@
 package DGU_AI_LAB.admin_be.domain.groups.controller;
 
-import DGU_AI_LAB.admin_be.domain.groups.controller.docs.GroupApi;
 import DGU_AI_LAB.admin_be.domain.groups.dto.request.CreateGroupRequestDTO;
 import DGU_AI_LAB.admin_be.domain.groups.dto.response.GroupResponseDTO;
 import DGU_AI_LAB.admin_be.domain.groups.service.GroupService;

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/controller/docs/GroupApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/controller/docs/GroupApi.java
@@ -8,7 +8,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "2. 그룹 API", description = "사용자용 그룹 목록 조회, 그룹 생성 API")
 public interface GroupApi {

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/controller/docs/GroupApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/controller/docs/GroupApi.java
@@ -1,18 +1,21 @@
 package DGU_AI_LAB.admin_be.domain.groups.controller.docs;
 
 import DGU_AI_LAB.admin_be.domain.groups.dto.request.CreateGroupRequestDTO;
+import DGU_AI_LAB.admin_be.global.auth.CustomUserDetails;
 import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "2. 그룹 API", description = "사용자용 그룹 목록 조회, 그룹 생성 API")
+@Tag(name = "2. 사용자 그룹 API", description = "사용자용 우분투 그룹 관련 API")
 public interface GroupApi {
 
     @Operation(summary = "모든 그룹 목록 조회", description = "시스템에 등록된 모든 그룹의 정보를 조회합니다. 사용 신청 단계에서 이 목록을 조회하고, 그룹을 선택할 수 있습니다.")
@@ -23,12 +26,18 @@ public interface GroupApi {
     @GetMapping
     ResponseEntity<SuccessResponse<?>> getGroups();
 
-    @Operation(summary = "새로운 그룹 생성", description = "새로운 그룹을 생성하고 DB에 저장합니다.")
+    @Operation(summary = "새로운 그룹 생성", description = "새로운 그룹을 생성하고 MySQL DB에 저장합니다. 이후 Config Server에 그룹 생성 API를 호출합니다. 그룹명과 사용자 이름은 필수값이지만, 사용자 이름은 생략 가능하며 이 경우 멤버 없는 그룹이 생성됩니다. " +
+            "사용 신청을 아직 생성하지 않았지만, 그룹을 먼저 생성해야 하는 경우를 고려했습니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "생성 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 (필수 필드 누락 등)"),
-            @ApiResponse(responseCode = "409", description = "중복된 GID를 가진 그룹이 이미 존재함")
+            @ApiResponse(responseCode = "400", description = "잘못된 요청: 필수 필드 누락(groupName) 또는 잘못된 형식"),
+            @ApiResponse(responseCode = "403", description = "접근 금지: 요청한 ubuntuUsername이 로그인한 사용자와 일치하지 않음"),
+            @ApiResponse(responseCode = "409", description = "데이터 충돌: 동일한 그룹명이 이미 존재함"),
+            @ApiResponse(responseCode = "500", description = "서버 오류: GID 할당 실패 또는 외부 API 호출 실패")
     })
     @PostMapping
-    ResponseEntity<SuccessResponse<?>> createGroup(@RequestBody @Valid CreateGroupRequestDTO dto);
+    ResponseEntity<SuccessResponse<?>> createGroup(
+            @RequestBody @Valid CreateGroupRequestDTO dto,
+            @AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails principal
+    );
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/dto/request/CreateGroupRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/dto/request/CreateGroupRequestDTO.java
@@ -2,8 +2,6 @@ package DGU_AI_LAB.admin_be.domain.groups.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import lombok.Builder;
 
 @Schema(description = "그룹 생성 요청 DTO")

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/dto/request/CreateGroupRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/dto/request/CreateGroupRequestDTO.java
@@ -6,15 +6,16 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Builder;
 
-@Schema(description = "1. 그룹 생성 요청 DTO")
+@Schema(description = "그룹 생성 요청 DTO")
 @Builder
 public record CreateGroupRequestDTO(
-        @Schema(description = "할당할 우분투 GID (Group ID)", example = "1001")
-        @NotNull @Positive
-        Long ubuntuGid,
 
         @Schema(description = "생성할 그룹명", example = "developers")
-        @NotBlank
-        String groupName
+        @NotBlank(message = "그룹명은 필수입니다.")
+        String groupName,
+
+        @Schema(description = "그룹에 추가할 우분투 사용자 이름", example = "user1")
+        @NotBlank(message = "우분투 사용자 이름은 필수입니다.")
+        String ubuntuUsername
 ) {
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/dto/request/CreateGroupRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/dto/request/CreateGroupRequestDTO.java
@@ -14,8 +14,7 @@ public record CreateGroupRequestDTO(
         @NotBlank(message = "그룹명은 필수입니다.")
         String groupName,
 
-        @Schema(description = "그룹에 추가할 우분투 사용자 이름", example = "user1")
-        @NotBlank(message = "우분투 사용자 이름은 필수입니다.")
+        @Schema(description = "그룹에 추가할 우분투 사용자 이름", example = "user1", required = false)
         String ubuntuUsername
 ) {
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/repository/GroupRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/repository/GroupRepository.java
@@ -13,4 +13,5 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
     List<Group> findAllByUbuntuGidIn(Set<Long> ubuntuGids);
     boolean existsByUbuntuGid(Long ubuntuGid);
     Optional<Group> findByUbuntuGid(Long ubuntuGid);
+    boolean existsByGroupName(String groupName);
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/repository/GroupRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/repository/GroupRepository.java
@@ -5,10 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Repository
 public interface GroupRepository extends JpaRepository<Group, Long> {
     List<Group> findAllByUbuntuGidIn(Set<Long> ubuntuGids);
     boolean existsByUbuntuGid(Long ubuntuGid);
+    Optional<Group> findByUbuntuGid(Long ubuntuGid);
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
@@ -4,31 +4,46 @@ import DGU_AI_LAB.admin_be.domain.groups.dto.request.CreateGroupRequestDTO;
 import DGU_AI_LAB.admin_be.domain.groups.dto.response.GroupResponseDTO;
 import DGU_AI_LAB.admin_be.domain.groups.entity.Group;
 import DGU_AI_LAB.admin_be.domain.groups.repository.GroupRepository;
+import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
 import DGU_AI_LAB.admin_be.domain.usedIds.entity.UsedId;
 import DGU_AI_LAB.admin_be.domain.usedIds.repository.UsedIdRepository;
+import DGU_AI_LAB.admin_be.domain.usedIds.service.IdAllocationService;
 import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class GroupService {
 
     private final GroupRepository groupRepository;
     private final UsedIdRepository usedIdRepository;
+    private final RequestRepository requestRepository;
+    private final ObjectMapper objectMapper;
+    private final IdAllocationService idAllocationService;
+    private final @Qualifier("configWebClient") WebClient groupCreationWebClient;
+
 
     /**
      * 모든 그룹 정보를 조회하는 API
      * GET /api/groups
      */
+    @Transactional(readOnly = true)
     public List<GroupResponseDTO> getAllGroups() {
         log.info("[getAllGroups] 모든 그룹 정보 조회 시작");
         var groups = groupRepository.findAll();
@@ -51,35 +66,80 @@ public class GroupService {
      * POST /api/groups
      */
     @Transactional
-    public GroupResponseDTO createGroup(CreateGroupRequestDTO dto) {
-        log.info("[createGroup] 그룹 생성 요청 시작: groupName={}, ubuntuGid={}", dto.groupName(), dto.ubuntuGid());
+    public GroupResponseDTO createGroup(CreateGroupRequestDTO dto, Long userId) {
 
-        // 1. 요청받은 GID로 UsedId가 이미 존재하는지 확인하고, 없으면 생성
-        Optional<UsedId> existingUsedId = usedIdRepository.findById(dto.ubuntuGid());
-        UsedId usedId;
-        if (existingUsedId.isPresent()) {
-            log.warn("[createGroup] 중복된 GID가 UsedId에 이미 존재합니다: {}", dto.ubuntuGid());
-            usedId = existingUsedId.get();
-        } else {
-            usedId = usedIdRepository.saveAndFlush(UsedId.builder().idValue(dto.ubuntuGid()).build());
-            log.info("[createGroup] UsedId에 GID {} 할당 완료", dto.ubuntuGid());
+        log.info("[createGroup] 그룹 생성 요청 시작: groupName={}, ubuntuUsername={}", dto.groupName(), dto.ubuntuUsername());
+
+        // 1. 요청된 ubuntuUsername이 로그인한 사용자의 계정인지 확인하는 유효성 검사
+        if (!requestRepository.existsByUbuntuUsernameAndUser_UserId(dto.ubuntuUsername(), userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN_REQUEST);
         }
 
-        // 2. 해당 GID의 그룹이 이미 존재하는지 확인
-        if (groupRepository.existsByUbuntuGid(dto.ubuntuGid())) {
-            log.warn("[createGroup] 중복된 GID를 가진 그룹이 이미 존재합니다: {}", dto.ubuntuGid());
-            throw new BusinessException(ErrorCode.DUPLICATE_GROUP_ID);
+        // 2. DB에서 그룹명 중복을 먼저 확인합니다.
+        if (groupRepository.existsByGroupName(dto.groupName())) {
+            log.warn("[createGroup] DB에 이미 존재하는 그룹명입니다: {}", dto.groupName());
+            throw new BusinessException(ErrorCode.DUPLICATE_GROUP_NAME);
         }
 
-        // 3. 그룹 엔티티 생성 및 저장
+        // 3. 새로운 GID를 할당받습니다.
+        Long assignedGid = idAllocationService.allocateNewGid();
+        log.info("[createGroup] 새로운 GID 할당 완료: {}", assignedGid);
+
+        // 4. GID가 int 타입으로 변환 가능한지 확인 (오버플로우 방지)
+        if (assignedGid > Integer.MAX_VALUE || assignedGid < Integer.MIN_VALUE) {
+            log.error("[createGroup] 할당된 GID가 int 범위를 벗어납니다: {}", assignedGid);
+            throw new BusinessException(ErrorCode.GID_ALLOCATION_FAILED);
+        }
+
+
+        // 5. 외부 API 호출을 위한 DTO를 준비하고 호출합니다.
+        Map<String, Object> apiDto = Map.of(
+                "name", dto.groupName(),
+                "gid", assignedGid.intValue(),
+                "members", List.of(dto.ubuntuUsername())
+        );
+
+        try {
+            log.info("[createGroup] 외부 그룹 생성 API 호출 시작: name={}, gid={}, members={}", apiDto.get("name"), apiDto.get("gid"), apiDto.get("members"));
+
+            groupCreationWebClient.post()
+                    .uri("/accounts/addgroup")
+                    .bodyValue(apiDto)
+                    .retrieve()
+                    .onStatus(HttpStatus.BAD_REQUEST::equals, clientResponse ->
+                            Mono.error(new BusinessException(ErrorCode.GROUP_CREATION_FAILED))
+                    )
+                    .onStatus(HttpStatus.CONFLICT::equals, clientResponse ->
+                            Mono.error(new BusinessException(ErrorCode.DUPLICATE_GROUP_ID))
+                    )
+                    .onStatus(HttpStatus.INTERNAL_SERVER_ERROR::equals, clientResponse ->
+                            Mono.error(new BusinessException(ErrorCode.EXTERNAL_API_ERROR))
+                    )
+                    .bodyToMono(Map.class)
+                    .block();
+
+            log.info("[createGroup] 외부 API 호출 성공");
+
+        } catch (WebClientResponseException e) {
+            log.error("[createGroup] 외부 API 호출 실패: 상태 코드={}, 응답={}", e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw new BusinessException(ErrorCode.GROUP_CREATION_FAILED);
+        } catch (Exception e) {
+            log.error("[createGroup] 외부 API 호출 중 예상치 못한 오류 발생", e);
+            throw new BusinessException(ErrorCode.GROUP_CREATION_FAILED);
+        }
+
+        // 4. API 호출이 성공한 후에만 로컬 DB에 그룹을 저장합니다.
+        UsedId usedId = usedIdRepository.findById(assignedGid)
+                .orElseGet(() -> usedIdRepository.saveAndFlush(UsedId.builder().idValue(assignedGid).build()));
+
         Group group = Group.builder()
                 .groupName(dto.groupName())
-                .ubuntuGid(dto.ubuntuGid())
+                .ubuntuGid(assignedGid)
                 .usedId(usedId)
                 .build();
 
         group = groupRepository.save(group);
-        log.info("[createGroup] 그룹 생성 완료: id={}, name={}", group.getGroupId(), group.getGroupName());
+        log.info("[createGroup] 그룹 생성 및 로컬 DB 저장 완료: id={}, name={}", group.getGroupId(), group.getGroupName());
 
         return GroupResponseDTO.fromEntity(group);
     }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
@@ -10,7 +10,6 @@ import DGU_AI_LAB.admin_be.domain.usedIds.repository.UsedIdRepository;
 import DGU_AI_LAB.admin_be.domain.usedIds.service.IdAllocationService;
 import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -20,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
-import reactor.core.publisher.Mono;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/AdminRequestChangeController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/AdminRequestChangeController.java
@@ -1,0 +1,55 @@
+package DGU_AI_LAB.admin_be.domain.requests.controller;
+
+import DGU_AI_LAB.admin_be.domain.requests.controller.docs.AdminRequestChangeApi;
+import DGU_AI_LAB.admin_be.domain.requests.dto.request.ApproveModificationDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.request.RejectModificationDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.ChangeRequestResponseDTO;
+import DGU_AI_LAB.admin_be.domain.requests.service.AdminRequestCommandService;
+import DGU_AI_LAB.admin_be.domain.requests.service.AdminRequestQueryService;
+import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/requests/change")
+public class AdminRequestChangeController implements AdminRequestChangeApi {
+
+    private final AdminRequestCommandService adminRequestCommandService;
+    private final AdminRequestQueryService adminRequestQueryService;
+
+    /**
+     * 변경 요청 목록 조회 (관리자용)
+     * PENDING 상태의 ChangeRequest 목록을 반환합니다.
+     */
+    @GetMapping("/change")
+    public ResponseEntity<SuccessResponse<?>> getChangeRequests() {
+        List<ChangeRequestResponseDTO> changeRequests = adminRequestQueryService.getChangeRequests();
+        return ResponseEntity.ok((SuccessResponse<?>) changeRequests);
+    }
+
+    @PatchMapping("/change/approve")
+    public ResponseEntity<SuccessResponse<?>> approveModification(
+            @AuthenticationPrincipal(expression = "userId") Long adminId,
+            @RequestBody @Valid ApproveModificationDTO dto
+    ) {
+        adminRequestCommandService.approveModification(adminId, dto);
+        return ResponseEntity.ok().build();
+    }
+
+
+    @PatchMapping("/change/reject")
+    public ResponseEntity<SuccessResponse<?>> rejectModification(
+            @AuthenticationPrincipal(expression = "userId") Long adminId,
+            @RequestBody @Valid RejectModificationDTO dto
+    ) {
+        adminRequestCommandService.rejectModification(adminId, dto);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/AdminRequestController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/AdminRequestController.java
@@ -3,6 +3,7 @@ package DGU_AI_LAB.admin_be.domain.requests.controller;
 import DGU_AI_LAB.admin_be.domain.requests.controller.docs.AdminRequestApi;
 import DGU_AI_LAB.admin_be.domain.requests.dto.request.ApproveModificationDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.request.ApproveRequestDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.request.RejectModificationDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.request.RejectRequestDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ChangeRequestResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ContainerInfoDTO;
@@ -10,6 +11,7 @@ import DGU_AI_LAB.admin_be.domain.requests.dto.response.ResourceUsageDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.SaveRequestResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.service.AdminRequestCommandService;
 import DGU_AI_LAB.admin_be.domain.requests.service.AdminRequestQueryService;
+import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -26,32 +28,15 @@ public class AdminRequestController implements AdminRequestApi {
     private final AdminRequestCommandService adminRequestCommandService;
     private final AdminRequestQueryService adminRequestQueryService;
 
-    @PatchMapping("/change/approve")
-    public ResponseEntity<Void> approveModification(
-            @AuthenticationPrincipal(expression = "userId") Long adminId,
-            @RequestBody @Valid ApproveModificationDTO dto
-    ) {
-        adminRequestCommandService.approveModification(adminId, dto);
-        return ResponseEntity.ok().build();
-    }
-
-    @GetMapping("/usage")
-    public ResponseEntity<List<ResourceUsageDTO>> getAllResourceUsage() {
-        return ResponseEntity.ok(adminRequestQueryService.getAllFulfilledResourceUsage());
-    }
-
-    @GetMapping("/containers")
-    public ResponseEntity<List<ContainerInfoDTO>> getAllActiveContainers() {
-        return ResponseEntity.ok(adminRequestQueryService.getAllActiveContainers());
-    }
 
     /**
      * 모든 요청 목록 조회 (관리자용)
      * 모든 상태의 Request 목록을 반환합니다.
      */
     @GetMapping
-    public ResponseEntity<List<SaveRequestResponseDTO>> getAllRequests() {
-        return ResponseEntity.ok(adminRequestQueryService.getAllRequests());
+    public ResponseEntity<SuccessResponse<?>> getAllRequests() {
+        List<SaveRequestResponseDTO> requests = adminRequestQueryService.getAllRequests();
+        return SuccessResponse.ok(requests);
     }
 
     /**
@@ -59,28 +44,33 @@ public class AdminRequestController implements AdminRequestApi {
      * PENDING 상태의 Request 목록을 반환합니다.
      */
     @GetMapping("/new")
-    public ResponseEntity<List<SaveRequestResponseDTO>> getNewRequests() {
+    public ResponseEntity<SuccessResponse<?>> getNewRequests() {
         List<SaveRequestResponseDTO> requests = adminRequestQueryService.getNewRequests();
-        return ResponseEntity.ok(requests);
+        return SuccessResponse.ok(requests);
     }
 
-    /**
-     * 변경 요청 목록 조회 (관리자용)
-     * PENDING 상태의 ChangeRequest 목록을 반환합니다.
-     */
-    @GetMapping("/change")
-    public ResponseEntity<List<ChangeRequestResponseDTO>> getChangeRequests() {
-        List<ChangeRequestResponseDTO> changeRequests = adminRequestQueryService.getChangeRequests();
-        return ResponseEntity.ok(changeRequests);
+    @GetMapping("/usage")
+    public ResponseEntity<SuccessResponse<?>> getAllResourceUsage() {
+        List<ResourceUsageDTO> usage = adminRequestQueryService.getAllFulfilledResourceUsage();
+        return SuccessResponse.ok(usage);
     }
 
-    @PatchMapping("/approval")
-    public ResponseEntity<SaveRequestResponseDTO> approve(@RequestBody @Valid ApproveRequestDTO dto) {
-        return ResponseEntity.ok(adminRequestCommandService.approveRequest(dto));
+    @GetMapping("/containers")
+    public ResponseEntity<SuccessResponse<?>> getAllActiveContainers() {
+        List<ContainerInfoDTO> containers = adminRequestQueryService.getAllActiveContainers();
+        return SuccessResponse.ok(containers);
+    }
+
+
+    @PatchMapping("/approve")
+    public ResponseEntity<SuccessResponse<?>> approveRequest(@RequestBody @Valid ApproveRequestDTO dto) {
+        SaveRequestResponseDTO responseDto = adminRequestCommandService.approveRequest(dto);
+        return SuccessResponse.ok(responseDto);
     }
 
     @PatchMapping("/reject")
-    public ResponseEntity<SaveRequestResponseDTO> reject(@RequestBody @Valid RejectRequestDTO dto) {
-        return ResponseEntity.ok(adminRequestCommandService.rejectRequest(dto));
+    public ResponseEntity<SuccessResponse<?>> rejectRequest(@RequestBody @Valid RejectRequestDTO dto) {
+        SaveRequestResponseDTO responseDto = adminRequestCommandService.rejectRequest(dto);
+        return SuccessResponse.ok(responseDto);
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/AdminRequestController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/AdminRequestController.java
@@ -1,11 +1,8 @@
 package DGU_AI_LAB.admin_be.domain.requests.controller;
 
 import DGU_AI_LAB.admin_be.domain.requests.controller.docs.AdminRequestApi;
-import DGU_AI_LAB.admin_be.domain.requests.dto.request.ApproveModificationDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.request.ApproveRequestDTO;
-import DGU_AI_LAB.admin_be.domain.requests.dto.request.RejectModificationDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.request.RejectRequestDTO;
-import DGU_AI_LAB.admin_be.domain.requests.dto.response.ChangeRequestResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ContainerInfoDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ResourceUsageDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.SaveRequestResponseDTO;
@@ -15,7 +12,6 @@ import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/RequestController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/RequestController.java
@@ -23,6 +23,9 @@ public class RequestController implements RequestApi {
     private final RequestQueryService requestService;
     private final RequestCommandService requestCommandService;
 
+    /**
+     * 사용 신청 생성
+     */
     @PostMapping
     public ResponseEntity<SaveRequestResponseDTO> createRequest(
             @AuthenticationPrincipal(expression = "userId") Long userId,
@@ -32,6 +35,9 @@ public class RequestController implements RequestApi {
         return ResponseEntity.ok(body);
     }
 
+    /**
+     * 사용 신청 변경 (저장공간 크기, 만료기한, 사용자가 속한 그룹, 리소스 그룹, 도커 이미지)
+     */
     @PostMapping("/{requestId}/change")
     public ResponseEntity<Void> createChangeRequest(
             @AuthenticationPrincipal(expression = "userId") Long userId,
@@ -42,6 +48,9 @@ public class RequestController implements RequestApi {
         return ResponseEntity.ok().build();
     }
 
+    /**
+     * 나의 사용 신청 조회
+     */
     @GetMapping("/my")
     public ResponseEntity<List<SaveRequestResponseDTO>> getMyRequests(
             @AuthenticationPrincipal CustomUserDetails user

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/AdminRequestApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/AdminRequestApi.java
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 
-@Tag(name = "1. 관리자 - 서버 사용 신청 관리", description = "신규 신청 조회 및 승인/거절 API")
+@Tag(name = "1. 관리자 서버 사용 신청 관리", description = "서버 신규 신청 조회 및 승인/거절 API")
 public interface AdminRequestApi {
 
     @Operation(summary = "모든 요청 목록 조회", description = "모든 상태의 서버 사용 신청 목록을 조회합니다.")

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/AdminRequestApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/AdminRequestApi.java
@@ -1,74 +1,74 @@
 package DGU_AI_LAB.admin_be.domain.requests.controller.docs;
 
-import DGU_AI_LAB.admin_be.domain.requests.dto.request.ApproveModificationDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.request.ApproveRequestDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.request.RejectRequestDTO;
-import DGU_AI_LAB.admin_be.domain.requests.dto.response.ChangeRequestResponseDTO;
-import DGU_AI_LAB.admin_be.domain.requests.dto.response.ContainerInfoDTO;
-import DGU_AI_LAB.admin_be.domain.requests.dto.response.ResourceUsageDTO;
-import DGU_AI_LAB.admin_be.domain.requests.dto.response.SaveRequestResponseDTO;
+import DGU_AI_LAB.admin_be.error.dto.ErrorResponse;
+import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
-@Tag(name = "1. 관리자 서버 사용 신청 처리", description = "관리자용 서버 사용 신청 관리 API")
+@Tag(name = "1. 관리자 - 서버 사용 신청 관리", description = "신규 신청 조회 및 승인/거절 API")
 public interface AdminRequestApi {
 
-    @Operation(summary = "변경 요청 승인", description = "사용자의 변경 요청을 승인합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "404", description = "변경 요청을 찾을 수 없음"),
-            @ApiResponse(responseCode = "409", description = "요청 상태가 PENDING이 아님")
+    @Operation(summary = "모든 요청 목록 조회", description = "모든 상태의 서버 사용 신청 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = "{\"status\": 200, \"message\": \"요청이 성공했습니다.\", \"data\": [...]}")
+                    )),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @PatchMapping("/change/approve")
-    ResponseEntity<Void> approveModification(
-            @AuthenticationPrincipal(expression = "userId") Long adminId,
-            @RequestBody @Valid ApproveModificationDTO dto
-    );
+    ResponseEntity<SuccessResponse<?>> getAllRequests();
 
-    @Operation(summary = "모든 리소스 사용량 조회", description = "현재 사용 중인 컨테이너들의 리소스 사용량을 조회합니다.")
-    @GetMapping("/usage")
-    ResponseEntity<List<ResourceUsageDTO>> getAllResourceUsage();
-
-    @Operation(summary = "모든 컨테이너 정보 조회", description = "현재 활성화된 모든 컨테이너의 상세 정보를 조회합니다.")
-    @GetMapping("/containers")
-    ResponseEntity<List<ContainerInfoDTO>> getAllActiveContainers();
-
-    @Operation(summary = "모든 요청 목록 조회", description = "모든 상태의 사용자 요청 목록을 조회합니다.")
-    @GetMapping
-    ResponseEntity<List<SaveRequestResponseDTO>> getAllRequests();
-
-    @Operation(summary = "신규 신청 목록 조회", description = "PENDING 상태의 신규 사용자 신청 목록을 조회합니다.")
-    @GetMapping("/new")
-    ResponseEntity<List<SaveRequestResponseDTO>> getNewRequests();
-
-    @Operation(summary = "변경 요청 목록 조회", description = "PENDING 상태의 사용자 변경 요청 목록을 조회합니다.")
-    @GetMapping("/change")
-    ResponseEntity<List<ChangeRequestResponseDTO>> getChangeRequests();
-
-    @Operation(summary = "신규 신청 승인", description = "신규 사용자 신청을 승인하고, 계정 및 리소스를 할당합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "404", description = "요청을 찾을 수 없음"),
-            @ApiResponse(responseCode = "409", description = "요청 상태가 PENDING이 아님"),
-            @ApiResponse(responseCode = "502", description = "외부 서버 오류")
+    @Operation(summary = "신규 신청 목록 조회", description = "PENDING 상태의 서버 사용 신청 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class)))
     })
-    @PatchMapping("/approval")
-    ResponseEntity<SaveRequestResponseDTO> approve(@RequestBody @Valid ApproveRequestDTO dto);
+    ResponseEntity<SuccessResponse<?>> getNewRequests();
 
-    @Operation(summary = "신규 신청 거절", description = "신규 사용자 신청을 거절합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "404", description = "요청을 찾을 수 없음"),
-            @ApiResponse(responseCode = "409", description = "요청 상태가 PENDING 또는 FULFILLED가 아님")
+    @Operation(summary = "전체 리소스 사용량 조회", description = "FULFILLED 상태인 모든 서버의 리소스 사용량 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class)))
     })
-    @PatchMapping("/reject")
-    ResponseEntity<SaveRequestResponseDTO> reject(@RequestBody @Valid RejectRequestDTO dto);
+    ResponseEntity<SuccessResponse<?>> getAllResourceUsage();
+
+    @Operation(summary = "모든 활성 컨테이너 조회", description = "현재 활성화된 모든 컨테이너 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class)))
+    })
+    ResponseEntity<SuccessResponse<?>> getAllActiveContainers();
+
+    @Operation(summary = "사용 신청 승인", description = "PENDING 상태의 사용 신청을 승인하고 사용자 PVC를 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "404", description = "리소스 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "사용자명 중복",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<SuccessResponse<?>> approveRequest(ApproveRequestDTO dto);
+
+    @Operation(summary = "사용 신청 거절", description = "PENDING 상태의 사용 신청을 거절합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "404", description = "리소스 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<SuccessResponse<?>> rejectRequest(RejectRequestDTO dto);
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/AdminRequestChangeApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/AdminRequestChangeApi.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 
-@Tag(name = "1. 관리자 - 서버 변경 요청 관리", description = "서버 설정 변경 요청 조회 및 승인/거절 API")
+@Tag(name = "1. 관리자 서버 변경 요청 관리", description = "서버 설정 변경 요청 조회 및 승인/거절 API")
 public interface AdminRequestChangeApi {
 
     @Operation(summary = "변경 요청 목록 조회", description = "PENDING 상태의 변경 요청 목록을 조회합니다.")
@@ -22,7 +22,7 @@ public interface AdminRequestChangeApi {
     })
     ResponseEntity<SuccessResponse<?>> getChangeRequests();
 
-    @Operation(summary = "변경 요청 승인", description = "PENDING 상태의 변경 요청을 승인하고 서버 설정을 업데이트합니다.")
+    @Operation(summary = "변경 요청 승인", description = "PENDING 상태의 변경 요청을 승인하고 설정을 업데이트합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공",
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class))),

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/AdminRequestChangeApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/AdminRequestChangeApi.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 
-@Tag(name = "2. 관리자 - 서버 변경 요청 관리", description = "서버 설정 변경 요청 조회 및 승인/거절 API")
+@Tag(name = "1. 관리자 - 서버 변경 요청 관리", description = "서버 설정 변경 요청 조회 및 승인/거절 API")
 public interface AdminRequestChangeApi {
 
     @Operation(summary = "변경 요청 목록 조회", description = "PENDING 상태의 변경 요청 목록을 조회합니다.")

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/AdminRequestChangeApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/AdminRequestChangeApi.java
@@ -1,0 +1,46 @@
+package DGU_AI_LAB.admin_be.domain.requests.controller.docs;
+
+import DGU_AI_LAB.admin_be.domain.requests.dto.request.ApproveModificationDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.request.RejectModificationDTO;
+import DGU_AI_LAB.admin_be.error.dto.ErrorResponse;
+import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "2. 관리자 - 서버 변경 요청 관리", description = "서버 설정 변경 요청 조회 및 승인/거절 API")
+public interface AdminRequestChangeApi {
+
+    @Operation(summary = "변경 요청 목록 조회", description = "PENDING 상태의 변경 요청 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class)))
+    })
+    ResponseEntity<SuccessResponse<?>> getChangeRequests();
+
+    @Operation(summary = "변경 요청 승인", description = "PENDING 상태의 변경 요청을 승인하고 서버 설정을 업데이트합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "404", description = "리소스 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 상태",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<SuccessResponse<?>> approveModification(Long adminId, ApproveModificationDTO dto);
+
+    @Operation(summary = "변경 요청 거절", description = "PENDING 상태의 변경 요청을 거절합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "404", description = "리소스 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 상태",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<SuccessResponse<?>> rejectModification(Long adminId, RejectModificationDTO dto);
+}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/ApproveModificationDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/ApproveModificationDTO.java
@@ -1,12 +1,17 @@
 package DGU_AI_LAB.admin_be.domain.requests.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+@Schema(description = "관리자용 변경 요청 승인 DTO")
 public record ApproveModificationDTO(
+
+        @Schema(description = "승인할 변경 요청 ID", example = "5")
         @NotNull(message = "변경 요청 ID는 필수입니다.")
         Long changeRequestId,
+
+        @Schema(description = "관리자 승인 코멘트", example = "변경 요청을 승인합니다.")
         @NotBlank(message = "승인 사유는 필수입니다.")
         String adminComment
-) {
-}
+) {}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/ModifyRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/ModifyRequestDTO.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 
 public record ModifyRequestDTO(
         @NotBlank(message = "변경 사유는 필수입니다.")
@@ -12,6 +13,13 @@ public record ModifyRequestDTO(
         @Positive(message = "볼륨 크기는 양수여야 합니다.")
         Long requestedVolumeSizeGiB,
 
-        LocalDateTime requestedExpiresAt
+        LocalDateTime requestedExpiresAt,
+
+        Set<Long> requestedGroupIds,
+
+        Integer requestedResourceGroupId,
+
+        Long requestedContainerImageId
+
 ) {
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/ModifyRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/ModifyRequestDTO.java
@@ -1,25 +1,32 @@
 package DGU_AI_LAB.admin_be.domain.requests.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 
 import java.time.LocalDateTime;
 import java.util.Set;
 
+@Schema(description = "사용자용 서버 설정 변경 요청 DTO")
 public record ModifyRequestDTO(
+
+        @Schema(description = "변경 요청 사유 (필수)", example = "프로젝트 요구사항 변경으로 인한 용량 증설")
         @NotBlank(message = "변경 사유는 필수입니다.")
         String reason,
 
+        @Schema(description = "요청하는 새로운 저장 공간 크기(GiB)", example = "200")
         @Positive(message = "볼륨 크기는 양수여야 합니다.")
         Long requestedVolumeSizeGiB,
 
+        @Schema(description = "요청하는 새로운 만료 기한", example = "2026-09-02T10:00:00")
         LocalDateTime requestedExpiresAt,
 
+        @Schema(description = "요청하는 새로운 그룹 ID 목록", example = "[1001, 1002]")
         Set<Long> requestedGroupIds,
 
+        @Schema(description = "요청하는 새로운 리소스 그룹 ID", example = "2")
         Integer requestedResourceGroupId,
 
+        @Schema(description = "요청하는 새로운 도커 이미지 ID", example = "3")
         Long requestedContainerImageId
-
-) {
-}
+) {}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/RejectModificationDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/RejectModificationDTO.java
@@ -1,8 +1,8 @@
 package DGU_AI_LAB.admin_be.domain.requests.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "관리자용 변경 요청 거절 DTO")
 public record RejectModificationDTO(

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/RejectModificationDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/RejectModificationDTO.java
@@ -1,0 +1,15 @@
+package DGU_AI_LAB.admin_be.domain.requests.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자용 변경 요청 거절 DTO")
+public record RejectModificationDTO(
+
+        @NotNull(message = "변경 요청 ID는 필수입니다.")
+        Long changeRequestId,
+        @NotBlank(message = "거절 사유는 필수입니다.")
+        String adminComment
+) {
+}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/RejectRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/RejectRequestDTO.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-@Schema(description = "1. 관리자용 요청 거절 요청 DTO")
+@Schema(description = "관리자용 요청 거절 요청 DTO")
 public record RejectRequestDTO(
 
         @Schema(description = "거절할 요청 ID", example = "3")

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/UserGroupUpdateRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/UserGroupUpdateRequestDTO.java
@@ -1,6 +1,7 @@
 package DGU_AI_LAB.admin_be.domain.requests.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public record UserGroupUpdateRequestDTO(

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/ChangeType.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/ChangeType.java
@@ -1,8 +1,8 @@
 package DGU_AI_LAB.admin_be.domain.requests.entity;
 
 public enum ChangeType {
-    VOLUME_SIZE,
-    EXPIRES_AT,
+    VOLUME_SIZE, // 볼륨 사이즈 변경
+    EXPIRES_AT, // 서버 사용 만료 기한 변경
     GROUP, // 사용자가 속한 그룹 변경
     RESOURCE_GROUP, // 리소스 그룹 변경
     CONTAINER_IMAGE // 도커 이미지 변경

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/ChangeType.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/ChangeType.java
@@ -1,5 +1,9 @@
 package DGU_AI_LAB.admin_be.domain.requests.entity;
 
 public enum ChangeType {
-    VOLUME_SIZE, EXPIRES_AT, RSGROUP_ID, IMAGE_ID, GROUPS
+    VOLUME_SIZE,
+    EXPIRES_AT,
+    GROUP, // 사용자가 속한 그룹 변경
+    RESOURCE_GROUP, // 리소스 그룹 변경
+    CONTAINER_IMAGE // 도커 이미지 변경
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Request.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Request.java
@@ -87,20 +87,28 @@ public class Request extends BaseTimeEntity {
     /**
      * 변경 요청을 반영하여 엔티티의 속성을 업데이트합니다.
      */
-    public void applyChange(ChangeType changeType, String newValue) {
-        if (this.status != Status.FULFILLED) {
-            throw new BusinessException(ErrorCode.INVALID_REQUEST_STATUS);
-        }
 
-        switch (changeType) {
-            case VOLUME_SIZE:
-                this.volumeSizeGiB = Long.parseLong(newValue);
-                break;
-            case EXPIRES_AT:
-                this.expiresAt = LocalDateTime.parse(newValue);
-                break;
-            default:
-                throw new BusinessException(ErrorCode.UNSUPPORTED_CHANGE_TYPE);
+    public void updateVolumeSize(Long newVolumeSize) {
+        if (newVolumeSize != null) {
+            this.volumeSizeGiB = newVolumeSize;
+        }
+    }
+
+    public void updateExpiresAt(LocalDateTime newExpiresAt) {
+        if (newExpiresAt != null) {
+            this.expiresAt = newExpiresAt;
+        }
+    }
+
+    public void updateResourceGroup(ResourceGroup newResourceGroup) {
+        if (newResourceGroup != null) {
+            this.resourceGroup = newResourceGroup;
+        }
+    }
+
+    public void updateContainerImage(ContainerImage newImage) {
+        if (newImage != null) {
+            this.containerImage = newImage;
         }
     }
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/repository/RequestRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/repository/RequestRepository.java
@@ -20,5 +20,6 @@ public interface RequestRepository extends JpaRepository<Request, Long> {
     Optional<Request> findTopByUbuntuUsernameAndUbuntuUidIsNotNullOrderByApprovedAtDesc(String ubuntuUsername);
     boolean existsByUbuntuUsername(String ubuntuUsername);
     List<Request> findAllByUser_UserIdAndStatus(Long userId, Status status);
+    boolean existsByUbuntuUsernameAndUser_UserId(String ubuntuUsername, Long userId);
 
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
@@ -51,8 +51,8 @@ public class AdminRequestCommandService {
     private final GroupRepository groupRepository;
     private final ObjectMapper objectMapper;
 
-    private final @Qualifier("pvcWebClient") WebClient pvcWebClient;
-    private final @Qualifier("pvcWebClient") WebClient userCreationWebClient;
+    private final @Qualifier("configWebClient") WebClient pvcWebClient;
+    private final @Qualifier("configWebClient") WebClient userCreationWebClient;
 
     @Transactional
     public SaveRequestResponseDTO approveRequest(ApproveRequestDTO dto) {

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
@@ -160,6 +160,22 @@ public class AdminRequestCommandService {
         return SaveRequestResponseDTO.fromEntity(request);
     }
 
+
+    @Transactional
+    public void rejectModification(Long adminId, RejectModificationDTO dto) {
+        ChangeRequest changeRequest = changeRequestRepository.findById(dto.changeRequestId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        if (changeRequest.getStatus() != Status.PENDING) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST_STATUS);
+        }
+
+        User admin = userRepository.findById(adminId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        changeRequest.deny(admin, dto.adminComment());
+    }
+
     @Transactional
     public void approveModification(Long adminId, ApproveModificationDTO dto) {
         ChangeRequest changeRequest = changeRequestRepository.findById(dto.changeRequestId())

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryService.java
@@ -10,6 +10,7 @@ import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/ConfigRequestService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/ConfigRequestService.java
@@ -10,7 +10,6 @@ import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestQueryService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestQueryService.java
@@ -1,18 +1,13 @@
 package DGU_AI_LAB.admin_be.domain.requests.service;
 
-import DGU_AI_LAB.admin_be.domain.containerImage.repository.ContainerImageRepository;
-import DGU_AI_LAB.admin_be.domain.groups.repository.GroupRepository;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ContainerInfoDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ResourceUsageDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.SaveRequestResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
-import DGU_AI_LAB.admin_be.domain.requests.repository.ChangeRequestRepository;
 import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
-import DGU_AI_LAB.admin_be.domain.resourceGroups.repository.ResourceGroupRepository;
 import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
 import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/usedIds/repository/UsedIdRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/usedIds/repository/UsedIdRepository.java
@@ -3,7 +3,6 @@ package DGU_AI_LAB.admin_be.domain.usedIds.repository;
 import DGU_AI_LAB.admin_be.domain.usedIds.entity.UsedId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/usedIds/repository/UsedIdRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/usedIds/repository/UsedIdRepository.java
@@ -3,10 +3,14 @@ package DGU_AI_LAB.admin_be.domain.usedIds.repository;
 import DGU_AI_LAB.admin_be.domain.usedIds.entity.UsedId;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UsedIdRepository extends JpaRepository<UsedId, Long> {
     @Query("SELECT MAX(u.idValue) FROM UsedId u")
     Optional<Long> findMaxIdValue();
+
+    @Query("SELECT MAX(u.idValue) FROM UsedId u WHERE u.idValue >= :startRange AND u.idValue <= :endRange")
+    Optional<Long> findMaxIdValueInRange(Long startRange, Long endRange);
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/controller/docs/AdminUserApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/controller/docs/AdminUserApi.java
@@ -7,7 +7,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "1. 관리자 유저 관리", description = "관리자용 사용자 계정 관리 API")
 public interface AdminUserApi {

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/controller/docs/UserApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/controller/docs/UserApi.java
@@ -12,7 +12,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "2. 사용자 정보 관리", description = "일반 사용자 본인 정보 관리 API")
 public interface UserApi {

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserService.java
@@ -30,7 +30,7 @@ public class AdminUserService {
 
     private final UserRepository userRepository;
     private final RequestRepository requestRepository;
-    private final @Qualifier("pvcWebClient") WebClient userWebClient;
+    private final @Qualifier("configWebClient") WebClient userWebClient;
 
     /**
      * 전체 유저 조회

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/UserService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/UserService.java
@@ -6,11 +6,9 @@ import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
 import DGU_AI_LAB.admin_be.domain.users.dto.request.PasswordUpdateRequestDTO;
 import DGU_AI_LAB.admin_be.domain.users.dto.request.PhoneUpdateRequestDTO;
 import DGU_AI_LAB.admin_be.domain.users.dto.request.UserAuthRequestDTO;
-import DGU_AI_LAB.admin_be.domain.users.dto.request.UserUpdateRequestDTO;
 import DGU_AI_LAB.admin_be.domain.users.dto.response.MyInfoResponseDTO;
 import DGU_AI_LAB.admin_be.domain.users.dto.response.UserAuthResponseDTO;
 import DGU_AI_LAB.admin_be.domain.users.dto.response.UserResponseDTO;
-import DGU_AI_LAB.admin_be.domain.users.dto.response.UserSummaryDTO;
 import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
 import DGU_AI_LAB.admin_be.error.ErrorCode;
@@ -23,8 +21,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Slf4j
 @Service

--- a/src/main/java/DGU_AI_LAB/admin_be/error/ErrorCode.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/error/ErrorCode.java
@@ -103,6 +103,7 @@ public enum ErrorCode {
     GROUP_CREATION_FAILED(HttpStatus.BAD_GATEWAY, "외부 API: 필수 필드 누락 또는 형식 오류 "),
     GID_ALLOCATION_FAILED(HttpStatus.BAD_GATEWAY, "IdAllocationService에서 GID 할당에 실패했습니다. "),
     FORBIDDEN_REQUEST(HttpStatus.BAD_REQUEST, "요청된 우분투 사용자 이름은 로그인한 사용자의 계정이 아닙니다."),
+    INVALID_GROUP_MEMBER(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
 
 
     /**

--- a/src/main/java/DGU_AI_LAB/admin_be/error/ErrorCode.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/error/ErrorCode.java
@@ -67,7 +67,7 @@ public enum ErrorCode {
      * 502 Bad Gateway
      */
     SLACK_DM_CHANNEL_FAILED(HttpStatus.BAD_GATEWAY, "Slack DM 채널 열기를 실패하였습니다."),
-    EXTERNAL_API_FAILED(HttpStatus.BAD_GATEWAY, "외부 API 호출에 실패했습니다."),
+    EXTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "외부 API 호출에 실패했습니다."),
 
     /**
      * 503 Service Unavailable
@@ -98,7 +98,11 @@ public enum ErrorCode {
      * Group Error
      */
     NO_AVAILABLE_GROUPS(HttpStatus.NOT_FOUND, "존재하는 그룹 정보가 없습니다."),
-    DUPLICATE_GROUP_ID(HttpStatus.CONFLICT, "중복된 그룹 ID를 할당할 수 없습니다."),
+    DUPLICATE_GROUP_ID(HttpStatus.CONFLICT, "외부 API: 그룹명 또는 GID 충돌"),
+    DUPLICATE_GROUP_NAME(HttpStatus.CONFLICT, "중복된 그룹 이름입니다."),
+    GROUP_CREATION_FAILED(HttpStatus.BAD_GATEWAY, "외부 API: 필수 필드 누락 또는 형식 오류 "),
+    GID_ALLOCATION_FAILED(HttpStatus.BAD_GATEWAY, "IdAllocationService에서 GID 할당에 실패했습니다. "),
+    FORBIDDEN_REQUEST(HttpStatus.BAD_REQUEST, "요청된 우분투 사용자 이름은 로그인한 사용자의 계정이 아닙니다."),
 
 
     /**
@@ -121,7 +125,7 @@ public enum ErrorCode {
      * Request Error
      */
     INVALID_REQUEST_STATUS(HttpStatus.CONFLICT, "이미 처리된 신청입니다."),
-    FORBIDDEN_REQUEST(HttpStatus.BAD_REQUEST, "본인의 신청만 변경 신청할 수 있습니다."),
+    //FORBIDDEN_REQUEST(HttpStatus.BAD_REQUEST, "본인의 신청만 변경 신청할 수 있습니다."),
     UNSUPPORTED_CHANGE_TYPE(HttpStatus.BAD_REQUEST, "지원되지 않는 요청 타입(enum)입니다."),
 
     /**

--- a/src/main/java/DGU_AI_LAB/admin_be/global/config/WebClientConfig.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/global/config/WebClientConfig.java
@@ -13,8 +13,8 @@ import java.time.Duration;
 public class WebClientConfig {
 
     @Bean
-    public WebClient pvcWebClient(@Value("${pvc.base-url}") String baseUrl,
-                                  @Value("${pvc.timeout-seconds}") int timeout) {
+    public WebClient configWebClient(@Value("${config.base-url}") String baseUrl,
+                                     @Value("${config.timeout-seconds}") int timeout) {
 
         /**
          * 연결 풀 설정: HTTP 연결을 효율적으로 재사용하도록 한다.
@@ -32,4 +32,6 @@ public class WebClientConfig {
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .build();
     }
+
+
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/global/config/WebClientConfig.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/global/config/WebClientConfig.java
@@ -7,6 +7,7 @@ import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
+
 import java.time.Duration;
 
 @Configuration


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #112 
- related: #126 

## 🌱 작업 사항
### 서버 신청(`Request`) 변경 요청 (`ChangeRequest`) 관련 작업
- 사용자가 변경 요청을 할 수 있다. (저장공간 크기, 만료기한, 사용자가 속한 그룹, 리소스 그룹, 도커 이미지)
- 관리자가 변경 승인을 할 수 있다. 
- 관리자가 변경 거절을 할 수 있다. 

### 컨트롤러 역할 분리  (`AdminRequestController`, `AdminRequestChangeController`)
- 기존에는 모든 관리자 관련 요청이 하나의 컨트롤러에 몰려 있어서, 특정 도메인에 대한 책임이 불명확했습니다. 
- `AdminRequestController`: 신규 서버 사용 신청 조회, 승인, 거질 등 `Request`'기능만 담당하도록 분리했습니다. 
- `AdminRequestChangeController`: 사용자가 제출한 변경 요청 조회, 승인, 거절 등 `ChangeRequest`기능만 담당하도록 분리했습니다. 

### API URI 및 용어 통일
- 기존에는 `approve`와 `approveModification`처럼 기능에 따라 메서드 명, URI 경로가 달랐고, 거절 기능의 경우 `reject`와 `deny`가 혼용되어 있었습니다. 
- `/api/admin/request`는 신규 요청 관련 기능을, `/api/admin/requests/change`는 변경 관련 기능을 다루도록 보다 명확하게 경로를 분리했습니다. 
- '거절'의 개념은 `reject`로 통일했습니다. 비즈니스 메서드명도 `reject + N `형태로 통일했습니다. 

### ubuntu 그룹 생성 API 연결
- Spring의 client에서는 gid를 직접 받지 않고, 내부적으로 id값을 할당하여 다시 Config 서버에 요청을 보내는 것이 핵심입니다. 
- 이를 위해서 GroupService 내부 DTO를 생성하였습니다. 서비스 코드와 분리할 지에 대한 고려가 필요하지만, 지금은 서비스 코드가 길지 않아 한 클래스에 작성했습니다.
- ubuntuUsername은 입력을 받을 수도, 받지 않을 수도 있습니다.

### 짜잘한 수정
- 컨트롤러 공통 응답으로 맞춰 수정했습니다. 
- API 문서를 작성했습니다.
- DTO validation을 강화했습니다. 
- enum의 이름에 ID가 붙은 게 오히려 혼란스러워서 같은 형태로 통일했습니다.

### 엔티티 메서드 수정
- `update()`로 전체 필드를 통으로 처리하는 것에서, 각 필드를 update하는 것으로 수정했습니다. 
- 기존의 `update()`는 `volumeSizeGiB`와 `expiresAt`만 처리하도록 고정되어 있었습니다. 만약에 새로운 변경 요구사항이 들어오면 이 메서드를 계속해서 수정해야 하는 문제가 발생합니다. 
- 하지만 각 필드에 대한 `updateVolumeSize()`등 setter 역할 메서드를 두면, 서비스 레이어의 switch-case문만 수정해주면 되기 때문에 변경 사항의 폭이 줄어들 것이라고 생각했습니다. 
- 하지만 그룹 관련 Update는 로직이 너무 길고 복잡해서 서비스 레이어에 넘겼습니다. (기존 그룹 초기화 -> 새로운 그룹 조회 -> 유효성 검증 -> 새로운 그룹 할당) 특히 `Request`, `RequestGroup`, `Group`, `ChangeRequest`, `Group `...이 엔티티 전체에 영향을 주는 메서드가 될 거라서, 한 엔티티 안에 넣기는 SRP에 맞지 않다고 생각했습니다. 특히 Request에 넣으면, 이 엔티티가 `GroupRepository`에 의존해야 하는데 도메인 엔티티가 인프라 레이어에 의존하게 되어 순수성을 잃어버릴 수밖에 없습니다. 

## 🌱 참고 사항
- 다른 get에서 그룹 정보 반환도 필요할 것 같으니 추가 필요!
- 서비스 코드도 공통 부분을 묶어서 처리하는 리팩토링이 필요할 거 같습니다. 특히 WebClient 부분..
- 이제 프론트도 작업 바로 들어가면 될 거 같습니다!!
- 내 Request의 ubuntuUsername을 조회하는 API를 추가하면 좋을 거 같습니다.