### PR TITLE
[refactor] Remove @MapsId from ResourceGroupImage and rely on EmbeddedId

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/resourceGroupImages/entity/ResourceGroupImage.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/resourceGroupImages/entity/ResourceGroupImage.java
@@ -18,19 +18,20 @@ public class ResourceGroupImage extends BaseTimeEntity {
     private ResourceGroupImageId id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId("rsgroupId")
-    @JoinColumn(name = "rsgroup_id", nullable = false)
+    @JoinColumn(name = "rsgroup_id", nullable = false, insertable = false, updatable = false)
     private ResourceGroup resourceGroup;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId("imageId")
-    @JoinColumn(name = "image_id", nullable = false)
+    @JoinColumn(name = "image_id", nullable = false, insertable = false, updatable = false)
     private ContainerImage containerImage;
 
     @Builder
     public ResourceGroupImage(ResourceGroup resourceGroup, ContainerImage containerImage) {
         this.resourceGroup = resourceGroup;
         this.containerImage = containerImage;
+        if (resourceGroup != null && containerImage != null) {
+            this.id = new ResourceGroupImageId(resourceGroup.getRsgroupId(), containerImage.getImageId());
+        }
     }
 
     @PrePersist


### PR DESCRIPTION
- Removed @MapsId from ResourceGroupImage associations to prevent composite-key coupling issues.
- Associations are now read-only via insertable=false, updatable=false; the actual FK columns are set via the embedded id.
- Constructor and @PrePersist ensure id is synchronized from associated entities.