### PR TITLE
[feat] PodServiceStub stub 프로파일 추가 및 배포 환경 mock 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
               --set image.repository=${{ secrets.DOCKER_USERNAME }}/admin-prod \
               --set image.tag=latest \
               --set env.application="$(echo "${{ secrets.APPLICATION }}" | base64 -w 0)" \
-              --set args[0]="--spring.profiles.active=prod" \
+              --set args[0]="--spring.profiles.active=prod,stub" \
               --set forceReload=$(date +%s)
 
             echo "🎉 배포 완료"

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/PodServiceStub.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/PodServiceStub.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Slf4j
 @Service
 @Primary
-@Profile("local")
+@Profile({"local", "stub"})
 public class PodServiceStub extends PodService {
 
     public PodServiceStub(@Qualifier("configWebClient") WebClient webClient) {


### PR DESCRIPTION
  🌱 작업 사항

  - PodServiceStub.java: @Profile("local") → @Profile({"local", "stub"}) 추가하여 stub 프로파일 활성화 시 mock 동작
  - .github/workflows/deploy.yml: 배포 시 --spring.profiles.active=prod,stub으로 변경하여 프로덕션 환경에서 mock 사용

  🌱 참고 사항

  - 실제 Pod 생성 API로 전환하려면 deploy.yml에서 ,stub만 제거하면 됩니다.
  --set args[0]="--spring.profiles.active=prod"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타 개선**
  * 애플리케이션 배포 구성에서 스텁 프로필이 활성화되었습니다. 이를 통해 로컬 및 스텁 환경에서 일관된 동작을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->