### PR TITLE
[feat] 우분투 username 조회 API

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/RequestController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/RequestController.java
@@ -7,6 +7,7 @@ import DGU_AI_LAB.admin_be.domain.requests.dto.response.SaveRequestResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.service.RequestCommandService;
 import DGU_AI_LAB.admin_be.domain.requests.service.RequestQueryService;
 import DGU_AI_LAB.admin_be.global.auth.CustomUserDetails;
+import DGU_AI_LAB.admin_be.global.common.SuccessResponse; // Import SuccessResponse
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,42 +21,48 @@ import java.util.List;
 @RequestMapping("/api/requests")
 public class RequestController implements RequestApi {
 
-    private final RequestQueryService requestService;
+    private final RequestQueryService requestQueryService;
     private final RequestCommandService requestCommandService;
 
     /**
      * 사용 신청 생성
      */
     @PostMapping
-    public ResponseEntity<SaveRequestResponseDTO> createRequest(
-            @AuthenticationPrincipal(expression = "userId") Long userId,
-            @RequestBody @Valid SaveRequestRequestDTO dto
+    public ResponseEntity<SuccessResponse<?>> createRequest(@AuthenticationPrincipal(expression = "userId") Long userId,
+                                                             @RequestBody @Valid SaveRequestRequestDTO dto
     ) {
         SaveRequestResponseDTO body = requestCommandService.createRequest(userId, dto);
-        return ResponseEntity.ok(body);
+        return SuccessResponse.created(body);
     }
 
     /**
      * 사용 신청 변경 (저장공간 크기, 만료기한, 사용자가 속한 그룹, 리소스 그룹, 도커 이미지)
      */
     @PostMapping("/{requestId}/change")
-    public ResponseEntity<Void> createChangeRequest(
-            @AuthenticationPrincipal(expression = "userId") Long userId,
-            @PathVariable Long requestId,
-            @RequestBody @Valid ModifyRequestDTO dto
+    public ResponseEntity<SuccessResponse<?>> createChangeRequest(@AuthenticationPrincipal(expression = "userId") Long userId,
+                                                                   @PathVariable Long requestId,
+                                                                   @RequestBody @Valid ModifyRequestDTO dto
     ) {
         requestCommandService.createModificationRequest(userId, requestId, dto);
-        return ResponseEntity.ok().build();
+        return SuccessResponse.ok(null);
     }
 
     /**
      * 나의 사용 신청 조회
      */
     @GetMapping("/my")
-    public ResponseEntity<List<SaveRequestResponseDTO>> getMyRequests(
-            @AuthenticationPrincipal CustomUserDetails user
+    public ResponseEntity<SuccessResponse<?>> getMyRequests(@AuthenticationPrincipal CustomUserDetails user
     ) {
-        return ResponseEntity.ok(requestService.getRequestsByUserId(user.getUserId()));
+        List<SaveRequestResponseDTO> body = requestQueryService.getRequestsByUserId(user.getUserId());
+        return SuccessResponse.ok(body);
     }
 
+    /**
+     * 나의 사용 신청에 대한 모든 ubuntu_username 조회
+     */
+    @GetMapping("/fulfilled-usernames")
+    public ResponseEntity<SuccessResponse<?>> getAllFulfilledUsernames() {
+        List<String> usernames = requestQueryService.getAllFulfilledUsernames();
+        return SuccessResponse.ok(usernames);
+    }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/RequestApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/RequestApi.java
@@ -3,6 +3,7 @@ package DGU_AI_LAB.admin_be.domain.requests.controller.docs;
 import DGU_AI_LAB.admin_be.domain.requests.dto.request.SaveRequestRequestDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.SaveRequestResponseDTO;
 import DGU_AI_LAB.admin_be.global.auth.CustomUserDetails;
+import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -13,8 +14,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-
-import java.util.List;
 
 @Tag(name = "2. 서버 사용 신청", description = "서버 사용 신청 API")
 public interface RequestApi {
@@ -28,7 +27,7 @@ public interface RequestApi {
             description = "신청 생성 성공",
             content = @Content(schema = @Schema(implementation = SaveRequestResponseDTO.class))
     )
-    ResponseEntity<SaveRequestResponseDTO> createRequest(
+    ResponseEntity<SuccessResponse<?>> createRequest(
             @Parameter(hidden = true, description = "인증된 사용자 ID")
             Long userId,
             @RequestBody(description = "서버 사용 신청 DTO", required = true)
@@ -44,8 +43,18 @@ public interface RequestApi {
             description = "조회 성공",
             content = @Content(array = @ArraySchema(schema = @Schema(implementation = SaveRequestResponseDTO.class)))
     )
-    ResponseEntity<List<SaveRequestResponseDTO>> getMyRequests(
+    ResponseEntity<SuccessResponse<?>> getMyRequests(
             @Parameter(hidden = true, description = "인증된 사용자")
             CustomUserDetails user
     );
+    @Operation(
+            summary = "승인 완료된 모든 Ubuntu 사용자 이름 조회",
+            description = "[그룹 생성 시 사용] 현재 시스템에서 사용 승인(FULFILLED)이 완료된 모든 요청의 Ubuntu 사용자 이름 목록을 조회합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "조회 성공. data 필드에 사용자 이름 문자열 배열이 포함됩니다.",
+            content = @Content(schema = @Schema(implementation = SuccessResponse.class))
+    )
+    ResponseEntity<SuccessResponse<?>> getAllFulfilledUsernames();
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/repository/RequestRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/repository/RequestRepository.java
@@ -4,6 +4,8 @@ import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
 import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -21,5 +23,8 @@ public interface RequestRepository extends JpaRepository<Request, Long> {
     boolean existsByUbuntuUsername(String ubuntuUsername);
     List<Request> findAllByUser_UserIdAndStatus(Long userId, Status status);
     boolean existsByUbuntuUsernameAndUser_UserId(String ubuntuUsername, Long userId);
+
+    @Query("SELECT r.ubuntuUsername FROM Request r WHERE r.status = :status")
+    List<String> findUbuntuUsernamesByStatus(@Param("status") Status status);
 
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestQueryService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestQueryService.java
@@ -29,7 +29,6 @@ public class RequestQueryService {
     private final PortRequestService portRequestService;
 
     /** 내 신청 목록 */
-    @Transactional(readOnly = true)
     public List<SaveRequestResponseDTO> getRequestsByUserId(Long userId) {
         if (!userRepository.existsById(userId)) {
             throw new BusinessException(ErrorCode.USER_NOT_FOUND);
@@ -49,7 +48,6 @@ public class RequestQueryService {
     }
 
     /** 승인 완료 자원 사용량 */
-    @Transactional(readOnly = true)
     public List<ResourceUsageDTO> getAllFulfilledResourceUsage() {
         return requestRepository.findAllByStatus(Status.FULFILLED).stream()
                 .map(ResourceUsageDTO::fromEntity)
@@ -57,11 +55,18 @@ public class RequestQueryService {
     }
 
     /** 활성 컨테이너 */
-    @Transactional(readOnly = true)
     public List<ContainerInfoDTO> getActiveContainers() {
         return requestRepository.findAllByStatus(Status.FULFILLED).stream()
                 .map(ContainerInfoDTO::fromEntity)
                 .toList();
+    }
+
+
+    /**
+     * 승인 완료(FULFILLED)된 모든 요청의 ubuntuUsername 목록을 조회합니다.
+     */
+    public List<String> getAllFulfilledUsernames() {
+        return requestRepository.findUbuntuUsernamesByStatus(Status.FULFILLED);
     }
 
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/dto/request/UserLoginRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/dto/request/UserLoginRequestDTO.java
@@ -6,11 +6,11 @@ import jakarta.validation.constraints.NotBlank;
 @Schema(description = "로그인 요청 DTO")
 public record UserLoginRequestDTO(
 
-        @Schema(description = "이메일 주소", example = "user@example.com")
+        @Schema(description = "이메일 주소", example = "leesoeun2746@naver.com")
         @NotBlank
         String email,
 
-        @Schema(description = "비밀번호", example = "abcd1234!")
+        @Schema(description = "비밀번호", example = "1234")
         @NotBlank
         String password
 ) {}


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #126 

## 🌱 작업 사항
- 그룹을 생성할 때 필요한 ubuntuUsername을 조회합니다.

## 🌱 참고 사항
- 그룹을 생성할 때 ubuntuUsername을 지정하면 빈 그룹이 생깁니다. 
- 사용 신청 시, 그룹을 지정하지 않으면 **_자동으로_** uid와 같은 gid가 생깁니다. (이 케이스 클라이언트에서 고려 X, 서버 단에서 처리)
- 사용 신청 프로세스 : 사용 신청 시작 > 우분투 그룹 생성 또는 선택 (옵션) -> 사용 신청서 작성 -> 승인 
- 사용 변경 프로세스 : 우분투 그룹 생성하는 페이지 (단일) > 사용 변경 신청서 작성 > 우분투 그룹 선택 > 승인