### PR TITLE
[refactor] #194 build-and-deploy job을 build / deploy로 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -33,6 +33,11 @@ jobs:
           docker push ${{ secrets.DOCKER_USERNAME }}/admin-prod:latest
           docker logout
 
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
       - name: 🚀 Helm을 통한 쿠버네티스 배포
         uses: appleboy/ssh-action@master
         with:


### PR DESCRIPTION
## Summary
- GitHub Actions 워크플로우의 `build-and-deploy` 단일 job을 `build`와 `deploy` 두 개의 job으로 분리
- `deploy` job에 `needs: build` 설정으로 빌드 성공 시에만 배포 실행되도록 의존성 명시

## Test plan
- [ ] `build` job 단독 실행 시 Gradle 빌드 및 Docker Push 정상 동작 확인
- [ ] `build` 실패 시 `deploy` job이 실행되지 않는지 확인
- [ ] `deploy` job에서 Helm 배포 정상 동작 확인

closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI/CD 워크플로우가 개선되어 빌드 단계와 배포 단계가 분리되었습니다. 각 단계는 독립적으로 실행되며, 빌드 완료 후 배포가 진행됩니다. 이를 통해 파이프라인 구조가 더욱 명확하고 확장 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->