### PR TITLE
[fix] JPA 엔티티 동일성(EqualsAndHashCode) 및 영속성 관련 버그 수정

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/service/AlarmService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/service/AlarmService.java
@@ -1,6 +1,7 @@
 package DGU_AI_LAB.admin_be.domain.alarm.service;
 
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
+import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -213,6 +214,38 @@ public class AlarmService {
         sendSlackAlert(message, targetWebhookUrl);
     }
 
+    /**
+     * 사용자에게 서버 사용 신청 승인 알림을 보냅니다.
+     * @param request 승인된 Request 엔티티
+     */
+    public void sendApprovalNotification(Request request) {
+        User user = request.getUser();
+        String subject = "[DGU AI LAB] 서버 사용 신청이 승인되었습니다.";
+        String message = String.format(
+                """
+                🎉 %s님의 서버 사용 신청이 성공적으로 승인되었습니다! 🎉
+                
+                아래 정보를 사용하여 서버에 접속해 주세요.
+                -------------------------------------
+                - Ubuntu 사용자 이름: %s
+                - 할당된 서버: %s
+                - 컨테이너 이미지: %s:%s
+                - 할당된 볼륨 크기: %d GiB
+                - 만료일: %s
+                -------------------------------------
+                
+                궁금한 점이 있다면 관리자에게 문의해 주세요.
+                """,
+                user.getName(),
+                request.getUbuntuUsername(),
+                request.getResourceGroup().getServerName(),
+                request.getContainerImage().getImageName(),
+                request.getContainerImage().getImageVersion(),
+                request.getVolumeSizeGiB(),
+                request.getExpiresAt().toLocalDate().toString()
+        );
 
+        sendAllAlerts(user.getName(), user.getEmail(), subject, message);
+    }
 
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/gpus/entity/Gpu.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/gpus/entity/Gpu.java
@@ -8,7 +8,6 @@ import lombok.*;
 @Table(name = "gpus")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(of = "gpuId")
 public class Gpu {
 
     @Id

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/entity/Group.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/entity/Group.java
@@ -8,7 +8,7 @@ import lombok.*;
 @Table(name = "`groups`")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(of = "groupId")
+@EqualsAndHashCode(of = "ubuntuGid")
 public class Group {
 
     @Id

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Request.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Request.java
@@ -19,6 +19,7 @@ import java.util.Set;
 @Table(name = "requests")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = "ubuntuUsername", callSuper = false)
 public class Request extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/RequestGroup.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/RequestGroup.java
@@ -8,17 +8,13 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "request_groups")
-@Access(AccessType.FIELD)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(of = "id")
+@EqualsAndHashCode(of = {"request", "group"})
 public class RequestGroup {
 
     @EmbeddedId
     private RequestGroupId id;
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY) @MapsId("requestId")
     @JoinColumn(name = "request_id", nullable = false)
