### PR TITLE
Refactor/#181 self invocation

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestExpiryService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestExpiryService.java
@@ -36,13 +36,12 @@ public class RequestExpiryService {
         String ubuntuUsername = request.getUbuntuUsername();
         User user = request.getUser();
 
-        ubuntuAccountService.deleteUbuntuAccount(ubuntuUsername);
-
         UsedId usedId = request.getUbuntuUid();
         if (usedId != null) {
             request.assignUbuntuUid(null);
             idAllocationService.releaseId(usedId);
         }
+        ubuntuAccountService.deleteUbuntuAccount(ubuntuUsername);
 
         request.delete();
         eventPublisher.publishEvent(new RequestExpiredEvent(user, ubuntuUsername, serverName));

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestExpiryService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestExpiryService.java
@@ -1,0 +1,51 @@
+package DGU_AI_LAB.admin_be.domain.requests.service;
+
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import DGU_AI_LAB.admin_be.domain.usedIds.entity.UsedId;
+import DGU_AI_LAB.admin_be.domain.usedIds.service.IdAllocationService;
+import DGU_AI_LAB.admin_be.domain.users.entity.User;
+import DGU_AI_LAB.admin_be.error.ErrorCode;
+import DGU_AI_LAB.admin_be.error.exception.EntityNotFoundException;
+import DGU_AI_LAB.admin_be.global.event.RequestExpiredEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RequestExpiryService {
+
+    private final RequestRepository requestRepository;
+    private final UbuntuAccountService ubuntuAccountService;
+    private final IdAllocationService idAllocationService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void deleteExpiredRequest(Long requestId) {
+        Request request = requestRepository.findById(requestId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        if (request.getStatus() != Status.FULFILLED) return;
+
+        String serverName = request.getResourceGroup().getServerName();
+        String ubuntuUsername = request.getUbuntuUsername();
+        User user = request.getUser();
+
+        ubuntuAccountService.deleteUbuntuAccount(ubuntuUsername);
+
+        UsedId usedId = request.getUbuntuUid();
+        if (usedId != null) {
+            request.assignUbuntuUid(null);
+            idAllocationService.releaseId(usedId);
+        }
+
+        request.delete();
+        eventPublisher.publishEvent(new RequestExpiredEvent(user, ubuntuUsername, serverName));
+        log.info("삭제 트랜잭션 성공: {}", ubuntuUsername);
+    }
+}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestSchedulerService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestSchedulerService.java
@@ -4,18 +4,11 @@ import DGU_AI_LAB.admin_be.domain.alarm.service.AlarmService;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
 import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
-import DGU_AI_LAB.admin_be.domain.requests.service.UbuntuAccountService;
-import DGU_AI_LAB.admin_be.domain.usedIds.entity.UsedId;
-import DGU_AI_LAB.admin_be.domain.usedIds.service.IdAllocationService;
+import DGU_AI_LAB.admin_be.domain.requests.service.RequestExpiryService;
 import DGU_AI_LAB.admin_be.domain.users.entity.User;
-import DGU_AI_LAB.admin_be.error.ErrorCode;
-import DGU_AI_LAB.admin_be.error.exception.EntityNotFoundException;
-import DGU_AI_LAB.admin_be.global.event.RequestExpiredEvent;
 import DGU_AI_LAB.admin_be.global.util.MessageUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,10 +27,7 @@ public class RequestSchedulerService {
 
     private final RequestRepository requestRepository;
     private final AlarmService alarmService;
-    private final UbuntuAccountService ubuntuAccountService;
-    private final IdAllocationService idAllocationService;
-    private final ApplicationEventPublisher eventPublisher;
-    private final ApplicationContext applicationContext;
+    private final RequestExpiryService requestExpiryService;
     private final MessageUtils messageUtils;
 
     @Scheduled(cron = "0 00 08 * * ?", zone = "Asia/Seoul")
@@ -58,8 +48,6 @@ public class RequestSchedulerService {
         List<Request> expiredRequests = requestRepository.findAllWithUserByExpiredDateBefore(now);
         if (expiredRequests.isEmpty()) return;
 
-        RequestSchedulerService self = applicationContext.getBean(RequestSchedulerService.class);
-
         for (Request request : expiredRequests) {
             String serverName = "Unknown";
             String username = request.getUbuntuUsername();
@@ -68,37 +56,13 @@ public class RequestSchedulerService {
                 if (request.getResourceGroup() != null) {
                     serverName = request.getResourceGroup().getServerName();
                 }
-                self.deleteExpiredRequest(request.getRequestId());
+                requestExpiryService.deleteExpiredRequest(request.getRequestId());
 
             } catch (Exception e) {
                 log.error("계정 삭제 실패 (ID: {}): {}", request.getRequestId(), e.getMessage());
                 sendFailureAlertToAdmin(serverName, username, e.getMessage());
             }
         }
-    }
-
-    @Transactional
-    public void deleteExpiredRequest(Long requestId) {
-        Request request = requestRepository.findById(requestId)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-
-        if (request.getStatus() != Status.FULFILLED) return;
-
-        String serverName = request.getResourceGroup().getServerName();
-        String ubuntuUsername = request.getUbuntuUsername();
-        User user = request.getUser();
-
-        ubuntuAccountService.deleteUbuntuAccount(ubuntuUsername);
-
-        UsedId usedId = request.getUbuntuUid();
-        if (usedId != null) {
-            request.assignUbuntuUid(null);
-            idAllocationService.releaseId(usedId);
-        }
-
-        request.delete();
-        eventPublisher.publishEvent(new RequestExpiredEvent(user, ubuntuUsername, serverName));
-        log.info("삭제 트랜잭션 성공: {}", ubuntuUsername);
     }
 
     @Transactional(readOnly = true)
@@ -149,6 +113,3 @@ public class RequestSchedulerService {
         return "SERVER";
     }
 }
-
-
-

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestSchedulerServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestSchedulerServiceTest.java
@@ -15,6 +15,8 @@ import DGU_AI_LAB.admin_be.domain.usedIds.repository.UsedIdRepository;
 import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
 import DGU_AI_LAB.admin_be.global.util.MessageUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -56,6 +58,23 @@ public class RequestSchedulerServiceTest {
     @Autowired private ContainerImageRepository containerImageRepository;
 
     private final LocalDateTime MOCK_NOW = LocalDateTime.of(2025, 11, 10, 10, 30, 0);
+
+    @BeforeEach
+    void cleanUpTestData() {
+        deleteTestUser();
+    }
+
+    @AfterEach
+    void tearDown() {
+        deleteTestUser();
+    }
+
+    private void deleteTestUser() {
+        userRepository.findByEmail("test@dgu.ac.kr").ifPresent(user -> {
+            requestRepository.deleteAllInBatch(requestRepository.findAllByUser(user));
+            userRepository.deleteById(user.getUserId());
+        });
+    }
 
     @Test
     @DisplayName("스케줄러 통합 테스트: 만료 삭제(이벤트) 및 1/3/7일 전 알림 발송 검증")

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestSchedulerServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestSchedulerServiceTest.java
@@ -27,6 +27,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -50,7 +51,6 @@ public class RequestSchedulerServiceTest {
     @MockitoBean
     private UbuntuAccountService ubuntuAccountService;
 
-    // --- Repositories ---
     @Autowired private RequestRepository requestRepository;
     @Autowired private UserRepository userRepository;
     @Autowired private UsedIdRepository usedIdRepository;
@@ -72,6 +72,8 @@ public class RequestSchedulerServiceTest {
     private void deleteTestUser() {
         userRepository.findByEmail("test@dgu.ac.kr").ifPresent(user -> {
             requestRepository.deleteAllInBatch(requestRepository.findAllByUser(user));
+            List<UsedId> testUsedIds = usedIdRepository.findAllById(List.of(1000L, 1001L, 1002L, 1003L, 1004L));
+            usedIdRepository.deleteAll(testUsedIds);
             userRepository.deleteById(user.getUserId());
         });
     }


### PR DESCRIPTION
● ## 🌱 관련 이슈            
  - close : #181
                                                                                                                                                                       
  ## 🌱 작업 사항
  - `RequestSchedulerService`에서 `ApplicationContext.getBean()`을 이용한 self-invocation 패턴 제거                                                                    
  - `deleteExpiredRequest()` 로직을 `RequestExpiryService`로 분리하여 Spring AOP 프록시를 통한 정상적인 `@Transactional` 적용                                        
  - `RequestSchedulerServiceTest`에 `@BeforeEach` / `@AfterEach` cleanup 추가하여 테스트 실행 시 중복 데이터로 인한 실패 수정

  ## 🌱 참고 사항
  - `@Transactional`이 붙은 메서드를 같은 클래스 내에서 호출(self-invocation)하면 Spring AOP 프록시를 우회하여 트랜잭션이 적용되지 않음. 기존 코드는 이를 피하기 위해
  `ApplicationContext.getBean()`으로 자기 자신의 프록시를 직접 꺼내 호출하는 방식을 사용했으나, 이는 Spring 컨테이너에 대한 불필요한 의존을 발생시킴
  - 해결책으로 트랜잭션이 필요한 메서드를 별도 빈(`RequestExpiryService`)으로 분리하면 외부 호출이 되어 AOP 프록시가 정상 동작함
  - `RequestSchedulerServiceTest`는 `@SpringBootTest`로 실제 MySQL에 연결하는 통합 테스트이므로, 테스트 데이터가 롤백 없이 커밋됨. `@BeforeEach`에서 잔존 데이터를
  정리하고 `@AfterEach`에서 테스트 후 정리하여 반복 실행 시에도 안정적으로 동작하도록 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 만료된 요청을 별도 서비스로 분리하여 자동으로 안전하게 삭제하도록 추가

* **버그 수정**
  * 만료 처리 중 실패 시 관리자에게 알림을 보내는 기능 추가
  * 삭제 시 관련 계정과 할당 아이디를 해제하고 후속 알림을 발송하도록 개선

* **테스트**
  * 테스트 전후 데이터 정리로 테스트 격리 및 신뢰성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->