### PR TITLE
[fix] 공식 이미지 지원 종료에 따라 이미지 최신 버전으로 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jre-jammy
 
 WORKDIR /app
 
 COPY build/libs/admin_be-0.0.1-SNAPSHOT.jar app.jar
 
 EXPOSE 8080
+
+ENV TZ=Asia/Seoul
 
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
openjdk 공식 이미지 지원 종료

## 🌱 관련 이슈
- close : #161 

## 🌱 작업 사항
### openjdk → eclipse-temurin:
- openjdk 공식 이미지는 지원이 종료
- eclipse-temurin: 현재 java에서 가장 표준적으로 사용되는 프로덕션용 이미지로 수정

### jdk → jre:
- 실행만 하면 되므로 컴파일러가 포함된 무거운 JDK 이미지가 필요 없음 -> JRE사용해서 이미지 가볍게
- 쿠버네티스 노드들이 이미지를 pull 받는 속도 줄이기
- 필요없는 도구는 설치하지 않음 -> 보안 이슈 막기 (코드 수정 X, 실행만 할 수 있도록)

### slim → jammy:
- 기존 slim은 데비안 계열의 경량화 버전
- jammy는 Ubuntu 22.04 LTS 기반

## 🌱 추가 작업 사항
- application.yml updated (프론트엔드 주소 수정, notion & github secret 반영 완료)
- timezone추가
