### PR TITLE
UID/GID 할당 로직 리팩토링

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
@@ -105,8 +105,9 @@ public class GroupService {
         try {
             log.info("[createGroup] 외부 그룹 생성 API 호출 시작: {}", apiDto);
 
-            groupCreationWebClient.post()
-                    .uri("/accounts/addgroup")
+            groupCreationWebClient
+                    .put()
+                    .uri("/accounts/groups")
                     .bodyValue(apiDto)
                     .retrieve()
                     .bodyToMono(Map.class)

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/RequestGroup.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/RequestGroup.java
@@ -29,6 +29,7 @@ public class RequestGroup {
 
     @Builder
     public RequestGroup(Request request, Group group) {
+        this.id = new RequestGroupId();
         this.request = request;
         this.group = group;
     }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/usedIds/entity/CounterKey.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/usedIds/entity/CounterKey.java
@@ -1,0 +1,6 @@
+package DGU_AI_LAB.admin_be.domain.usedIds.entity;
+
+public enum CounterKey {
+    UID,
+    SHARED_GID;
+}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/usedIds/entity/IdCounter.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/usedIds/entity/IdCounter.java
@@ -1,0 +1,53 @@
+package DGU_AI_LAB.admin_be.domain.usedIds.entity;
+
+import DGU_AI_LAB.admin_be.error.ErrorCode;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity
+@Table(name = "id_counter")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IdCounter {
+
+    @Id
+    @Enumerated(EnumType.STRING)
+    @Column(name = "counter_key", nullable = false)
+    private CounterKey key;
+
+    @Column(name = "min_value", nullable = false)
+    private long minValue;
+
+    @Column(name = "max_value", nullable = false)
+    private long maxValue;
+
+    @Column(name = "next_value", nullable = false)
+    private long nextValue;
+
+    @Builder
+    public IdCounter(CounterKey key, long minValue, long maxValue, long nextValue) {
+        this.key = key;
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+        this.nextValue = nextValue;
+    }
+
+    /**
+     * 다음 ID를 할당하고 카운터를 1 증가시킵니다.
+     * nextValue가 minValue보다 작으면 minValue부터 시작합니다.
+     *
+     * @return 할당된 ID 값
+     * @throws BusinessException nextValue가 maxValue를 초과한 경우
+     */
+    public long allocateOne() {
+        if (nextValue < minValue) {
+            nextValue = minValue;
+        }
+        if (nextValue > maxValue) {
+            throw new BusinessException(ErrorCode.NO_AVAILABLE_RESOURCES);
+        }
+        return nextValue++;
+    }
+}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/usedIds/repository/IdCounterRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/usedIds/repository/IdCounterRepository.java
@@ -1,0 +1,17 @@
+package DGU_AI_LAB.admin_be.domain.usedIds.repository;
+
+import DGU_AI_LAB.admin_be.domain.usedIds.entity.CounterKey;
+import DGU_AI_LAB.admin_be.domain.usedIds.entity.IdCounter;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface IdCounterRepository extends JpaRepository<IdCounter, CounterKey> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<IdCounter> findByKey(CounterKey key);
+}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/usedIds/service/IdAllocationService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/usedIds/service/IdAllocationService.java
@@ -4,7 +4,10 @@ import DGU_AI_LAB.admin_be.domain.groups.entity.Group;
 import DGU_AI_LAB.admin_be.domain.groups.repository.GroupRepository;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import DGU_AI_LAB.admin_be.domain.usedIds.entity.CounterKey;
+import DGU_AI_LAB.admin_be.domain.usedIds.entity.IdCounter;
 import DGU_AI_LAB.admin_be.domain.usedIds.entity.UsedId;
+import DGU_AI_LAB.admin_be.domain.usedIds.repository.IdCounterRepository;
 import DGU_AI_LAB.admin_be.domain.usedIds.repository.UsedIdRepository;
 import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
@@ -22,14 +25,11 @@ import java.util.Optional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class IdAllocationService {
 
-    private static final long UID_BASE = 10_000L;
-    private static final int MAX_RETRY = 5;
-    private static final long GID_BASE = 2_000L;
-    private static final long GID_MAX_VALUE = 65535L;
-
     private final UsedIdRepository usedIdRepository;
+    private final IdCounterRepository idCounterRepository;
     private final GroupRepository groupRepository;
     private final RequestRepository requestRepository;
 
@@ -48,7 +48,7 @@ public class IdAllocationService {
                 .orElseGet(this::allocateNewUid);
 
         Group primaryGroup = groupRepository.findById(uid.getIdValue())
-                .orElseGet(() -> createGroupWithSameId(username, uid.getIdValue()));
+                .orElseGet(() -> createPrimaryGroup(username, uid.getIdValue()));
 
         return new AllocationResult(uid, primaryGroup);
     }
@@ -59,58 +59,42 @@ public class IdAllocationService {
                 .map(Request::getUbuntuUid);
     }
 
-    // 새 UID 생성
     private UsedId allocateNewUid() {
-        for (int i = 0; i < MAX_RETRY; i++) {
-            long currentMax = usedIdRepository.findMaxIdValue().orElse(UID_BASE - 1L);
-            long candidate = Math.max(UID_BASE, currentMax + 1);
-            try {
-                return usedIdRepository.saveAndFlush(UsedId.builder().idValue(candidate).build());
-            } catch (DataIntegrityViolationException ignore) {}
-        }
-        throw new BusinessException(ErrorCode.UID_ALLOCATION_FAILED);
+        IdCounter counter = idCounterRepository.findByKey(CounterKey.UID)
+                .orElseThrow(() -> new BusinessException(ErrorCode.UID_ALLOCATION_FAILED));
+        long uid = counter.allocateOne();
+        idCounterRepository.saveAndFlush(counter);
+        return usedIdRepository.saveAndFlush(UsedId.builder().idValue(uid).build());
     }
 
     /**
      * 새로운 GID를 할당하고 UsedId 테이블에 저장합니다.
+     * IdCounter에 비관적 락을 적용하여 동시성을 보장합니다.
      */
     @Transactional
     public Long allocateNewGid() {
-        for (int i = 0; i < MAX_RETRY; i++) {
-            // GID 범위 내에서 최대값을 찾습니다.
-            Long currentMax = usedIdRepository.findMaxIdValueInRange(GID_BASE, GID_MAX_VALUE)
-                    .orElse(GID_BASE - 1L);
+        IdCounter counter = idCounterRepository.findByKey(CounterKey.SHARED_GID)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GID_ALLOCATION_FAILED));
 
-            long candidate = Math.max(GID_BASE, currentMax + 1);
+        long gid = counter.allocateOne(); // 범위 초과 시 NO_AVAILABLE_RESOURCES 예외 발생
+        idCounterRepository.saveAndFlush(counter);
 
-            if (candidate > GID_MAX_VALUE) {
-                throw new BusinessException(ErrorCode.GID_ALLOCATION_FAILED);
-            }
-
-            try {
-                usedIdRepository.saveAndFlush(UsedId.builder().idValue(candidate).build());
-                return candidate;
-            } catch (DataIntegrityViolationException ignore) {}
+        try {
+            usedIdRepository.saveAndFlush(UsedId.builder().idValue(gid).build());
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.GID_ALLOCATION_FAILED);
         }
-        throw new BusinessException(ErrorCode.GID_ALLOCATION_FAILED);
+
+        return gid;
     }
 
-
-    private Group createGroupWithSameId(String username, long uidValue) {
-        Optional<Group> existing = groupRepository.findById(uidValue);
-        if (existing.isPresent()) return existing.get();
-
-        UsedId gidUsedId = usedIdRepository.findById(uidValue)
-                .orElseGet(() -> usedIdRepository.saveAndFlush(
-                        UsedId.builder().idValue(uidValue).build()
-                ));
-
-        Group group = Group.builder()
-                .groupName(username)
-                .ubuntuGid(uidValue)
-                .build();
-
-        return groupRepository.saveAndFlush(group);
+    private Group createPrimaryGroup(String username, long uidValue) {
+        return groupRepository.saveAndFlush(
+                Group.builder()
+                        .groupName(username)
+                        .ubuntuGid(uidValue)
+                        .build()
+        );
     }
 
     /**
@@ -124,7 +108,6 @@ public class IdAllocationService {
             return;
         }
 
-        // Request와의 연관관계는 스케줄러에서 (request.assignUbuntuUid(null)) 해제합니다.
         try {
             usedIdRepository.delete(usedId);
             log.info("UsedId 반환 (삭제) 성공: {}", usedId.getIdValue());

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/entity/RequestGroupTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/entity/RequestGroupTest.java
@@ -1,0 +1,107 @@
+package DGU_AI_LAB.admin_be.domain.requests.entity;
+
+import DGU_AI_LAB.admin_be.domain.groups.entity.Group;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RequestGroupTest {
+
+    @Test
+    @DisplayName("builder: id(RequestGroupId)가 null이 아닌 빈 인스턴스로 초기화된다")
+    void builder_initializesNonNullId() {
+        // @MapsId가 flush 시 RequestGroupId 필드에 값을 채우려면
+        // id 객체 자체가 null이 아니어야 한다 (null이면 NPE 발생)
+        RequestGroup rg = RequestGroup.builder()
+                .request(mock(Request.class))
+                .group(mock(Group.class))
+                .build();
+
+        assertThat(rg.getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("builder: id의 requestId, ubuntuGid는 null이다 (@MapsId가 flush 시 채운다)")
+    void builder_idFieldsAreNullBeforeFlush() {
+        RequestGroup rg = RequestGroup.builder()
+                .request(mock(Request.class))
+                .group(mock(Group.class))
+                .build();
+
+        assertThat(rg.getId().getRequestId()).isNull();
+        assertThat(rg.getId().getUbuntuGid()).isNull();
+    }
+
+    @Test
+    @DisplayName("@PrePersist: createdAt이 null이면 현재 시각으로 설정된다")
+    void prePersist_setsCreatedAtWhenNull() throws Exception {
+        Request request = mock(Request.class);
+        Group group = mock(Group.class);
+        when(request.getRequestId()).thenReturn(1L);
+        when(group.getUbuntuGid()).thenReturn(2000L);
+
+        RequestGroup rg = RequestGroup.builder()
+                .request(request)
+                .group(group)
+                .build();
+
+        assertThat(rg.getCreatedAt()).isNull();
+
+        invokeOnCreate(rg);
+
+        assertThat(rg.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("@PrePersist: createdAt이 이미 있으면 덮어쓰지 않는다")
+    void prePersist_doesNotOverrideExistingCreatedAt() throws Exception {
+        Request request = mock(Request.class);
+        Group group = mock(Group.class);
+        when(request.getRequestId()).thenReturn(1L);
+        when(group.getUbuntuGid()).thenReturn(2000L);
+
+        RequestGroup rg = RequestGroup.builder()
+                .request(request)
+                .group(group)
+                .build();
+
+        invokeOnCreate(rg); // 첫 번째 호출 → createdAt 설정
+        var firstCreatedAt = rg.getCreatedAt();
+
+        invokeOnCreate(rg); // 두 번째 호출 → 덮어쓰지 않음
+
+        assertThat(rg.getCreatedAt()).isEqualTo(firstCreatedAt);
+    }
+
+    @Test
+    @DisplayName("@PrePersist: id가 builder에서 초기화됐으면 @PrePersist가 교체하지 않는다")
+    void prePersist_doesNotOverrideExistingId() throws Exception {
+        Request request = mock(Request.class);
+        Group group = mock(Group.class);
+        when(request.getRequestId()).thenReturn(1L);
+        when(group.getUbuntuGid()).thenReturn(2000L);
+
+        RequestGroup rg = RequestGroup.builder()
+                .request(request)
+                .group(group)
+                .build();
+
+        RequestGroupId idBeforePersist = rg.getId();
+
+        invokeOnCreate(rg);
+
+        // builder에서 이미 id가 설정됐으므로 @PrePersist는 새 인스턴스를 만들지 않는다
+        assertThat(rg.getId()).isSameAs(idBeforePersist);
+    }
+
+    private void invokeOnCreate(RequestGroup rg) throws Exception {
+        Method onCreate = RequestGroup.class.getDeclaredMethod("onCreate");
+        onCreate.setAccessible(true);
+        onCreate.invoke(rg);
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/usedIds/entity/IdCounterTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/usedIds/entity/IdCounterTest.java
@@ -1,0 +1,92 @@
+package DGU_AI_LAB.admin_be.domain.usedIds.entity;
+
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class IdCounterTest {
+
+    @Test
+    @DisplayName("allocateOne: nextValue를 반환하고 1 증가시킨다")
+    void allocateOne_returnsCurrentAndIncrements() {
+        IdCounter counter = IdCounter.builder()
+                .key(CounterKey.UID)
+                .nextValue(10000L)
+                .minValue(10000L)
+                .maxValue(99999L)
+                .build();
+
+        long first = counter.allocateOne();
+        long second = counter.allocateOne();
+
+        assertThat(first).isEqualTo(10000L);
+        assertThat(second).isEqualTo(10001L);
+        assertThat(counter.getNextValue()).isEqualTo(10002L);
+    }
+
+    @Test
+    @DisplayName("allocateOne: nextValue가 minValue보다 작으면 minValue부터 할당한다")
+    void allocateOne_belowMin_startsFromMin() {
+        IdCounter counter = IdCounter.builder()
+                .key(CounterKey.SHARED_GID)
+                .nextValue(1000L)
+                .minValue(2000L)
+                .maxValue(65535L)
+                .build();
+
+        long result = counter.allocateOne();
+
+        assertThat(result).isEqualTo(2000L);
+        assertThat(counter.getNextValue()).isEqualTo(2001L);
+    }
+
+    @Test
+    @DisplayName("allocateOne: nextValue가 maxValue를 초과하면 예외를 던진다")
+    void allocateOne_exceedsMax_throwsException() {
+        IdCounter counter = IdCounter.builder()
+                .key(CounterKey.SHARED_GID)
+                .nextValue(65536L)
+                .minValue(2000L)
+                .maxValue(65535L)
+                .build();
+
+        assertThatThrownBy(counter::allocateOne)
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("allocateOne: maxValue 경계값에서 정상 할당 후 다음 호출에서 예외")
+    void allocateOne_atMaxBoundary_allocatesThenThrows() {
+        IdCounter counter = IdCounter.builder()
+                .key(CounterKey.SHARED_GID)
+                .nextValue(65535L)
+                .minValue(2000L)
+                .maxValue(65535L)
+                .build();
+
+        long result = counter.allocateOne();
+        assertThat(result).isEqualTo(65535L);
+
+        assertThatThrownBy(counter::allocateOne)
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("allocateOne: 연속 호출 시 순차적으로 증가한다")
+    void allocateOne_sequential_incrementsCorrectly() {
+        IdCounter counter = IdCounter.builder()
+                .key(CounterKey.UID)
+                .nextValue(10000L)
+                .minValue(10000L)
+                .maxValue(99999L)
+                .build();
+
+        for (long expected = 10000L; expected < 10010L; expected++) {
+            assertThat(counter.allocateOne()).isEqualTo(expected);
+        }
+        assertThat(counter.getNextValue()).isEqualTo(10010L);
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/usedIds/service/IdAllocationServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/usedIds/service/IdAllocationServiceTest.java
@@ -1,0 +1,278 @@
+package DGU_AI_LAB.admin_be.domain.usedIds.service;
+
+import DGU_AI_LAB.admin_be.domain.groups.entity.Group;
+import DGU_AI_LAB.admin_be.domain.groups.repository.GroupRepository;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
+import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import DGU_AI_LAB.admin_be.domain.usedIds.entity.CounterKey;
+import DGU_AI_LAB.admin_be.domain.usedIds.entity.IdCounter;
+import DGU_AI_LAB.admin_be.domain.usedIds.entity.UsedId;
+import DGU_AI_LAB.admin_be.domain.usedIds.repository.IdCounterRepository;
+import DGU_AI_LAB.admin_be.domain.usedIds.repository.UsedIdRepository;
+import DGU_AI_LAB.admin_be.error.ErrorCode;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class IdAllocationServiceTest {
+
+    @Mock
+    private UsedIdRepository usedIdRepository;
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Mock
+    private RequestRepository requestRepository;
+
+    @Mock
+    private IdCounterRepository idCounterRepository;
+
+    @InjectMocks
+    private IdAllocationService idAllocationService;
+
+    // ===== allocateNewGid =====
+
+    @Nested
+    @DisplayName("allocateNewGid")
+    class AllocateNewGidTest {
+
+        @Test
+        @DisplayName("카운터가 존재하면 GID를 할당하고 UsedId를 저장한다")
+        void success() {
+            IdCounter counter = IdCounter.builder()
+                    .key(CounterKey.SHARED_GID)
+                    .nextValue(2000L)
+                    .minValue(2000L)
+                    .maxValue(65535L)
+                    .build();
+
+            when(idCounterRepository.findByKey(CounterKey.SHARED_GID))
+                    .thenReturn(Optional.of(counter));
+            when(idCounterRepository.saveAndFlush(any(IdCounter.class)))
+                    .thenReturn(counter);
+            when(usedIdRepository.saveAndFlush(any(UsedId.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            Long gid = idAllocationService.allocateNewGid();
+
+            assertThat(gid).isEqualTo(2000L);
+            assertThat(counter.getNextValue()).isEqualTo(2001L);
+            verify(idCounterRepository).saveAndFlush(counter);
+            verify(usedIdRepository).saveAndFlush(any(UsedId.class));
+        }
+
+        @Test
+        @DisplayName("카운터가 없으면 GID_ALLOCATION_FAILED 예외를 던진다")
+        void counterNotFound_throwsException() {
+            when(idCounterRepository.findByKey(CounterKey.SHARED_GID))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> idAllocationService.allocateNewGid())
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.GID_ALLOCATION_FAILED);
+        }
+
+        @Test
+        @DisplayName("GID 범위가 소진되면 NO_AVAILABLE_RESOURCES 예외를 던진다")
+        void maxExceeded_throwsException() {
+            IdCounter counter = IdCounter.builder()
+                    .key(CounterKey.SHARED_GID)
+                    .nextValue(65536L)
+                    .minValue(2000L)
+                    .maxValue(65535L)
+                    .build();
+
+            when(idCounterRepository.findByKey(CounterKey.SHARED_GID))
+                    .thenReturn(Optional.of(counter));
+
+            assertThatThrownBy(() -> idAllocationService.allocateNewGid())
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.NO_AVAILABLE_RESOURCES);
+        }
+
+        @Test
+        @DisplayName("UsedId 저장 시 중복 키 충돌이면 GID_ALLOCATION_FAILED 예외를 던진다")
+        void duplicateKey_throwsException() {
+            IdCounter counter = IdCounter.builder()
+                    .key(CounterKey.SHARED_GID)
+                    .nextValue(2000L)
+                    .minValue(2000L)
+                    .maxValue(65535L)
+                    .build();
+
+            when(idCounterRepository.findByKey(CounterKey.SHARED_GID))
+                    .thenReturn(Optional.of(counter));
+            when(idCounterRepository.saveAndFlush(any(IdCounter.class)))
+                    .thenReturn(counter);
+            when(usedIdRepository.saveAndFlush(any(UsedId.class)))
+                    .thenThrow(new DataIntegrityViolationException("duplicate"));
+
+            assertThatThrownBy(() -> idAllocationService.allocateNewGid())
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.GID_ALLOCATION_FAILED);
+        }
+
+        @Test
+        @DisplayName("연속 할당 시 GID가 순차적으로 증가한다")
+        void sequential_incrementsCorrectly() {
+            IdCounter counter = IdCounter.builder()
+                    .key(CounterKey.SHARED_GID)
+                    .nextValue(2000L)
+                    .minValue(2000L)
+                    .maxValue(65535L)
+                    .build();
+
+            when(idCounterRepository.findByKey(CounterKey.SHARED_GID))
+                    .thenReturn(Optional.of(counter));
+            when(idCounterRepository.saveAndFlush(any(IdCounter.class)))
+                    .thenReturn(counter);
+            when(usedIdRepository.saveAndFlush(any(UsedId.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            Long first = idAllocationService.allocateNewGid();
+            Long second = idAllocationService.allocateNewGid();
+            Long third = idAllocationService.allocateNewGid();
+
+            assertThat(first).isEqualTo(2000L);
+            assertThat(second).isEqualTo(2001L);
+            assertThat(third).isEqualTo(2002L);
+        }
+    }
+
+    // ===== allocateFor =====
+
+    @Nested
+    @DisplayName("allocateFor")
+    class AllocateForTest {
+
+        @Test
+        @DisplayName("기존 UID가 있으면 재사용하고, 기존 그룹이 있으면 재사용한다")
+        void reusesExistingUidAndGroup() {
+            UsedId existingUid = UsedId.builder().idValue(10001L).build();
+            Group existingGroup = Group.builder().groupName("testuser").ubuntuGid(10001L).build();
+            Request prevRequest = mock(Request.class);
+            Request request = mock(Request.class);
+
+            when(request.getUbuntuUsername()).thenReturn("testuser");
+            when(requestRepository.findTopByUbuntuUsernameAndUbuntuUidIsNotNullOrderByApprovedAtDesc("testuser"))
+                    .thenReturn(Optional.of(prevRequest));
+            when(prevRequest.getUbuntuUid()).thenReturn(existingUid);
+            when(groupRepository.findById(10001L)).thenReturn(Optional.of(existingGroup));
+
+            IdAllocationService.AllocationResult result = idAllocationService.allocateFor(request);
+
+            assertThat(result.getUid()).isEqualTo(existingUid);
+            assertThat(result.getPrimaryGroup()).isEqualTo(existingGroup);
+            verify(idCounterRepository, never()).findByKey(any());
+        }
+
+        @Test
+        @DisplayName("기존 UID가 없으면 새 UID를 할당한다")
+        void allocatesNewUidWhenNoneExists() {
+            Request request = mock(Request.class);
+            when(request.getUbuntuUsername()).thenReturn("newuser");
+            when(requestRepository.findTopByUbuntuUsernameAndUbuntuUidIsNotNullOrderByApprovedAtDesc("newuser"))
+                    .thenReturn(Optional.empty());
+
+            IdCounter uidCounter = IdCounter.builder()
+                    .key(CounterKey.UID)
+                    .nextValue(10000L)
+                    .minValue(10000L)
+                    .maxValue(2147483647L)
+                    .build();
+
+            UsedId newUid = UsedId.builder().idValue(10000L).build();
+            Group newGroup = Group.builder().groupName("newuser").ubuntuGid(10000L).build();
+
+            when(idCounterRepository.findByKey(CounterKey.UID))
+                    .thenReturn(Optional.of(uidCounter));
+            when(idCounterRepository.saveAndFlush(any(IdCounter.class)))
+                    .thenReturn(uidCounter);
+            when(usedIdRepository.saveAndFlush(any(UsedId.class)))
+                    .thenReturn(newUid);
+            when(groupRepository.findById(10000L))
+                    .thenReturn(Optional.empty());
+            when(groupRepository.saveAndFlush(any(Group.class)))
+                    .thenReturn(newGroup);
+
+            IdAllocationService.AllocationResult result = idAllocationService.allocateFor(request);
+
+            assertThat(result.getUid().getIdValue()).isEqualTo(10000L);
+            assertThat(result.getPrimaryGroup().getGroupName()).isEqualTo("newuser");
+            verify(idCounterRepository).findByKey(CounterKey.UID);
+            verify(idCounterRepository).saveAndFlush(uidCounter);
+        }
+
+        @Test
+        @DisplayName("UID 카운터가 없으면 UID_ALLOCATION_FAILED 예외를 던진다")
+        void noUidCounter_throwsException() {
+            Request request = mock(Request.class);
+            when(request.getUbuntuUsername()).thenReturn("newuser");
+            when(requestRepository.findTopByUbuntuUsernameAndUbuntuUidIsNotNullOrderByApprovedAtDesc("newuser"))
+                    .thenReturn(Optional.empty());
+            when(idCounterRepository.findByKey(CounterKey.UID))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> idAllocationService.allocateFor(request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.UID_ALLOCATION_FAILED);
+        }
+    }
+
+    // ===== releaseId =====
+
+    @Nested
+    @DisplayName("releaseId")
+    class ReleaseIdTest {
+
+        @Test
+        @DisplayName("UsedId를 정상적으로 삭제한다")
+        void success() {
+            UsedId usedId = UsedId.builder().idValue(10001L).build();
+
+            idAllocationService.releaseId(usedId);
+
+            verify(usedIdRepository).delete(usedId);
+        }
+
+        @Test
+        @DisplayName("null이 전달되면 삭제를 건너뛴다")
+        void nullInput_skips() {
+            idAllocationService.releaseId(null);
+
+            verify(usedIdRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("삭제 실패 시 USED_ID_RELEASE_FAILED 예외를 던진다")
+        void deleteFails_throwsException() {
+            UsedId usedId = UsedId.builder().idValue(10001L).build();
+            doThrow(new RuntimeException("DB error"))
+                    .when(usedIdRepository).delete(usedId);
+
+            assertThatThrownBy(() -> idAllocationService.releaseId(usedId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.USED_ID_RELEASE_FAILED);
+        }
+    }
+}


### PR DESCRIPTION
🌱 관련 이슈                                                                                                                                                         

  - close : #176                                                                                                                                                       
                  
  🌱 작업 사항                                                                                                                                                         

  1. IdCounter 테이블 도입 및 비관적 락 적용

  - IdCounter 엔티티 및 CounterKey enum 신규 생성
    - CounterKey.UID / CounterKey.SHARED_GID 두 가지 카운터 키 관리
    - allocateOne() 메서드에서 범위(min~max) 검증 후 순차 할당
  - IdCounterRepository에 @Lock(LockModeType.PESSIMISTIC_WRITE) 적용하여 동시 요청 시 중복 할당 방지

  2. IdAllocationService 리팩터링

  - 기존 findMaxIdValue() + retry 루프 방식을 IdCounter + 비관적 락 방식으로 전체 교체
    - UID 할당: IdCounter(UID) 카운터로 순차 발급
    - GID 할당: IdCounter(SHARED_GID) 카운터로 순차 발급
  - createGroupWithSameId() → createPrimaryGroup()으로 단순화 (중복 조회 로직 제거)

  3. Config API 요청 경로 수정

  - 그룹 생성 외부 API 호출: POST /accounts/addgroup → PUT /accounts/groups

  4. 테스트 코드 작성

  - IdCounterTest: allocateOne() 경계값 및 예외 케이스 단위 테스트
  - IdAllocationServiceTest: allocateFor, allocateNewGid, releaseId Mockito 기반 단위 테스트
  - RequestGroupTest: builder 초기화 및 @PrePersist 동작 검증

  🌱 참고 사항
  - IdCounter 초기 데이터 삽입 필요: id_counter 테이블에 UID, SHARED_GID 레코드가 없으면 할당 시 예외가 발생하므로, 배포 전 초기 데이터를 반드시 삽입해야 함.
