### PR TITLE
[feat] #196 모든 도메인 테스트 코드 작성 및 테스트 커버리지 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out/
 
 application.yml
 /.gradle
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.3'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'DGU_AI_LAB'
@@ -68,4 +69,41 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacoco {
+	toolVersion = "0.8.11"
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required = true
+		html.required = true
+		csv.required = false
+	}
+	afterEvaluate {
+		classDirectories.setFrom(files(classDirectories.files.collect {
+			fileTree(dir: it, excludes: [
+				'**/global/config/**',
+				'**/global/auth/**',
+				'**/*Application*',
+				'**/*DTO*',
+				'**/*RequestDTO*',
+				'**/*ResponseDTO*',
+				'**/error/exception/**'
+			])
+		}))
+	}
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			limit {
+				minimum = 0.50
+			}
+		}
+	}
 }

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,0 +1,199 @@
+# ✅ Tests Reference (대화용)
+
+이 문서는 `admin_be` 레포의 테스트 코드를 **대화/리뷰/온보딩**에 바로 활용할 수 있도록 정리한 레퍼런스입니다.
+
+- **테스트 실행법**: 어떻게/어디까지 돌릴 수 있는지
+- **테스트가 고정하는 규칙**: “어떤 조건에서 어떤 결과가 나와야 하는가(상태 전이/예외/알림/저장)”
+
+---
+
+## 1) 테스트 실행 방법
+
+```bash
+# 전체 테스트 실행
+./gradlew test
+
+# 특정 테스트 클래스만 실행 (예: TokenServiceTest)
+./gradlew test --tests "DGU_AI_LAB.admin_be.domain.users.service.TokenServiceTest"
+
+# 특정 테스트 메서드만 실행
+./gradlew test --tests "DGU_AI_LAB.admin_be.domain.users.service.TokenServiceTest.issueToken_createsNewRefreshToken_whenNotInRedis"
+```
+
+이 프로젝트는 `build.gradle`에서 `test` 이후 `jacocoTestReport`가 자동 실행되도록 설정되어 있습니다.
+
+```bash
+# JaCoCo 커버리지 리포트 생성
+./gradlew jacocoTestReport
+```
+
+`jacocoTestReport`는 **먼저 `test` 태스크를 실행**한 뒤 리포트를 만듭니다. 그래서 커버리지 생성 중에 테스트가 실패하면, 로그상으로는 `:test` 실패가 먼저 보입니다.
+
+### `./gradlew test` / WebMvcTest에서 `IllegalStateException` (Failed to load ApplicationContext)
+
+터미널에 아래처럼만 나오고 테스트 본문 assertion 오류가 아닌 경우가 많습니다.
+
+- `java.lang.IllegalStateException` … `DefaultCacheAwareContextLoaderDelegate`
+- 원인 체인: `BeanCreationException` → `IllegalArgumentException` (Spring `Assert`)
+
+의미는 **슬라이스 테스트(`@WebMvcTest`)용 Spring 컨텍스트를 띄우다가 빈 정의/주입 단계에서 깨졌다**는 뜻입니다. 이 레포에서는 `@WebMvcTest` + 공통 `WebMvcTestSupport`(JPA metamodel / JWT / Redis / UserDetails 등 mock) 조합에서 자주 나옵니다.
+
+- **대응**: `./gradlew clean test`로 `build/`를 깨끗이 한 뒤 재실행
+- **코드**: Spring Boot 3.4+에서는 `@MockBean` 대신 **`@MockitoBean`** 권장 — `WebMvcTestSupport`와 컨트롤러 테스트는 이 방식으로 맞춰 두었습니다.
+
+---
+
+## 2) 테스트 종류(패턴) 빠른 이해
+
+테스트 코드는 주로 `src/test/java/DGU_AI_LAB/admin_be/`에 있습니다.
+
+### A. 컨트롤러 테스트 (`@WebMvcTest` + `MockMvc`)
+
+- **목적**: HTTP 요청/응답(상태 코드, JSON 포맷, validation, 예외 → HTTP 매핑)을 빠르게 검증
+- **특징**
+  - 서비스는 `@MockBean`으로 대체
+  - Security는 `excludeAutoConfiguration = {SecurityAutoConfiguration.class}`로 비활성화하는 패턴 사용
+
+### B. 서비스 테스트 (Mockito 단위 테스트)
+
+- **목적**: 비즈니스 규칙(예외 조건, 저장/조회 흐름, 외부 의존성과 상호작용)을 고정
+- **특징**: Repository/WebClient/Redis/JWT/Alarm 등은 mock으로 대체하고 호출/결과를 단언
+
+### C. 리포지토리 테스트 (`@DataJpaTest` + H2)
+
+- **목적**: Spring Data JPA 쿼리 메서드가 원하는 조건으로 데이터를 반환하는지 검증
+- **특징**: `@ActiveProfiles("test")`로 테스트 프로파일에서 동작
+
+### D. 엔티티 테스트 (Plain JUnit)
+
+- **목적**: 엔티티 메서드의 상태 전이, 기본값, 경계조건(중복 삭제 등)을 코드 레벨로 고정
+
+### E. 스케줄러 통합 테스트 (`@SpringBootTest`)
+
+- **목적**: 만료/삭제/사전 알림/유저 수명주기처럼 여러 컴포넌트가 얽힌 “정책”을 DB까지 포함해 검증
+- **특징**: 외부로 나가면 안 되는 부분(알림 발송, 계정 삭제 등)은 `@MockitoBean`으로 대체하고 메시지 내용/호출 횟수까지 단언
+
+---
+
+## 3) 도메인별 테스트가 고정하는 비즈니스 규칙(상세)
+
+아래는 테스트 파일을 “대화용”으로 바로 설명할 수 있게 **무엇을 보장하는지** 중심으로 정리했습니다.
+
+### A. Container Image (`domain/containerImage`)
+
+- **`ContainerImageControllerTest`**
+  - **POST `/api/images`**: 유효한 요청 → `200 OK` + DTO
+  - **GET `/api/images/{id}`**: 존재하면 `200`, 미존재면 `404`
+  - **GET `/api/images`**: 목록 조회 `200` + 리스트
+- **`ContainerImageServiceTest`**
+  - **createImage/getImageById/getAllImages**: 저장/조회/빈 목록 및 미존재 예외 정책 고정
+
+### B. Groups (`domain/groups`)
+
+- **`GroupControllerTest`**
+  - **GET `/api/groups`**: 목록 조회 성공/빈 목록일 때의 `404` 매핑
+- **`GroupServiceTest`**
+  - **getAllGroups**: 빈 목록이면 예외
+  - **createGroup**
+    - 그룹명 중복이면 예외
+    - `IdAllocationService.allocateNewGid()` 기반 GID 할당
+    - 외부 그룹 생성 API(WebClient 체인) 호출 흐름이 깨지지 않도록 모킹
+    - `ubuntuUsername`이 주어진 경우 “해당 유저 소유 요청인지” 검증
+
+### C. Users/Auth/Token (`domain/users`)
+
+#### 컨트롤러
+
+- **`AuthControllerTest`**
+  - 회원가입: 정상/형식 오류(`400`)/중복(`409`) HTTP 규칙
+  - 로그인: 정상(`200` + access/refresh 반환)/필수값 오류(`400`) 규칙
+- **`AdminUserControllerTest`**
+  - 관리자 유저 조회/삭제의 성공/미존재(`404`) 규칙
+
+#### 서비스
+
+- **`UserLoginServiceTest`**
+  - 회원가입은 Redis의 `VERIFIED:{email}` 인증키가 있어야 가능(없으면 `UnauthorizedException`)
+  - 가입 성공 시 인증키 삭제
+  - 로그인 실패 조건(이메일 없음/비활성/비밀번호 불일치) 시 `UnauthorizedException`
+  - 로그인 성공 시 JWT 발급 + Redis 저장 흐름 고정
+- **`TokenServiceTest`**
+  - refresh 토큰 키 네이밍은 `RT:{userId}`
+  - Redis에 refresh가 있으면 재사용, 없으면 생성/저장
+  - reissue: access subject 디코딩 + refresh 검증 후 재발급
+  - logout: Redis 키 삭제
+- **`UserServiceTest`**
+  - 내 정보/유저 조회의 미존재 예외(`EntityNotFoundException`)
+  - 비밀번호 변경 정책(현재 불일치/신규 동일/정상 변경)
+  - SSH 인증(userAuth): base64 입력 → 해싱 → request(username/pw) 매칭
+- **`AdminUserServiceTest`**
+  - soft delete 정책(연결된 Request 없을 때 `isActive=false`)
+  - 미존재 시 `EntityNotFoundException`
+
+#### 리포지토리/엔티티
+
+- **`UserRepositoryTest`**: `findByEmail`, 비활성/Hard delete 대상 조회의 기준일(경계조건)
+- **`UserTest`**: 기본값(Role/활성화/lastLoginAt), withdraw/recordLogin/update 동작
+
+### D. Requests (`domain/requests`)
+
+#### 서비스
+
+- **`RequestCommandServiceTest`**
+  - 요청 생성 시 ubuntu username 중복이면 예외
+  - user/resourceGroup 미존재 시 예외
+  - 변경요청 requestId 미존재 시 예외
+- **`RequestQueryServiceTest`**
+  - userId 존재 검증 후 조회(없으면 예외)
+  - 승인(FULFILLED) 요청 조회/username 목록 조회 규칙
+- **`AdminRequestQueryServiceTest`**
+  - 전체/신규(PENDING)/변경요청(PENDING)/리소스 요약 조회 규칙
+- **`AdminRequestCommandServiceTest`**
+  - 승인 시 `PodService.createPod()` 호출 정책
+  - Pod 응답의 external ports → `PodExternalPortRepository` 저장 정책(포트 없으면 저장 없음)
+- **`ConfigRequestServiceTest`**
+  - `getAcceptInfo`가 `PortRequests` → `additional_ports` 변환(내부포트/목적만 포함)
+  - Node 정보 → `gpu_nodes` 변환 시 CPU/메모리 포맷까지 고정
+
+#### 리포지토리/엔티티
+
+- **`RequestRepositoryTest`**: 유저/상태/username 기준 조회 및 username 목록 추출 규칙
+- **`RequestTest`**: approve/reject/delete/update 상태 전이 + 중복 삭제 예외 + null 업데이트 정책
+- **`RequestGroupTest`**: `@MapsId` 복합키 builder 초기화/`@PrePersist` 동작 규칙
+
+### E. Dashboard (`domain/dashboard`)
+
+- **`DashboardServiceTest`**
+  - `Status.ALL` vs 특정 상태(FULFILLED/PENDING)에 따라 어떤 Repository 메서드를 호출해야 하는지 고정
+
+### F. Resource Groups (`domain/resourceGroups`)
+
+- **`ResourceGroupServiceTest`**
+  - 전체 조회는 빈 리스트 허용
+  - GPU 요약 정보가 비어 있으면 예외(“현황이 없으면 오류” 정책)
+
+### G. Used IDs (`domain/usedIds`)
+
+- **`IdCounterTest`**
+  - `allocateOne()` 증가, min/max 경계, 초과 예외 정책
+- **`IdAllocationServiceTest`**
+  - GID/UID 할당 실패 조건(카운터 없음/범위 소진/중복키 충돌)과 재사용 정책
+  - releaseId의 null 처리/삭제 실패 예외 정책
+
+### H. Scheduler 통합 테스트 (`domain/scheduler`)
+
+- **`RequestSchedulerServiceTest`**
+  - 시간 고정 후 만료 요청의 삭제/알림/관리자 슬랙 알림 정책 검증
+  - 1/3/7일 전 알림의 subject/body가 `MessageUtils`와 정확히 일치해야 함
+- **`UserSchedulerServiceTest`**
+  - 유저 라이프사이클(경고 D-7/D-1, Soft Delete, Hard Delete)
+  - “활동 유저 보호/Pod 유저 보호” 정책 검증
+
+---
+
+## 4) 이 문서를 대화에 쓰는 법
+
+- **“이 API는 어떤 상태 코드가 맞아?”** → 컨트롤러 테스트 항목을 보면 됩니다.
+- **“만료 삭제, D-7 알림 같은 정책이 요구사항이야?”** → 스케줄러 통합 테스트가 사실상 정책 스펙입니다.
+- **“키 네이밍/호출 횟수 같은 규칙은 어디서 보장돼?”** → Token/스케줄러/승인 서비스 테스트가 그 규칙을 고정합니다.
+

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/containerImage/controller/ContainerImageControllerTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/containerImage/controller/ContainerImageControllerTest.java
@@ -1,0 +1,114 @@
+package DGU_AI_LAB.admin_be.domain.containerImage.controller;
+
+import DGU_AI_LAB.admin_be.domain.containerImage.dto.request.ContainerImageCreateRequest;
+import DGU_AI_LAB.admin_be.domain.containerImage.dto.response.ContainerImageResponseDTO;
+import DGU_AI_LAB.admin_be.domain.containerImage.service.ContainerImageService;
+import DGU_AI_LAB.admin_be.error.ErrorCode;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import DGU_AI_LAB.admin_be.support.WebMvcTestSupport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        value = ContainerImageController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class}
+)
+class ContainerImageControllerTest extends WebMvcTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private ContainerImageService containerImageService;
+
+    private ContainerImageResponseDTO sampleDto() {
+        return ContainerImageResponseDTO.builder()
+                .imageId(1L)
+                .imageName("pytorch")
+                .imageVersion("2.1.0")
+                .cudaVersion("11.8")
+                .description("PyTorch 2.1.0")
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    @Nested
+    @DisplayName("POST /api/images")
+    class CreateImage {
+
+        @Test
+        @DisplayName("유효한 요청으로 이미지를 생성하면 200 OK와 DTO를 반환한다")
+        void createImage_returns200WithDto() throws Exception {
+            when(containerImageService.createImage(any())).thenReturn(sampleDto());
+
+            ContainerImageCreateRequest request = new ContainerImageCreateRequest(
+                    "pytorch", "2.1.0", "11.8", "PyTorch 2.1.0"
+            );
+
+            mockMvc.perform(post("/api/images")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.imageName").value("pytorch"));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/images/{id}")
+    class GetImageById {
+
+        @Test
+        @DisplayName("존재하는 id로 조회하면 200 OK와 DTO를 반환한다")
+        void getImageById_returns200WithDto() throws Exception {
+            when(containerImageService.getImageById(1L)).thenReturn(sampleDto());
+
+            mockMvc.perform(get("/api/images/1").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.imageName").value("pytorch"));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 id로 조회하면 404 Not Found를 반환한다")
+        void getImageById_returns404_whenNotFound() throws Exception {
+            when(containerImageService.getImageById(99L))
+                    .thenThrow(new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
+
+            mockMvc.perform(get("/api/images/99").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/images")
+    class GetAllImages {
+
+        @Test
+        @DisplayName("이미지 목록을 조회하면 200 OK와 리스트를 반환한다")
+        void getAllImages_returns200WithList() throws Exception {
+            when(containerImageService.getAllImages()).thenReturn(List.of(sampleDto()));
+
+            mockMvc.perform(get("/api/images").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0].imageName").value("pytorch"));
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/containerImage/service/ContainerImageServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/containerImage/service/ContainerImageServiceTest.java
@@ -1,0 +1,124 @@
+package DGU_AI_LAB.admin_be.domain.containerImage.service;
+
+import DGU_AI_LAB.admin_be.domain.containerImage.dto.request.ContainerImageCreateRequest;
+import DGU_AI_LAB.admin_be.domain.containerImage.dto.response.ContainerImageResponseDTO;
+import DGU_AI_LAB.admin_be.domain.containerImage.entity.ContainerImage;
+import DGU_AI_LAB.admin_be.domain.containerImage.repository.ContainerImageRepository;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ContainerImageServiceTest {
+
+    @InjectMocks
+    private ContainerImageService containerImageService;
+
+    @Mock
+    private ContainerImageRepository imageRepository;
+
+    private ContainerImage mockImage;
+
+    @BeforeEach
+    void setUp() {
+        mockImage = ContainerImage.builder()
+                .imageName("pytorch")
+                .imageVersion("2.1.0")
+                .cudaVersion("11.8")
+                .description("PyTorch 2.1.0 with CUDA 11.8")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("createImage")
+    class CreateImage {
+
+        @Test
+        @DisplayName("이미지를 생성하면 저장된 DTO를 반환한다")
+        void createImage_success() {
+            when(imageRepository.save(any(ContainerImage.class))).thenReturn(mockImage);
+
+            ContainerImageCreateRequest request = new ContainerImageCreateRequest(
+                    "pytorch", "2.1.0", "11.8", "PyTorch 2.1.0 with CUDA 11.8"
+            );
+
+            ContainerImageResponseDTO result = containerImageService.createImage(request);
+
+            assertThat(result).isNotNull();
+            assertThat(result.imageName()).isEqualTo("pytorch");
+            assertThat(result.imageVersion()).isEqualTo("2.1.0");
+            assertThat(result.cudaVersion()).isEqualTo("11.8");
+        }
+    }
+
+    @Nested
+    @DisplayName("getImageById")
+    class GetImageById {
+
+        @Test
+        @DisplayName("존재하는 id로 조회하면 DTO를 반환한다")
+        void getImageById_returnsDTO_whenExists() {
+            when(imageRepository.findById(1L)).thenReturn(Optional.of(mockImage));
+
+            ContainerImageResponseDTO result = containerImageService.getImageById(1L);
+
+            assertThat(result.imageName()).isEqualTo("pytorch");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 id로 조회하면 BusinessException을 던진다")
+        void getImageById_throwsException_whenNotFound() {
+            when(imageRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> containerImageService.getImageById(99L))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllImages")
+    class GetAllImages {
+
+        @Test
+        @DisplayName("이미지 목록을 반환한다")
+        void getAllImages_returnsList() {
+            ContainerImage image2 = ContainerImage.builder()
+                    .imageName("tensorflow")
+                    .imageVersion("2.13.0")
+                    .cudaVersion("11.8")
+                    .description("TensorFlow 2.13.0")
+                    .build();
+
+            when(imageRepository.findAll()).thenReturn(List.of(mockImage, image2));
+
+            List<ContainerImageResponseDTO> result = containerImageService.getAllImages();
+
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting("imageName").containsExactlyInAnyOrder("pytorch", "tensorflow");
+        }
+
+        @Test
+        @DisplayName("이미지가 없으면 빈 리스트를 반환한다")
+        void getAllImages_returnsEmptyList_whenNoImages() {
+            when(imageRepository.findAll()).thenReturn(List.of());
+
+            List<ContainerImageResponseDTO> result = containerImageService.getAllImages();
+
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/dashboard/service/DashboardServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/dashboard/service/DashboardServiceTest.java
@@ -1,0 +1,72 @@
+package DGU_AI_LAB.admin_be.domain.dashboard.service;
+
+import DGU_AI_LAB.admin_be.domain.nodes.repository.NodeRepository;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.UserServerResponseDTO;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DashboardServiceTest {
+
+    @InjectMocks
+    private DashboardService dashboardService;
+
+    @Mock
+    private RequestRepository requestRepository;
+
+    @Mock
+    private NodeRepository nodeRepository;
+
+    @Nested
+    @DisplayName("getUserServers")
+    class GetUserServers {
+
+        @Test
+        @DisplayName("Status.ALL이면 userId의 모든 요청을 반환한다")
+        void getUserServers_returnsAllRequests_whenStatusAll() {
+            when(requestRepository.findAllByUser_UserId(1L)).thenReturn(List.of());
+
+            List<UserServerResponseDTO> result = dashboardService.getUserServers(1L, Status.ALL);
+
+            assertThat(result).isEmpty();
+            verify(requestRepository).findAllByUser_UserId(1L);
+            verify(requestRepository, never()).findByUserUserIdAndStatus(anyLong(), any());
+        }
+
+        @Test
+        @DisplayName("Status.FULFILLED이면 FULFILLED 요청만 반환한다")
+        void getUserServers_returnsFulfilledRequests_whenStatusFulfilled() {
+            when(requestRepository.findByUserUserIdAndStatus(1L, Status.FULFILLED)).thenReturn(List.of());
+
+            List<UserServerResponseDTO> result = dashboardService.getUserServers(1L, Status.FULFILLED);
+
+            assertThat(result).isEmpty();
+            verify(requestRepository).findByUserUserIdAndStatus(1L, Status.FULFILLED);
+        }
+
+        @Test
+        @DisplayName("Status.PENDING이면 PENDING 요청만 반환한다")
+        void getUserServers_returnsPendingRequests_whenStatusPending() {
+            when(requestRepository.findByUserUserIdAndStatus(1L, Status.PENDING)).thenReturn(List.of());
+
+            List<UserServerResponseDTO> result = dashboardService.getUserServers(1L, Status.PENDING);
+
+            assertThat(result).isEmpty();
+            verify(requestRepository).findByUserUserIdAndStatus(1L, Status.PENDING);
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/groups/controller/GroupControllerTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/groups/controller/GroupControllerTest.java
@@ -1,0 +1,67 @@
+package DGU_AI_LAB.admin_be.domain.groups.controller;
+
+import DGU_AI_LAB.admin_be.domain.groups.dto.response.GroupResponseDTO;
+import DGU_AI_LAB.admin_be.domain.groups.service.GroupService;
+import DGU_AI_LAB.admin_be.error.ErrorCode;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import DGU_AI_LAB.admin_be.support.WebMvcTestSupport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        value = GroupController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class}
+)
+class GroupControllerTest extends WebMvcTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private GroupService groupService;
+
+    @Nested
+    @DisplayName("GET /api/groups")
+    class GetGroups {
+
+        @Test
+        @DisplayName("그룹 목록을 조회하면 200 OK와 리스트를 반환한다")
+        void getGroups_returns200WithList() throws Exception {
+            List<GroupResponseDTO> groups = List.of(
+                    GroupResponseDTO.builder().ubuntuGid(2000L).groupName("developers").build()
+            );
+            when(groupService.getAllGroups()).thenReturn(groups);
+
+            mockMvc.perform(get("/api/groups").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data[0].groupName").value("developers"));
+        }
+
+        @Test
+        @DisplayName("그룹이 없으면 BusinessException에 의해 404를 반환한다")
+        void getGroups_returns404_whenEmpty() throws Exception {
+            when(groupService.getAllGroups())
+                    .thenThrow(new BusinessException(ErrorCode.NO_AVAILABLE_GROUPS));
+
+            mockMvc.perform(get("/api/groups").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound());
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupServiceTest.java
@@ -1,0 +1,141 @@
+package DGU_AI_LAB.admin_be.domain.groups.service;
+
+import DGU_AI_LAB.admin_be.domain.groups.dto.request.CreateGroupRequestDTO;
+import DGU_AI_LAB.admin_be.domain.groups.dto.response.GroupResponseDTO;
+import DGU_AI_LAB.admin_be.domain.groups.entity.Group;
+import DGU_AI_LAB.admin_be.domain.groups.repository.GroupRepository;
+import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import DGU_AI_LAB.admin_be.domain.usedIds.entity.UsedId;
+import DGU_AI_LAB.admin_be.domain.usedIds.repository.UsedIdRepository;
+import DGU_AI_LAB.admin_be.domain.usedIds.service.IdAllocationService;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GroupServiceTest {
+
+    @InjectMocks
+    private GroupService groupService;
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Mock
+    private UsedIdRepository usedIdRepository;
+
+    @Mock
+    private RequestRepository requestRepository;
+
+    @Mock
+    private IdAllocationService idAllocationService;
+
+    @Mock
+    private WebClient groupCreationWebClient;
+
+    @Nested
+    @DisplayName("getAllGroups")
+    class GetAllGroups {
+
+        @Test
+        @DisplayName("그룹이 있으면 GroupResponseDTO 리스트를 반환한다")
+        void getAllGroups_returnsList() {
+            Group group1 = Group.builder().groupName("developers").ubuntuGid(2000L).build();
+            Group group2 = Group.builder().groupName("admins").ubuntuGid(2001L).build();
+            when(groupRepository.findAll()).thenReturn(List.of(group1, group2));
+
+            List<GroupResponseDTO> result = groupService.getAllGroups();
+
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting("groupName").containsExactlyInAnyOrder("developers", "admins");
+        }
+
+        @Test
+        @DisplayName("그룹이 없으면 BusinessException을 던진다")
+        void getAllGroups_throwsException_whenEmpty() {
+            when(groupRepository.findAll()).thenReturn(List.of());
+
+            assertThatThrownBy(() -> groupService.getAllGroups())
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("createGroup")
+    class CreateGroup {
+
+        @Test
+        @DisplayName("유효한 요청으로 그룹을 생성하면 GroupResponseDTO를 반환한다")
+        @SuppressWarnings("unchecked")
+        void createGroup_success() {
+            // Arrange
+            when(groupRepository.existsByGroupName("developers")).thenReturn(false);
+            when(idAllocationService.allocateNewGid()).thenReturn(2000L);
+
+            // Mock WebClient chain
+            WebClient.RequestBodyUriSpec uriSpec = mock(WebClient.RequestBodyUriSpec.class);
+            WebClient.RequestBodySpec bodySpec = mock(WebClient.RequestBodySpec.class);
+            WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
+            doReturn(uriSpec).when(groupCreationWebClient).put();
+            doReturn(bodySpec).when(uriSpec).uri(anyString());
+            doReturn(bodySpec).when(bodySpec).bodyValue(any());
+            doReturn(responseSpec).when(bodySpec).retrieve();
+            doReturn(Mono.just(Map.of("result", "ok"))).when(responseSpec).bodyToMono(Map.class);
+
+            UsedId usedId = UsedId.builder().idValue(2000L).build();
+            when(usedIdRepository.findById(2000L)).thenReturn(Optional.of(usedId));
+
+            Group savedGroup = Group.builder().groupName("developers").ubuntuGid(2000L).build();
+            when(groupRepository.save(any(Group.class))).thenReturn(savedGroup);
+
+            CreateGroupRequestDTO dto = new CreateGroupRequestDTO("developers", null);
+
+            // Act
+            GroupResponseDTO result = groupService.createGroup(dto, 1L);
+
+            // Assert
+            assertThat(result.groupName()).isEqualTo("developers");
+            assertThat(result.ubuntuGid()).isEqualTo(2000L);
+        }
+
+        @Test
+        @DisplayName("중복된 그룹명으로 생성하면 BusinessException을 던진다")
+        void createGroup_throwsException_whenGroupNameDuplicated() {
+            when(groupRepository.existsByGroupName("developers")).thenReturn(true);
+
+            CreateGroupRequestDTO dto = new CreateGroupRequestDTO("developers", null);
+
+            assertThatThrownBy(() -> groupService.createGroup(dto, 1L))
+                    .isInstanceOf(BusinessException.class);
+        }
+
+        @Test
+        @DisplayName("ubuntuUsername이 제공됐지만 해당 유저의 요청이 아니면 BusinessException을 던진다")
+        void createGroup_throwsException_whenUsernameNotOwnedByUser() {
+            when(requestRepository.existsByUbuntuUsernameAndUser_UserId("otheruser", 1L)).thenReturn(false);
+
+            CreateGroupRequestDTO dto = new CreateGroupRequestDTO("newgroup", "otheruser");
+
+            assertThatThrownBy(() -> groupService.createGroup(dto, 1L))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/entity/RequestTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/entity/RequestTest.java
@@ -1,0 +1,155 @@
+package DGU_AI_LAB.admin_be.domain.requests.entity;
+
+import DGU_AI_LAB.admin_be.domain.containerImage.entity.ContainerImage;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
+import DGU_AI_LAB.admin_be.domain.users.entity.User;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class RequestTest {
+
+    private Request request;
+
+    @BeforeEach
+    void setUp() {
+        User user = mock(User.class);
+        ResourceGroup rg = mock(ResourceGroup.class);
+        ContainerImage image = mock(ContainerImage.class);
+
+        request = Request.builder()
+                .ubuntuUsername("testuser")
+                .ubuntuPassword("hashedPassword")
+                .volumeSizeGiB(50L)
+                .expiresAt(LocalDateTime.now().plusDays(30))
+                .usagePurpose("딥러닝 연구")
+                .formAnswers("{}")
+                .user(user)
+                .resourceGroup(rg)
+                .containerImage(image)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("approve")
+    class Approve {
+
+        @Test
+        @DisplayName("승인하면 상태가 FULFILLED로 변경된다")
+        void approve_changesStatusToFulfilled() {
+            ContainerImage newImage = mock(ContainerImage.class);
+            ResourceGroup newRg = mock(ResourceGroup.class);
+
+            request.approve(newImage, newRg, 100L, "승인합니다");
+
+            assertThat(request.getStatus()).isEqualTo(Status.FULFILLED);
+            assertThat(request.getVolumeSizeGiB()).isEqualTo(100L);
+            assertThat(request.getApprovedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("reject")
+    class Reject {
+
+        @Test
+        @DisplayName("거절하면 상태가 DENIED로 변경된다")
+        void reject_changesStatusToDenied() {
+            request.reject("리소스 부족");
+
+            assertThat(request.getStatus()).isEqualTo(Status.DENIED);
+            assertThat(request.getAdminComment()).isEqualTo("리소스 부족");
+        }
+    }
+
+    @Nested
+    @DisplayName("delete")
+    class Delete {
+
+        @Test
+        @DisplayName("삭제하면 상태가 DELETED로 변경된다")
+        void delete_changesStatusToDeleted() {
+            request.delete();
+
+            assertThat(request.getStatus()).isEqualTo(Status.DELETED);
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 Request를 다시 삭제하면 BusinessException을 던진다")
+        void delete_throwsException_whenAlreadyDeleted() {
+            request.delete();
+
+            assertThatThrownBy(request::delete)
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateVolumeSize")
+    class UpdateVolumeSize {
+
+        @Test
+        @DisplayName("null이 아닌 값으로 볼륨 크기를 업데이트한다")
+        void updateVolumeSize_updatesWhenNotNull() {
+            request.updateVolumeSize(200L);
+
+            assertThat(request.getVolumeSizeGiB()).isEqualTo(200L);
+        }
+
+        @Test
+        @DisplayName("null이면 볼륨 크기를 변경하지 않는다")
+        void updateVolumeSize_doesNotUpdateWhenNull() {
+            request.updateVolumeSize(null);
+
+            assertThat(request.getVolumeSizeGiB()).isEqualTo(50L);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateExpiresAt")
+    class UpdateExpiresAt {
+
+        @Test
+        @DisplayName("null이 아닌 값으로 만료일을 업데이트한다")
+        void updateExpiresAt_updatesWhenNotNull() {
+            LocalDateTime newDate = LocalDateTime.now().plusDays(60);
+            request.updateExpiresAt(newDate);
+
+            assertThat(request.getExpiresAt()).isEqualTo(newDate);
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    class Update {
+
+        @Test
+        @DisplayName("FULFILLED 상태가 아닌 요청을 수정하면 BusinessException을 던진다")
+        void update_throwsException_whenNotFulfilled() {
+            assertThatThrownBy(() -> request.update(100L, null, "이유"))
+                    .isInstanceOf(BusinessException.class);
+        }
+
+        @Test
+        @DisplayName("FULFILLED 상태의 요청을 수정하면 성공한다")
+        void update_success_whenFulfilled() {
+            ContainerImage image = mock(ContainerImage.class);
+            ResourceGroup rg = mock(ResourceGroup.class);
+            request.approve(image, rg, 50L, null);
+
+            LocalDateTime newDate = LocalDateTime.now().plusDays(90);
+            request.update(200L, newDate, "용량 증가 필요");
+
+            assertThat(request.getVolumeSizeGiB()).isEqualTo(200L);
+            assertThat(request.getExpiresAt()).isEqualTo(newDate);
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/repository/RequestRepositoryTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/repository/RequestRepositoryTest.java
@@ -1,0 +1,198 @@
+package DGU_AI_LAB.admin_be.domain.requests.repository;
+
+import DGU_AI_LAB.admin_be.domain.containerImage.entity.ContainerImage;
+import DGU_AI_LAB.admin_be.domain.containerImage.repository.ContainerImageRepository;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.repository.ResourceGroupRepository;
+import DGU_AI_LAB.admin_be.domain.users.entity.User;
+import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class RequestRepositoryTest {
+
+    @Autowired
+    private RequestRepository requestRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ResourceGroupRepository resourceGroupRepository;
+
+    @Autowired
+    private ContainerImageRepository containerImageRepository;
+
+    private User user;
+    private ResourceGroup resourceGroup;
+    private ContainerImage containerImage;
+    private Request pendingRequest;
+    private Request fulfilledRequest;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(User.builder()
+                .email("test@dgu.ac.kr")
+                .password("encoded")
+                .name("홍길동")
+                .studentId("2021001234")
+                .phone("010-1111-2222")
+                .department("컴퓨터공학과")
+                .build());
+
+        resourceGroup = resourceGroupRepository.save(ResourceGroup.builder()
+                .resourceGroupName("GPU Server A")
+                .description("메인 GPU 서버")
+                .serverName("server-01")
+                .build());
+
+        containerImage = containerImageRepository.save(ContainerImage.builder()
+                .imageName("pytorch")
+                .imageVersion("2.1.0")
+                .cudaVersion("11.8")
+                .description("PyTorch 2.1.0")
+                .build());
+
+        pendingRequest = requestRepository.save(Request.builder()
+                .ubuntuUsername("pendinguser")
+                .ubuntuPassword("hashedPw1")
+                .volumeSizeGiB(50L)
+                .expiresAt(LocalDateTime.now().plusDays(30))
+                .usagePurpose("연구 목적")
+                .formAnswers("{}")
+                .user(user)
+                .resourceGroup(resourceGroup)
+                .containerImage(containerImage)
+                .build());
+
+        Request req2 = Request.builder()
+                .ubuntuUsername("fulfilleduser")
+                .ubuntuPassword("hashedPw2")
+                .volumeSizeGiB(100L)
+                .expiresAt(LocalDateTime.now().plusDays(60))
+                .usagePurpose("머신러닝")
+                .formAnswers("{}")
+                .user(user)
+                .resourceGroup(resourceGroup)
+                .containerImage(containerImage)
+                .build();
+        req2.approve(containerImage, resourceGroup, 100L, null);
+        fulfilledRequest = requestRepository.save(req2);
+    }
+
+    @Nested
+    @DisplayName("findAllByUser")
+    class FindAllByUser {
+
+        @Test
+        @DisplayName("특정 유저의 모든 요청을 조회한다")
+        void findAllByUser_returnsUserRequests() {
+            List<Request> result = requestRepository.findAllByUser(user);
+
+            assertThat(result).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByUbuntuUsername")
+    class FindByUbuntuUsername {
+
+        @Test
+        @DisplayName("존재하는 ubuntuUsername으로 조회하면 Request를 반환한다")
+        void findByUbuntuUsername_returnsRequest_whenExists() {
+            Optional<Request> result = requestRepository.findByUbuntuUsername("pendinguser");
+
+            assertThat(result).isPresent();
+            assertThat(result.get().getStatus()).isEqualTo(Status.PENDING);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ubuntuUsername으로 조회하면 빈 Optional을 반환한다")
+        void findByUbuntuUsername_returnsEmpty_whenNotExists() {
+            Optional<Request> result = requestRepository.findByUbuntuUsername("notexist");
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByStatus")
+    class FindAllByStatus {
+
+        @Test
+        @DisplayName("PENDING 상태 요청 목록을 조회한다")
+        void findAllByStatus_returnsPendingRequests() {
+            List<Request> result = requestRepository.findAllByStatus(Status.PENDING);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getUbuntuUsername()).isEqualTo("pendinguser");
+        }
+
+        @Test
+        @DisplayName("FULFILLED 상태 요청 목록을 조회한다")
+        void findAllByStatus_returnsFulfilledRequests() {
+            List<Request> result = requestRepository.findAllByStatus(Status.FULFILLED);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getUbuntuUsername()).isEqualTo("fulfilleduser");
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByUbuntuUsername")
+    class ExistsByUbuntuUsername {
+
+        @Test
+        @DisplayName("존재하는 ubuntuUsername에 대해 true를 반환한다")
+        void existsByUbuntuUsername_returnsTrue_whenExists() {
+            assertThat(requestRepository.existsByUbuntuUsername("pendinguser")).isTrue();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ubuntuUsername에 대해 false를 반환한다")
+        void existsByUbuntuUsername_returnsFalse_whenNotExists() {
+            assertThat(requestRepository.existsByUbuntuUsername("notexist")).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("findUbuntuUsernamesByStatus")
+    class FindUbuntuUsernamesByStatus {
+
+        @Test
+        @DisplayName("FULFILLED 상태 요청들의 ubuntuUsername 목록을 반환한다")
+        void findUbuntuUsernamesByStatus_returnsFulfilledUsernames() {
+            List<String> result = requestRepository.findUbuntuUsernamesByStatus(Status.FULFILLED);
+
+            assertThat(result).containsExactly("fulfilleduser");
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByUser_UserId")
+    class FindAllByUserUserId {
+
+        @Test
+        @DisplayName("userId로 해당 유저의 모든 요청을 조회한다")
+        void findAllByUserUserId_returnsRequests() {
+            List<Request> result = requestRepository.findAllByUser_UserId(user.getUserId());
+
+            assertThat(result).hasSize(2);
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryServiceTest.java
@@ -1,0 +1,131 @@
+package DGU_AI_LAB.admin_be.domain.requests.service;
+
+import DGU_AI_LAB.admin_be.domain.portRequests.service.PortRequestService;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.ChangeRequestResponseDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.ContainerInfoDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.ResourceUsageDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.SaveRequestResponseDTO;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import DGU_AI_LAB.admin_be.domain.requests.repository.ChangeRequestRepository;
+import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminRequestQueryServiceTest {
+
+    @InjectMocks
+    private AdminRequestQueryService adminRequestQueryService;
+
+    @Mock
+    private RequestRepository requestRepository;
+
+    @Mock
+    private ChangeRequestRepository changeRequestRepository;
+
+    @Mock
+    private PortRequestService portRequestService;
+
+    @Nested
+    @DisplayName("getAllRequests")
+    class GetAllRequests {
+
+        @Test
+        @DisplayName("모든 요청 목록을 반환한다")
+        void getAllRequests_returnsList() {
+            when(requestRepository.findAll()).thenReturn(List.of());
+
+            List<SaveRequestResponseDTO> result = adminRequestQueryService.getAllRequests();
+
+            assertThat(result).isEmpty();
+            verify(requestRepository).findAll();
+        }
+    }
+
+    @Nested
+    @DisplayName("getNewRequests")
+    class GetNewRequests {
+
+        @Test
+        @DisplayName("PENDING 상태 요청 목록을 반환한다")
+        void getNewRequests_returnsPendingList() {
+            when(requestRepository.findAllByStatus(Status.PENDING)).thenReturn(List.of());
+
+            List<SaveRequestResponseDTO> result = adminRequestQueryService.getNewRequests();
+
+            assertThat(result).isEmpty();
+            verify(requestRepository).findAllByStatus(Status.PENDING);
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllFulfilledResourceUsage")
+    class GetAllFulfilledResourceUsage {
+
+        @Test
+        @DisplayName("FULFILLED 상태 요청들의 리소스 사용량을 반환한다")
+        void getAllFulfilledResourceUsage_returnsList() {
+            when(requestRepository.findAllByStatus(Status.FULFILLED)).thenReturn(List.of());
+
+            List<ResourceUsageDTO> result = adminRequestQueryService.getAllFulfilledResourceUsage();
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllActiveContainers")
+    class GetAllActiveContainers {
+
+        @Test
+        @DisplayName("FULFILLED 상태 요청들의 컨테이너 정보를 반환한다")
+        void getAllActiveContainers_returnsList() {
+            when(requestRepository.findAllByStatus(Status.FULFILLED)).thenReturn(List.of());
+
+            List<ContainerInfoDTO> result = adminRequestQueryService.getAllActiveContainers();
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getChangeRequests")
+    class GetChangeRequests {
+
+        @Test
+        @DisplayName("PENDING 상태 변경 요청 목록을 반환한다")
+        void getChangeRequests_returnsPendingChangeRequests() {
+            when(changeRequestRepository.findAllByStatus(Status.PENDING)).thenReturn(List.of());
+
+            List<ChangeRequestResponseDTO> result = adminRequestQueryService.getChangeRequests();
+
+            assertThat(result).isEmpty();
+            verify(changeRequestRepository).findAllByStatus(Status.PENDING);
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllChangeRequests")
+    class GetAllChangeRequests {
+
+        @Test
+        @DisplayName("모든 변경 요청 목록을 반환한다")
+        void getAllChangeRequests_returnsList() {
+            when(changeRequestRepository.findAll()).thenReturn(List.of());
+
+            List<ChangeRequestResponseDTO> result = adminRequestQueryService.getAllChangeRequests();
+
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestCommandServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestCommandServiceTest.java
@@ -1,0 +1,140 @@
+package DGU_AI_LAB.admin_be.domain.requests.service;
+
+import DGU_AI_LAB.admin_be.domain.alarm.service.AlarmService;
+import DGU_AI_LAB.admin_be.domain.containerImage.entity.ContainerImage;
+import DGU_AI_LAB.admin_be.domain.containerImage.repository.ContainerImageRepository;
+import DGU_AI_LAB.admin_be.domain.groups.repository.GroupRepository;
+import DGU_AI_LAB.admin_be.domain.portRequests.service.PortRequestService;
+import DGU_AI_LAB.admin_be.domain.requests.dto.request.SaveRequestRequestDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.SaveRequestResponseDTO;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import DGU_AI_LAB.admin_be.domain.requests.repository.ChangeRequestRepository;
+import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.repository.ResourceGroupRepository;
+import DGU_AI_LAB.admin_be.domain.users.entity.User;
+import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RequestCommandServiceTest {
+
+    @InjectMocks
+    private RequestCommandService requestCommandService;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private RequestRepository requestRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ContainerImageRepository containerImageRepository;
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Mock
+    private ResourceGroupRepository resourceGroupRepository;
+
+    @Mock
+    private ChangeRequestRepository changeRequestRepository;
+
+    @Mock
+    private PortRequestService portRequestService;
+
+    @Mock
+    private AlarmService alarmService;
+
+    @Nested
+    @DisplayName("createRequest")
+    class CreateRequest {
+
+        @Test
+        @DisplayName("중복된 ubuntuUsername으로 요청을 생성하면 BusinessException을 던진다")
+        void createRequest_throwsException_whenDuplicateUsername() {
+            User user = User.builder()
+                    .email("test@dgu.ac.kr").password("pw").name("홍길동")
+                    .studentId("2021001234").phone("010-0000-0000").department("컴퓨터공학과")
+                    .build();
+            ResourceGroup rg = ResourceGroup.builder().resourceGroupName("GPU-A").serverName("server01").build();
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(resourceGroupRepository.findById(any())).thenReturn(Optional.of(rg));
+            when(requestRepository.existsByUbuntuUsername("existinguser")).thenReturn(true);
+
+            SaveRequestRequestDTO dto = mock(SaveRequestRequestDTO.class);
+            when(dto.resourceGroupId()).thenReturn(1);
+            when(dto.ubuntuUsername()).thenReturn("existinguser");
+
+            assertThatThrownBy(() -> requestCommandService.createRequest(1L, dto))
+                    .isInstanceOf(BusinessException.class);
+        }
+
+        @Test
+        @DisplayName("유저가 없으면 BusinessException을 던진다")
+        void createRequest_throwsException_whenUserNotFound() {
+            when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+            SaveRequestRequestDTO dto = mock(SaveRequestRequestDTO.class);
+
+            assertThatThrownBy(() -> requestCommandService.createRequest(99L, dto))
+                    .isInstanceOf(BusinessException.class);
+        }
+
+        @Test
+        @DisplayName("리소스 그룹이 없으면 BusinessException을 던진다")
+        void createRequest_throwsException_whenResourceGroupNotFound() {
+            User user = User.builder()
+                    .email("test@dgu.ac.kr").password("pw").name("홍길동")
+                    .studentId("2021001234").phone("010-0000-0000").department("컴퓨터공학과")
+                    .build();
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(resourceGroupRepository.findById(any())).thenReturn(Optional.empty());
+
+            SaveRequestRequestDTO dto = mock(SaveRequestRequestDTO.class);
+            when(dto.resourceGroupId()).thenReturn(1);
+
+            assertThatThrownBy(() -> requestCommandService.createRequest(1L, dto))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("createModificationRequest")
+    class CreateModificationRequest {
+
+        @Test
+        @DisplayName("존재하지 않는 requestId로 변경 요청하면 BusinessException을 던진다")
+        void createModificationRequest_throwsException_whenRequestNotFound() {
+            when(requestRepository.findById(99L)).thenReturn(Optional.empty());
+
+            var dto = mock(DGU_AI_LAB.admin_be.domain.requests.dto.request.ModifyRequestDTO.class);
+
+            assertThatThrownBy(() -> requestCommandService.createModificationRequest(1L, 99L, dto))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestQueryServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestQueryServiceTest.java
@@ -1,0 +1,167 @@
+package DGU_AI_LAB.admin_be.domain.requests.service;
+
+import DGU_AI_LAB.admin_be.domain.portRequests.service.PortRequestService;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.ContainerInfoDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.ResourceUsageDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.SaveRequestResponseDTO;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import DGU_AI_LAB.admin_be.domain.requests.repository.ChangeRequestRepository;
+import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RequestQueryServiceTest {
+
+    @InjectMocks
+    private RequestQueryService requestQueryService;
+
+    @Mock
+    private RequestRepository requestRepository;
+
+    @Mock
+    private ChangeRequestRepository changeRequestRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PortRequestService portRequestService;
+
+    @Nested
+    @DisplayName("getRequestsByUserId")
+    class GetRequestsByUserId {
+
+        @Test
+        @DisplayName("존재하는 userId로 조회하면 요청 목록을 반환한다")
+        void getRequestsByUserId_returnsList() {
+            when(userRepository.existsById(1L)).thenReturn(true);
+            when(requestRepository.findAllByUser_UserId(1L)).thenReturn(List.of());
+
+            List<SaveRequestResponseDTO> result = requestQueryService.getRequestsByUserId(1L);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 userId로 조회하면 BusinessException을 던진다")
+        void getRequestsByUserId_throwsException_whenUserNotFound() {
+            when(userRepository.existsById(99L)).thenReturn(false);
+
+            assertThatThrownBy(() -> requestQueryService.getRequestsByUserId(99L))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getApprovedRequestsByUserId")
+    class GetApprovedRequestsByUserId {
+
+        @Test
+        @DisplayName("존재하는 userId로 조회하면 FULFILLED 상태 요청만 반환한다")
+        void getApprovedRequestsByUserId_returnsFulfilledList() {
+            when(userRepository.existsById(1L)).thenReturn(true);
+            when(requestRepository.findAllByUser_UserIdAndStatus(1L, Status.FULFILLED)).thenReturn(List.of());
+
+            List<SaveRequestResponseDTO> result = requestQueryService.getApprovedRequestsByUserId(1L);
+
+            assertThat(result).isEmpty();
+            verify(requestRepository).findAllByUser_UserIdAndStatus(1L, Status.FULFILLED);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 userId로 조회하면 BusinessException을 던진다")
+        void getApprovedRequestsByUserId_throwsException_whenUserNotFound() {
+            when(userRepository.existsById(99L)).thenReturn(false);
+
+            assertThatThrownBy(() -> requestQueryService.getApprovedRequestsByUserId(99L))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllFulfilledResourceUsage")
+    class GetAllFulfilledResourceUsage {
+
+        @Test
+        @DisplayName("FULFILLED 상태 요청들의 리소스 사용량을 반환한다")
+        void getAllFulfilledResourceUsage_returnsList() {
+            when(requestRepository.findAllByStatus(Status.FULFILLED)).thenReturn(List.of());
+
+            List<ResourceUsageDTO> result = requestQueryService.getAllFulfilledResourceUsage();
+
+            assertThat(result).isEmpty();
+            verify(requestRepository).findAllByStatus(Status.FULFILLED);
+        }
+    }
+
+    @Nested
+    @DisplayName("getActiveContainers")
+    class GetActiveContainers {
+
+        @Test
+        @DisplayName("FULFILLED 상태 요청들의 컨테이너 정보를 반환한다")
+        void getActiveContainers_returnsList() {
+            when(requestRepository.findAllByStatus(Status.FULFILLED)).thenReturn(List.of());
+
+            List<ContainerInfoDTO> result = requestQueryService.getActiveContainers();
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllFulfilledUsernames")
+    class GetAllFulfilledUsernames {
+
+        @Test
+        @DisplayName("FULFILLED 상태 요청들의 ubuntu username 목록을 반환한다")
+        void getAllFulfilledUsernames_returnsList() {
+            when(requestRepository.findUbuntuUsernamesByStatus(Status.FULFILLED))
+                    .thenReturn(List.of("user1", "user2"));
+
+            List<String> result = requestQueryService.getAllFulfilledUsernames();
+
+            assertThat(result).containsExactlyInAnyOrder("user1", "user2");
+        }
+    }
+
+    @Nested
+    @DisplayName("getMyChangeRequests")
+    class GetMyChangeRequests {
+
+        @Test
+        @DisplayName("존재하는 userId로 내 변경 요청 목록을 조회한다")
+        void getMyChangeRequests_returnsList() {
+            when(userRepository.existsById(1L)).thenReturn(true);
+            when(changeRequestRepository.findAllByRequestedBy_UserId(1L)).thenReturn(List.of());
+
+            var result = requestQueryService.getMyChangeRequests(1L);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 userId로 조회하면 BusinessException을 던진다")
+        void getMyChangeRequests_throwsException_whenUserNotFound() {
+            when(userRepository.existsById(99L)).thenReturn(false);
+
+            assertThatThrownBy(() -> requestQueryService.getMyChangeRequests(99L))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/resourceGroups/service/ResourceGroupServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/resourceGroups/service/ResourceGroupServiceTest.java
@@ -1,0 +1,78 @@
+package DGU_AI_LAB.admin_be.domain.resourceGroups.service;
+
+import DGU_AI_LAB.admin_be.domain.gpus.repository.GpuRepository;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.dto.response.ResourceGroupResponseDTO;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.repository.ResourceGroupRepository;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ResourceGroupServiceTest {
+
+    @InjectMocks
+    private ResourceGroupService resourceGroupService;
+
+    @Mock
+    private GpuRepository gpuRepository;
+
+    @Mock
+    private ResourceGroupRepository resourceGroupRepository;
+
+    @Nested
+    @DisplayName("getAllResourceGroups")
+    class GetAllResourceGroups {
+
+        @Test
+        @DisplayName("리소스 그룹이 있으면 목록을 반환한다")
+        void getAllResourceGroups_returnsList() {
+            ResourceGroup rg = ResourceGroup.builder()
+                    .resourceGroupName("GPU-Server-A")
+                    .description("메인 GPU 서버")
+                    .serverName("server-01")
+                    .build();
+
+            when(resourceGroupRepository.findAll()).thenReturn(List.of(rg));
+
+            List<ResourceGroupResponseDTO> result = resourceGroupService.getAllResourceGroups();
+
+            assertThat(result).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("리소스 그룹이 없어도 빈 리스트를 반환한다")
+        void getAllResourceGroups_returnsEmptyList_whenNoGroups() {
+            when(resourceGroupRepository.findAll()).thenReturn(List.of());
+
+            List<ResourceGroupResponseDTO> result = resourceGroupService.getAllResourceGroups();
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getGpuTypeResources")
+    class GetGpuTypeResources {
+
+        @Test
+        @DisplayName("GPU 요약 정보가 없으면 BusinessException을 던진다")
+        void getGpuTypeResources_throwsException_whenEmpty() {
+            when(gpuRepository.findGpuSummary()).thenReturn(List.of());
+
+            assertThatThrownBy(() -> resourceGroupService.getGpuTypeResources())
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/controller/AdminUserControllerTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/controller/AdminUserControllerTest.java
@@ -1,0 +1,113 @@
+package DGU_AI_LAB.admin_be.domain.users.controller;
+
+import DGU_AI_LAB.admin_be.domain.users.dto.response.UserResponseDTO;
+import DGU_AI_LAB.admin_be.domain.users.dto.response.UserSummaryDTO;
+import DGU_AI_LAB.admin_be.domain.users.service.AdminUserService;
+import DGU_AI_LAB.admin_be.domain.users.service.UserService;
+import DGU_AI_LAB.admin_be.error.ErrorCode;
+import DGU_AI_LAB.admin_be.error.exception.EntityNotFoundException;
+import DGU_AI_LAB.admin_be.support.WebMvcTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        value = AdminUserController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class}
+)
+class AdminUserControllerTest extends WebMvcTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminUserService adminUserService;
+
+    @MockitoBean
+    private UserService userService;
+
+    @Nested
+    @DisplayName("GET /api/admin/users")
+    class GetAllUsers {
+
+        @Test
+        @DisplayName("전체 유저 목록을 조회하면 200 OK와 목록을 반환한다")
+        void getAllUsers_returns200WithList() throws Exception {
+            List<UserSummaryDTO> users = List.of(
+                    UserSummaryDTO.builder()
+                            .userId(1L).name("홍길동").email("test@dgu.ac.kr")
+                            .role("USER").studentId("2021001234").phone("010-1111-2222")
+                            .department("컴퓨터공학과").isActive(true)
+                            .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())
+                            .build()
+            );
+            when(adminUserService.getAllUsers()).thenReturn(users);
+
+            mockMvc.perform(get("/api/admin/users").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data[0].name").value("홍길동"));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/admin/users/{id}")
+    class GetUser {
+
+        @Test
+        @DisplayName("존재하는 id로 조회하면 200 OK와 유저 정보를 반환한다")
+        void getUser_returns200WithUser() throws Exception {
+            UserResponseDTO dto = new UserResponseDTO(1L, "홍길동", true);
+            when(userService.getUserById(1L)).thenReturn(dto);
+
+            mockMvc.perform(get("/api/admin/users/1").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.username").value("홍길동"));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 id로 조회하면 404 Not Found를 반환한다")
+        void getUser_returns404_whenNotFound() throws Exception {
+            when(userService.getUserById(99L)).thenThrow(new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+            mockMvc.perform(get("/api/admin/users/99").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/admin/users/{id}")
+    class DeleteUser {
+
+        @Test
+        @DisplayName("유저를 삭제하면 200 OK를 반환한다")
+        void deleteUser_returns200() throws Exception {
+            doNothing().when(adminUserService).deleteUser(1L);
+
+            mockMvc.perform(delete("/api/admin/users/1").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저를 삭제하면 404 Not Found를 반환한다")
+        void deleteUser_returns404_whenNotFound() throws Exception {
+            doThrow(new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND))
+                    .when(adminUserService).deleteUser(99L);
+
+            mockMvc.perform(delete("/api/admin/users/99").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound());
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/controller/AuthControllerTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/controller/AuthControllerTest.java
@@ -1,0 +1,125 @@
+package DGU_AI_LAB.admin_be.domain.users.controller;
+
+import DGU_AI_LAB.admin_be.domain.users.dto.request.UserLoginRequestDTO;
+import DGU_AI_LAB.admin_be.domain.users.dto.request.UserRegisterRequestDTO;
+import DGU_AI_LAB.admin_be.domain.users.dto.response.UserTokenResponseDTO;
+import DGU_AI_LAB.admin_be.domain.users.service.UserLoginService;
+import DGU_AI_LAB.admin_be.domain.users.service.UserService;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import DGU_AI_LAB.admin_be.error.ErrorCode;
+import DGU_AI_LAB.admin_be.support.WebMvcTestSupport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        value = AuthController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class}
+)
+class AuthControllerTest extends WebMvcTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private UserLoginService userLoginService;
+
+    @MockitoBean
+    private UserService userService;
+
+    @Nested
+    @DisplayName("POST /api/auth/register")
+    class Register {
+
+        @Test
+        @DisplayName("유효한 요청으로 회원가입하면 200 OK를 반환한다")
+        void register_returns200_whenSuccess() throws Exception {
+            doNothing().when(userLoginService).register(any());
+
+            UserRegisterRequestDTO dto = new UserRegisterRequestDTO(
+                    "test@dgu.ac.kr", "password123", "홍길동", "컴퓨터공학과", "2021001234", "010-1234-5678"
+            );
+
+            mockMvc.perform(post("/api/auth/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(dto)))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("이메일 형식이 잘못되면 400 Bad Request를 반환한다")
+        void register_returns400_whenEmailInvalid() throws Exception {
+            UserRegisterRequestDTO dto = new UserRegisterRequestDTO(
+                    "invalid-email", "password123", "홍길동", "컴퓨터공학과", "2021001234", "010-1234-5678"
+            );
+
+            mockMvc.perform(post("/api/auth/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(dto)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("이미 가입된 이메일이면 409 Conflict를 반환한다")
+        void register_returns409_whenEmailAlreadyExists() throws Exception {
+            doThrow(new BusinessException(ErrorCode.USER_ALREADY_EXISTS))
+                    .when(userLoginService).register(any());
+
+            UserRegisterRequestDTO dto = new UserRegisterRequestDTO(
+                    "test@dgu.ac.kr", "password123", "홍길동", "컴퓨터공학과", "2021001234", "010-1234-5678"
+            );
+
+            mockMvc.perform(post("/api/auth/register")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(dto)))
+                    .andExpect(status().isConflict());
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/auth/login")
+    class Login {
+
+        @Test
+        @DisplayName("유효한 자격증명으로 로그인하면 200 OK와 토큰을 반환한다")
+        void login_returns200WithTokens_whenSuccess() throws Exception {
+            UserTokenResponseDTO tokenDto = new UserTokenResponseDTO("accessToken", "refreshToken");
+            when(userLoginService.login(any())).thenReturn(tokenDto);
+
+            UserLoginRequestDTO dto = new UserLoginRequestDTO("test@dgu.ac.kr", "password123");
+
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(dto)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.accessToken").value("accessToken"))
+                    .andExpect(jsonPath("$.refreshToken").value("refreshToken"));
+        }
+
+        @Test
+        @DisplayName("이메일이 없으면 400 Bad Request를 반환한다")
+        void login_returns400_whenEmailBlank() throws Exception {
+            UserLoginRequestDTO dto = new UserLoginRequestDTO("", "password123");
+
+            mockMvc.perform(post("/api/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(dto)))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/entity/UserTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/entity/UserTest.java
@@ -1,0 +1,133 @@
+package DGU_AI_LAB.admin_be.domain.users.entity;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserTest {
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .email("test@dgu.ac.kr")
+                .password("encodedPassword")
+                .name("홍길동")
+                .studentId("2021001234")
+                .phone("010-1234-5678")
+                .department("컴퓨터공학과")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("Builder 기본값")
+    class DefaultValues {
+
+        @Test
+        @DisplayName("기본 역할은 USER이다")
+        void defaultRole_isUser() {
+            assertThat(user.getRole()).isEqualTo(Role.USER);
+        }
+
+        @Test
+        @DisplayName("기본 활성화 상태는 true이다")
+        void defaultIsActive_isTrue() {
+            assertThat(user.getIsActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("생성 시 lastLoginAt이 설정된다")
+        void lastLoginAt_isSetOnCreation() {
+            assertThat(user.getLastLoginAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("updatePassword")
+    class UpdatePassword {
+
+        @Test
+        @DisplayName("새 비밀번호로 업데이트한다")
+        void updatePassword_changesPassword() {
+            user.updatePassword("newEncodedPassword");
+
+            assertThat(user.getPassword()).isEqualTo("newEncodedPassword");
+        }
+    }
+
+    @Nested
+    @DisplayName("updatePhone")
+    class UpdatePhone {
+
+        @Test
+        @DisplayName("새 전화번호로 업데이트한다")
+        void updatePhone_changesPhone() {
+            user.updatePhone("010-9999-8888");
+
+            assertThat(user.getPhone()).isEqualTo("010-9999-8888");
+        }
+    }
+
+    @Nested
+    @DisplayName("updateUserInfo")
+    class UpdateUserInfo {
+
+        @Test
+        @DisplayName("encodedPassword가 null이 아니면 비밀번호를 업데이트한다")
+        void updateUserInfo_updatesPassword_whenNotNull() {
+            user.updateUserInfo("newPw", null);
+
+            assertThat(user.getPassword()).isEqualTo("newPw");
+        }
+
+        @Test
+        @DisplayName("isActive가 false이면 비활성화한다")
+        void updateUserInfo_deactivates_whenIsActiveFalse() {
+            user.updateUserInfo(null, false);
+
+            assertThat(user.getIsActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("null 값은 기존 값을 유지한다")
+        void updateUserInfo_doesNotChange_whenNull() {
+            user.updateUserInfo(null, null);
+
+            assertThat(user.getPassword()).isEqualTo("encodedPassword");
+            assertThat(user.getIsActive()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("recordLogin")
+    class RecordLogin {
+
+        @Test
+        @DisplayName("로그인 기록 시 lastLoginAt이 갱신된다")
+        void recordLogin_updatesLastLoginAt() throws InterruptedException {
+            var before = user.getLastLoginAt();
+            Thread.sleep(10); // ensure time difference
+            user.recordLogin();
+
+            assertThat(user.getLastLoginAt()).isAfterOrEqualTo(before);
+        }
+    }
+
+    @Nested
+    @DisplayName("withdraw")
+    class Withdraw {
+
+        @Test
+        @DisplayName("탈퇴하면 isActive가 false가 되고 deletedAt이 설정된다")
+        void withdraw_setsInactiveAndDeletedAt() {
+            user.withdraw();
+
+            assertThat(user.getIsActive()).isFalse();
+            assertThat(user.getDeletedAt()).isNotNull();
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/repository/UserRepositoryTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/repository/UserRepositoryTest.java
@@ -1,0 +1,123 @@
+package DGU_AI_LAB.admin_be.domain.users.repository;
+
+import DGU_AI_LAB.admin_be.domain.users.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user1;
+    private User user2;
+
+    @BeforeEach
+    void setUp() {
+        user1 = userRepository.save(User.builder()
+                .email("active@dgu.ac.kr")
+                .password("encoded1")
+                .name("홍길동")
+                .studentId("2021001234")
+                .phone("010-1111-2222")
+                .department("컴퓨터공학과")
+                .build());
+
+        user2 = userRepository.save(User.builder()
+                .email("user2@dgu.ac.kr")
+                .password("encoded2")
+                .name("이순신")
+                .studentId("2021005678")
+                .phone("010-5678-1234")
+                .department("전자공학과")
+                .build());
+    }
+
+    @Nested
+    @DisplayName("findByEmail")
+    class FindByEmail {
+
+        @Test
+        @DisplayName("존재하는 이메일로 조회하면 유저를 반환한다")
+        void findByEmail_returnsUser_whenExists() {
+            Optional<User> result = userRepository.findByEmail("active@dgu.ac.kr");
+
+            assertThat(result).isPresent();
+            assertThat(result.get().getName()).isEqualTo("홍길동");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 이메일로 조회하면 빈 Optional을 반환한다")
+        void findByEmail_returnsEmpty_whenNotExists() {
+            Optional<User> result = userRepository.findByEmail("notexist@dgu.ac.kr");
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findInactiveUsers")
+    class FindInactiveUsers {
+
+        @Test
+        @DisplayName("마지막 로그인이 기준일 이전인 활성 유저를 조회한다")
+        void findInactiveUsers_returnsUsersInactiveBeforeThreshold() {
+            // 3개월+1일 전에 마지막 로그인한 유저 설정 (reflection 사용)
+            LocalDateTime thresholdDate = LocalDateTime.now().minusMonths(3);
+
+            List<User> result = userRepository.findInactiveUsers(thresholdDate);
+            // 새로 가입한 유저들은 현재 시간으로 lastLoginAt이 설정되어 있어 비활성 대상 아님
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findUsersForHardDelete")
+    class FindUsersForHardDelete {
+
+        @Test
+        @DisplayName("Soft delete된 지 1년이 지난 유저를 조회한다")
+        void findUsersForHardDelete_returnsUsersForHardDelete() {
+            // Soft delete 처리
+            user1.withdraw();
+            userRepository.save(user1);
+            userRepository.flush();
+
+            // 1년 후 기준으로 조회 - 아직 1년이 안 됐으므로 조회 안 됨
+            List<User> result = userRepository.findUsersForHardDelete(
+                    LocalDateTime.now().minusDays(1)  // deletedAt < 어제 = 아직 조회 안 됨
+            );
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Soft delete 날짜가 기준일 이전인 유저는 Hard delete 대상이다")
+        void findUsersForHardDelete_returnsUser_whenDeletedBeforeThreshold() {
+            user1.withdraw();
+            userRepository.save(user1);
+            userRepository.flush();
+
+            // 기준일을 내일로 설정 -> deletedAt < 내일 = 조회됨
+            List<User> result = userRepository.findUsersForHardDelete(
+                    LocalDateTime.now().plusDays(1)
+            );
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getEmail()).isEqualTo("active@dgu.ac.kr");
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserServiceTest.java
@@ -1,0 +1,145 @@
+package DGU_AI_LAB.admin_be.domain.users.service;
+
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import DGU_AI_LAB.admin_be.domain.users.dto.request.UserUpdateRequestDTO;
+import DGU_AI_LAB.admin_be.domain.users.dto.response.UserResponseDTO;
+import DGU_AI_LAB.admin_be.domain.users.dto.response.UserSummaryDTO;
+import DGU_AI_LAB.admin_be.domain.users.entity.User;
+import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
+import DGU_AI_LAB.admin_be.error.exception.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminUserServiceTest {
+
+    @InjectMocks
+    private AdminUserService adminUserService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RequestRepository requestRepository;
+
+    @Mock
+    private WebClient userWebClient;
+
+    private User mockUser;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = User.builder()
+                .email("test@dgu.ac.kr")
+                .password("encodedPassword")
+                .name("홍길동")
+                .studentId("2021001234")
+                .phone("010-1234-5678")
+                .department("컴퓨터공학과")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("getAllUsers")
+    class GetAllUsers {
+
+        @Test
+        @DisplayName("유저 목록이 있으면 UserSummaryDTO 리스트를 반환한다")
+        void getAllUsers_returnsUserList() {
+            User user2 = User.builder()
+                    .email("user2@dgu.ac.kr")
+                    .password("pw")
+                    .name("이순신")
+                    .studentId("2021005678")
+                    .phone("010-5678-1234")
+                    .department("전자공학과")
+                    .build();
+
+            when(userRepository.findAll()).thenReturn(List.of(mockUser, user2));
+
+            List<UserSummaryDTO> result = adminUserService.getAllUsers();
+
+            assertThat(result).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("유저가 없으면 빈 리스트를 반환한다")
+        void getAllUsers_returnsEmptyList_whenNoUsers() {
+            when(userRepository.findAll()).thenReturn(List.of());
+
+            List<UserSummaryDTO> result = adminUserService.getAllUsers();
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateUser")
+    class UpdateUser {
+
+        @Test
+        @DisplayName("유저가 존재하면 정보를 수정하고 UserResponseDTO를 반환한다")
+        void updateUser_success() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+
+            UserUpdateRequestDTO request = new UserUpdateRequestDTO("홍길동", "newPw", false);
+            UserResponseDTO result = adminUserService.updateUser(1L, request);
+
+            assertThat(result).isNotNull();
+        }
+
+        @Test
+        @DisplayName("유저가 없으면 EntityNotFoundException을 던진다")
+        void updateUser_throwsException_whenUserNotFound() {
+            when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+            UserUpdateRequestDTO request = new UserUpdateRequestDTO("홍길동", "newPw", false);
+
+            assertThatThrownBy(() -> adminUserService.updateUser(99L, request))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteUser")
+    class DeleteUser {
+
+        @Test
+        @DisplayName("연결된 Request가 없는 유저를 삭제하면 isActive를 false로 변경한다")
+        void deleteUser_withNoRequests_softDeletes() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+            when(requestRepository.findAllByUser(mockUser)).thenReturn(List.of());
+
+            adminUserService.deleteUser(1L);
+
+            assertThat(mockUser.getIsActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저를 삭제하려 하면 EntityNotFoundException을 던진다")
+        void deleteUser_throwsException_whenUserNotFound() {
+            when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> adminUserService.deleteUser(99L))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/TokenServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/TokenServiceTest.java
@@ -1,0 +1,127 @@
+package DGU_AI_LAB.admin_be.domain.users.service;
+
+import DGU_AI_LAB.admin_be.domain.users.dto.request.UserTokenRequestDTO;
+import DGU_AI_LAB.admin_be.domain.users.dto.response.UserTokenResponseDTO;
+import DGU_AI_LAB.admin_be.error.exception.UnauthorizedException;
+import DGU_AI_LAB.admin_be.global.auth.jwt.JwtProvider;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TokenServiceTest {
+
+    @InjectMocks
+    private TokenService tokenService;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Nested
+    @DisplayName("issueToken")
+    class IssueToken {
+
+        @Test
+        @DisplayName("Redis에 리프레시 토큰이 없으면 새로 발급하고 저장한다")
+        void issueToken_createsNewRefreshToken_whenNotInRedis() {
+            ReflectionTestUtils.setField(tokenService, "REFRESH_TOKEN_EXPIRE_TIME", 604800L);
+            when(jwtProvider.getIssueToken(1L, true)).thenReturn("newAccessToken");
+            when(jwtProvider.getIssueToken(1L, false)).thenReturn("newRefreshToken");
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get("RT:1")).thenReturn(null);
+
+            UserTokenResponseDTO result = tokenService.issueToken(1L);
+
+            assertThat(result.accessToken()).isEqualTo("newAccessToken");
+            assertThat(result.refreshToken()).isEqualTo("newRefreshToken");
+            verify(valueOperations).set(eq("RT:1"), eq("newRefreshToken"), anyLong(), any());
+        }
+
+        @Test
+        @DisplayName("Redis에 기존 리프레시 토큰이 있으면 재사용한다")
+        void issueToken_reusesExistingRefreshToken_whenInRedis() {
+            when(jwtProvider.getIssueToken(1L, true)).thenReturn("newAccessToken");
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get("RT:1")).thenReturn("existingRefreshToken");
+
+            UserTokenResponseDTO result = tokenService.issueToken(1L);
+
+            assertThat(result.accessToken()).isEqualTo("newAccessToken");
+            assertThat(result.refreshToken()).isEqualTo("existingRefreshToken");
+            verify(jwtProvider, never()).getIssueToken(1L, false);
+        }
+    }
+
+    @Nested
+    @DisplayName("issueTempToken")
+    class IssueTempToken {
+
+        @Test
+        @DisplayName("임시 토큰을 발급하면 액세스/리프레시 토큰을 모두 새로 발급한다")
+        void issueTempToken_issuesBothTokens() {
+            when(jwtProvider.getIssueToken(1L, true)).thenReturn("tempAccess");
+            when(jwtProvider.getIssueToken(1L, false)).thenReturn("tempRefresh");
+
+            UserTokenResponseDTO result = tokenService.issueTempToken(1L);
+
+            assertThat(result.accessToken()).isEqualTo("tempAccess");
+            assertThat(result.refreshToken()).isEqualTo("tempRefresh");
+        }
+    }
+
+    @Nested
+    @DisplayName("reissue")
+    class Reissue {
+
+        @Test
+        @DisplayName("유효한 리프레시 토큰으로 재발급하면 새 토큰을 반환한다")
+        void reissue_success() throws JsonProcessingException {
+            ReflectionTestUtils.setField(tokenService, "REFRESH_TOKEN_EXPIRE_TIME", 604800L);
+            when(jwtProvider.decodeJwtPayloadSubject("accessToken")).thenReturn("1");
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get("RT:1")).thenReturn("storedRefreshToken");
+            doNothing().when(jwtProvider).validateRefreshToken("refreshToken");
+            doNothing().when(jwtProvider).equalsRefreshToken("refreshToken", "storedRefreshToken");
+            when(jwtProvider.getIssueToken(1L, true)).thenReturn("newAccessToken");
+            when(jwtProvider.getIssueToken(1L, false)).thenReturn("newRefreshToken");
+
+            UserTokenRequestDTO dto = new UserTokenRequestDTO("accessToken", "refreshToken");
+            UserTokenResponseDTO result = tokenService.reissue(dto);
+
+            assertThat(result.accessToken()).isEqualTo("newAccessToken");
+            assertThat(result.refreshToken()).isEqualTo("newRefreshToken");
+        }
+    }
+
+    @Nested
+    @DisplayName("logout")
+    class Logout {
+
+        @Test
+        @DisplayName("로그아웃하면 Redis에서 리프레시 토큰을 삭제한다")
+        void logout_deletesRefreshTokenFromRedis() {
+            tokenService.logout(1L);
+
+            verify(redisTemplate, times(1)).delete("RT:1");
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/UserLoginServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/UserLoginServiceTest.java
@@ -1,0 +1,183 @@
+package DGU_AI_LAB.admin_be.domain.users.service;
+
+import DGU_AI_LAB.admin_be.domain.groups.repository.GroupRepository;
+import DGU_AI_LAB.admin_be.domain.users.dto.request.UserLoginRequestDTO;
+import DGU_AI_LAB.admin_be.domain.users.dto.request.UserRegisterRequestDTO;
+import DGU_AI_LAB.admin_be.domain.users.dto.response.UserTokenResponseDTO;
+import DGU_AI_LAB.admin_be.domain.users.entity.User;
+import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import DGU_AI_LAB.admin_be.error.exception.UnauthorizedException;
+import DGU_AI_LAB.admin_be.global.auth.jwt.JwtProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserLoginServiceTest {
+
+    @InjectMocks
+    private UserLoginService userLoginService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private User activeUser;
+
+    @BeforeEach
+    void setUp() {
+        activeUser = User.builder()
+                .email("test@dgu.ac.kr")
+                .password("encodedPassword")
+                .name("홍길동")
+                .studentId("2021001234")
+                .phone("010-1234-5678")
+                .department("컴퓨터공학과")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("register (회원가입)")
+    class Register {
+
+        @Test
+        @DisplayName("이메일 인증이 완료되고 중복이 없으면 회원가입에 성공한다")
+        void register_success() {
+            when(redisTemplate.hasKey("VERIFIED:test@dgu.ac.kr")).thenReturn(true);
+            when(userRepository.findByEmail("test@dgu.ac.kr")).thenReturn(Optional.empty());
+            when(passwordEncoder.encode(anyString())).thenReturn("encodedPw");
+
+            UserRegisterRequestDTO dto = new UserRegisterRequestDTO(
+                    "test@dgu.ac.kr", "password123", "홍길동", "컴퓨터공학과", "2021001234", "010-1234-5678"
+            );
+
+            userLoginService.register(dto);
+
+            verify(userRepository, times(1)).save(any(User.class));
+            verify(redisTemplate, times(1)).delete("VERIFIED:test@dgu.ac.kr");
+        }
+
+        @Test
+        @DisplayName("이메일 인증이 안 된 경우 UnauthorizedException을 던진다")
+        void register_throwsException_whenEmailNotVerified() {
+            when(redisTemplate.hasKey("VERIFIED:test@dgu.ac.kr")).thenReturn(false);
+
+            UserRegisterRequestDTO dto = new UserRegisterRequestDTO(
+                    "test@dgu.ac.kr", "password123", "홍길동", "컴퓨터공학과", "2021001234", "010-1234-5678"
+            );
+
+            assertThatThrownBy(() -> userLoginService.register(dto))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("이미 가입된 이메일로 회원가입하면 BusinessException을 던진다")
+        void register_throwsException_whenEmailAlreadyExists() {
+            when(redisTemplate.hasKey("VERIFIED:test@dgu.ac.kr")).thenReturn(true);
+            when(userRepository.findByEmail("test@dgu.ac.kr")).thenReturn(Optional.of(activeUser));
+
+            UserRegisterRequestDTO dto = new UserRegisterRequestDTO(
+                    "test@dgu.ac.kr", "password123", "홍길동", "컴퓨터공학과", "2021001234", "010-1234-5678"
+            );
+
+            assertThatThrownBy(() -> userLoginService.register(dto))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("login (로그인)")
+    class Login {
+
+        @Test
+        @DisplayName("올바른 이메일과 비밀번호로 로그인하면 토큰을 반환한다")
+        void login_success() {
+            when(userRepository.findByEmail("test@dgu.ac.kr")).thenReturn(Optional.of(activeUser));
+            when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(true);
+            when(jwtProvider.getIssueToken(any(), eq(true))).thenReturn("accessToken");
+            when(jwtProvider.getIssueToken(any(), eq(false))).thenReturn("refreshToken");
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+            UserLoginRequestDTO dto = new UserLoginRequestDTO("test@dgu.ac.kr", "password123");
+            UserTokenResponseDTO result = userLoginService.login(dto);
+
+            assertThat(result).isNotNull();
+            assertThat(result.accessToken()).isEqualTo("accessToken");
+            assertThat(result.refreshToken()).isEqualTo("refreshToken");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 이메일로 로그인하면 UnauthorizedException을 던진다")
+        void login_throwsException_whenEmailNotFound() {
+            when(userRepository.findByEmail("notexist@dgu.ac.kr")).thenReturn(Optional.empty());
+
+            UserLoginRequestDTO dto = new UserLoginRequestDTO("notexist@dgu.ac.kr", "password");
+
+            assertThatThrownBy(() -> userLoginService.login(dto))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("비활성화된 계정으로 로그인하면 UnauthorizedException을 던진다")
+        void login_throwsException_whenAccountDisabled() {
+            User inactiveUser = User.builder()
+                    .email("inactive@dgu.ac.kr")
+                    .password("encodedPassword")
+                    .name("비활성유저")
+                    .studentId("2021000001")
+                    .phone("010-0000-0000")
+                    .department("컴퓨터공학과")
+                    .build();
+            inactiveUser.withdraw(); // isActive = false
+
+            when(userRepository.findByEmail("inactive@dgu.ac.kr")).thenReturn(Optional.of(inactiveUser));
+
+            UserLoginRequestDTO dto = new UserLoginRequestDTO("inactive@dgu.ac.kr", "password");
+
+            assertThatThrownBy(() -> userLoginService.login(dto))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("비밀번호가 틀리면 UnauthorizedException을 던진다")
+        void login_throwsException_whenPasswordWrong() {
+            when(userRepository.findByEmail("test@dgu.ac.kr")).thenReturn(Optional.of(activeUser));
+            when(passwordEncoder.matches("wrongPw", "encodedPassword")).thenReturn(false);
+
+            UserLoginRequestDTO dto = new UserLoginRequestDTO("test@dgu.ac.kr", "wrongPw");
+
+            assertThatThrownBy(() -> userLoginService.login(dto))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/UserServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/UserServiceTest.java
@@ -1,0 +1,224 @@
+package DGU_AI_LAB.admin_be.domain.users.service;
+
+import DGU_AI_LAB.admin_be.domain.groups.repository.GroupRepository;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
+import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+
+import DGU_AI_LAB.admin_be.domain.users.dto.request.PasswordUpdateRequestDTO;
+import DGU_AI_LAB.admin_be.domain.users.dto.request.PhoneUpdateRequestDTO;
+import DGU_AI_LAB.admin_be.domain.users.dto.request.UserAuthRequestDTO;
+import DGU_AI_LAB.admin_be.domain.users.dto.response.MyInfoResponseDTO;
+import DGU_AI_LAB.admin_be.domain.users.dto.response.UserAuthResponseDTO;
+import DGU_AI_LAB.admin_be.domain.users.dto.response.UserResponseDTO;
+import DGU_AI_LAB.admin_be.domain.users.entity.User;
+import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import DGU_AI_LAB.admin_be.error.exception.EntityNotFoundException;
+import DGU_AI_LAB.admin_be.error.exception.UnauthorizedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Mock
+    private RequestRepository requestRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private User mockUser;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = User.builder()
+                .email("test@dgu.ac.kr")
+                .password("encodedPassword")
+                .name("홍길동")
+                .studentId("2021001234")
+                .phone("010-1234-5678")
+                .department("컴퓨터공학과")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("getMyInfo")
+    class GetMyInfo {
+
+        @Test
+        @DisplayName("존재하는 userId로 내 정보를 조회하면 MyInfoResponseDTO를 반환한다")
+        void getMyInfo_returnsDTO_whenUserExists() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+
+            MyInfoResponseDTO result = userService.getMyInfo(1L);
+
+            assertThat(result).isNotNull();
+            assertThat(result.email()).isEqualTo("test@dgu.ac.kr");
+            assertThat(result.name()).isEqualTo("홍길동");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 userId로 조회하면 EntityNotFoundException을 던진다")
+        void getMyInfo_throwsException_whenUserNotFound() {
+            when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> userService.getMyInfo(99L))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getUserById")
+    class GetUserById {
+
+        @Test
+        @DisplayName("존재하는 userId로 단일 유저를 조회하면 UserResponseDTO를 반환한다")
+        void getUserById_returnsDTO_whenUserExists() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+
+            UserResponseDTO result = userService.getUserById(1L);
+
+            assertThat(result).isNotNull();
+            assertThat(result.username()).isEqualTo("홍길동");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 userId로 조회하면 EntityNotFoundException을 던진다")
+        void getUserById_throwsException_whenUserNotFound() {
+            when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> userService.getUserById(99L))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("updatePassword")
+    class UpdatePassword {
+
+        @Test
+        @DisplayName("현재 비밀번호가 일치하고 새 비밀번호가 다르면 비밀번호 변경에 성공한다")
+        void updatePassword_success() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+            when(passwordEncoder.matches("currentPw", "encodedPassword")).thenReturn(true);
+            when(passwordEncoder.matches("newPw", "encodedPassword")).thenReturn(false);
+            when(passwordEncoder.encode("newPw")).thenReturn("newEncodedPw");
+
+            PasswordUpdateRequestDTO request = new PasswordUpdateRequestDTO("currentPw", "newPw");
+            UserResponseDTO result = userService.updatePassword(1L, request);
+
+            assertThat(result).isNotNull();
+        }
+
+        @Test
+        @DisplayName("현재 비밀번호가 틀리면 BusinessException을 던진다")
+        void updatePassword_throwsException_whenCurrentPasswordWrong() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+            when(passwordEncoder.matches("wrongPw", "encodedPassword")).thenReturn(false);
+
+            PasswordUpdateRequestDTO request = new PasswordUpdateRequestDTO("wrongPw", "newPw");
+
+            assertThatThrownBy(() -> userService.updatePassword(1L, request))
+                    .isInstanceOf(BusinessException.class);
+        }
+
+        @Test
+        @DisplayName("새 비밀번호가 현재 비밀번호와 같으면 BusinessException을 던진다")
+        void updatePassword_throwsException_whenNewPasswordSameAsCurrent() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+            when(passwordEncoder.matches(anyString(), eq("encodedPassword"))).thenReturn(true);
+
+            PasswordUpdateRequestDTO request = new PasswordUpdateRequestDTO("currentPw", "currentPw");
+
+            assertThatThrownBy(() -> userService.updatePassword(1L, request))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("updatePhone")
+    class UpdatePhone {
+
+        @Test
+        @DisplayName("유저가 존재하면 연락처 변경에 성공한다")
+        void updatePhone_success() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+
+            PhoneUpdateRequestDTO request = new PhoneUpdateRequestDTO("010-9999-8888");
+            UserResponseDTO result = userService.updatePhone(1L, request);
+
+            assertThat(result).isNotNull();
+        }
+
+        @Test
+        @DisplayName("유저가 없으면 EntityNotFoundException을 던진다")
+        void updatePhone_throwsException_whenUserNotFound() {
+            when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+            PhoneUpdateRequestDTO request = new PhoneUpdateRequestDTO("010-9999-8888");
+
+            assertThatThrownBy(() -> userService.updatePhone(99L, request))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("userAuth (SSH 로그인)")
+    class UserAuth {
+
+        @Test
+        @DisplayName("올바른 username과 password로 인증하면 성공 응답을 반환한다")
+        void userAuth_success() {
+            String passwordBase64 = "dGVzdA==";
+            // PasswordUtil.encodePassword는 SHA-512 해싱을 적용
+            String encodedPassword = DGU_AI_LAB.admin_be.global.util.PasswordUtil.encodePassword(passwordBase64);
+
+            Request request = mock(Request.class);
+            when(request.getUbuntuUsername()).thenReturn("testuser");
+            when(request.getUbuntuPassword()).thenReturn(encodedPassword);
+            when(requestRepository.findByUbuntuUsernameAndUbuntuPassword("testuser", encodedPassword))
+                    .thenReturn(Optional.of(request));
+
+            UserAuthRequestDTO dto = new UserAuthRequestDTO("testuser", passwordBase64);
+            UserAuthResponseDTO result = userService.userAuth(dto);
+
+            assertThat(result.success()).isTrue();
+            assertThat(result.authenticatedUsername()).isEqualTo("testuser");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 username으로 인증하면 UnauthorizedException을 던진다")
+        void userAuth_throwsException_whenUsernameNotFound() {
+            when(requestRepository.findByUbuntuUsernameAndUbuntuPassword(anyString(), anyString()))
+                    .thenReturn(Optional.empty());
+
+            UserAuthRequestDTO dto = new UserAuthRequestDTO("unknownuser", "dGVzdA==");
+
+            assertThatThrownBy(() -> userService.userAuth(dto))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/support/WebMvcTestSupport.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/support/WebMvcTestSupport.java
@@ -1,0 +1,27 @@
+package DGU_AI_LAB.admin_be.support;
+
+import DGU_AI_LAB.admin_be.global.auth.CustomUserDetailsService;
+import DGU_AI_LAB.admin_be.global.auth.jwt.JwtProvider;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+/**
+ * @WebMvcTest에서 Spring Security 및 JPA 관련 빈 충돌 방지를 위한 공통 Mock 설정.
+ * - SecurityConfig → JwtProvider, CustomUserDetailsService, RedisTemplate 필요
+ * - spring-data-jpa 클래스패스 존재 시 JpaMetamodelMappingContext 필요
+ */
+public abstract class WebMvcTestSupport {
+
+    @MockitoBean
+    protected JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockitoBean
+    protected JwtProvider jwtProvider;
+
+    @MockitoBean
+    protected CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    protected RedisTemplate<String, String> redisTemplate;
+}


### PR DESCRIPTION
## 관련 이슈
- close : #196 

## 작업 사항
- 주요 도메인(users, requests, groups 등등)에 대한 단위 테스트 추가
- `@WebMvcTest` 공통 목 설정용 `WebMvcTestSupport` 도입
- Gradle에 JaCoCo 설정(리포트 생성과 커버리지 검증) 및 테스트 실행에 필요한 의존성(H2 등) 반영 완료
- 테스트 실행 방법·`@WebMvcTest` 트러블슈팅 요약을 `docs/TESTS.md`에 정리

## 참고 사항
- `./gradlew test` 실행 시 JaCoCo 리포트가 이어서 생성되도록 연결되어 있습니다. HTML 리포트는 `./gradlew jacocoTestReport` 후 `build/reports/jacoco/test/html`에서 확인할 수 있습니다.
- 슬라이스 테스트에서 컨텍스트 로드 실패가 나면 `docs/TESTS.md`의 WebMvcTest 절을 참고하면 됩니다.

<img width="1165" height="731" alt="스크린샷 2026-03-29 오후 3 22 15" src="https://github.com/user-attachments/assets/12a4050a-28a2-4487-8177-d98c12458703" />
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Tests**
  * 사용자, 요청, 리소스 그룹, 컨테이너 이미지, 대시보드 등 전 도메인에 걸친 포괄적인 단위 및 통합 테스트 추가
  * 테스트 실행 및 커버리지 리포팅을 위한 지원 인프라 구성

* **Chores**
  * 코드 품질 측정을 위한 JaCoCo 코드 커버리지 도구 통합
  * 테스트 설명서 작성 및 시스템 파일 관리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->