@@ -28,6 +24,9 @@ public class RequestGroup {
     @JoinColumn(name = "ubuntu_gid", nullable = false)
     private Group group;
 
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
     @Builder
     public RequestGroup(Request request, Group group) {
         this.request = request;
@@ -36,10 +35,12 @@ public class RequestGroup {
 
     @PrePersist
     void onCreate() {
-        if (createdAt == null) createdAt = LocalDateTime.now();
-        // @MapsId가 id를 자동으로 채워주지만 방어적으로 ID도 보완
-        if (id == null && request != null && group != null) {
-            id = new RequestGroupId(request.getRequestId(), group.getUbuntuGid());
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+
+        if (this.id == null) {
+            this.id = new RequestGroupId(this.request.getRequestId(), this.group.getUbuntuGid());
         }
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
@@ -1,5 +1,6 @@
 package DGU_AI_LAB.admin_be.domain.requests.service;
 
+import DGU_AI_LAB.admin_be.domain.alarm.service.AlarmService;
 import DGU_AI_LAB.admin_be.domain.containerImage.entity.ContainerImage;
 import DGU_AI_LAB.admin_be.domain.containerImage.repository.ContainerImageRepository;
 import DGU_AI_LAB.admin_be.domain.groups.entity.Group;
@@ -41,6 +42,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional
 public class AdminRequestCommandService {
+
+    private final AlarmService alarmService;
 
     private final RequestRepository requestRepository;
     private final UserRepository userRepository;
@@ -154,6 +157,14 @@ public class AdminRequestCommandService {
         request.approve(image, rg, dto.volumeSizeGiB(), dto.adminComment());
         requestRepository.flush();
 
+        // 4. 사용자에게 승인 알림 발송
+        try {
+            alarmService.sendApprovalNotification(request);
+            log.info("사용자 '{}'에게 승인 알림을 성공적으로 발송했습니다.", request.getUser().getName());
+        } catch (Exception e) {
+            log.warn("사용자 '{}'에게 승인 알림을 보내는 데 실패했습니다. (RequestId: {})",
+                    request.getUser().getName(), request.getRequestId(), e);
+        }
         return SaveRequestResponseDTO.fromEntity(request);
     }
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
@@ -155,7 +155,7 @@ public class AdminRequestCommandService {
         ResourceGroup rg = resourceGroupRepository.findById(dto.resourceGroupId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
         request.approve(image, rg, dto.volumeSizeGiB(), dto.adminComment());
-        requestRepository.flush();
+        // requestRepository.flush();
 
         // 4. 사용자에게 승인 알림 발송
         try {

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/entity/User.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/entity/User.java
@@ -8,6 +8,7 @@ import lombok.*;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = "email", callSuper = false)
 public class User extends BaseTimeEntity {
 
     @Id


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #142 

## 🌱 작업 사항
- 다수의 엔티티에서 EqualsAndHashCode 구현이 잘못되었거나 누락된 것을 수정했습니다.
- `Could not set value... (setter)` 에러를 수정합니다!

## 🌱 참고 사항
🤔 기존 @EqualsAndHashCode 사용 이유
- 컬렉션(Set, Map)을 정상 동작시키기 위해: Set은 원소 중복 여부를 hasCode(), equals()로 판단하기 때문에 사용했습니다.
- JPA 영속성 컨텍스트 관리: 캐싱하고 관리할 때 equals(), hashCode()를 사용해 동일성을 식별하기 때문에 사용했습니다. 

## 🐞 에러 원인 분석
### @GeneratedValue ID를 기준으로 한 불안정한 hashCode: 자동 생성되는 ID를 기준으로 구현하면서 에러 발생
1. Group 객체 생성 (이때 groupId가 null)
2. hasCode()가 null을 기반으로 계산
3. 이 객체가 Request의 Set 에 추가
4. 트랜잭션을 커밋하면서 JPA가 Group을 DB에 저장 -> groupId에 실제 값이 할당
5. Set에 있던 Group의 hasdCode()값이 중간에 변경
6. Hibernate가 이걸 보고 어지러워서 JpaSystemException를 던져버림. 

### 성급한 flush() 호출로 인한 생명주기 충돌
- 서비스 중간에 flush()를 명시적으로 호출했었는데, 아직 관계가 안정되지 않은 상태에서 강제 동기화를 시키면서 JPA 생명 주기에 혼란을 줌.


## 🔧 수정사항
1. 안정적인 비즈니스 키 기반으로 EqualsAndHashCode 재정의
- 영속화 전부터 값이 존재하고 && 변하지 않는 비즈니스 키를 기준으로 삼자 : email, ubuntuUsername...
2. flush() 호출 제거 : approveRequest메서드에서 제거

### 🔗 참고
https://velog.io/@nmrhtn7898/JPA-Entity%EC%97%90%EC%84%9C-equals-hashcode-%EC%82%AC%EC%9A%A9%EC%8B%9C-%EB%B0%9C%EC%83%9D%ED%95%A0-%EC%88%98-%EC%9E%88%EB%8A%94-%EB%AC%B8%EC%A0%9C%EC%A0%90


Set을 사용하면 List보다 논리적 & 성능적으로 좋지만 
- 논리적: 중복 허용 X, Request에 똑같은 Group이 두 번 연결되는 일 절대 없음.
- 성능적: List를 OneToMany에서 사용하면 순서를 유지하기 위해 추가적인 작업, delete하나 하면 지우고 다시 남은 원소들 insert해야 함. set은 순서 없으니 당여니 상관이 없음. 
- Set 사용할 때는 equals, hashCode 주의하자.