### PR TITLE
[refactor] #198 deploy.yml 하드코딩된 toni 경로 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,17 +38,17 @@ jobs:
         with:
           host: ${{ secrets.K8S_HOST }}
           port: 8088
-          username: toni
+          username: ${{ secrets.K8S_USERNAME }}
           key: ${{ secrets.K8S_PRIVATE_KEY }}
           script: |
             set -e # 실패 시 즉시 중단
-            export KUBECONFIG=/home/toni/.kube/config
+            export KUBECONFIG=/etc/kubernetes/admin.conf
 
             echo "✅ 쿠버네티스 연결 테스트"
             kubectl get nodes
 
             echo "📦 Helm 차트 배포 (절대 경로 사용)"
-            helm upgrade --install admin-prod /home/toni/admin_be/helm/admin-prod \
+            helm upgrade --install admin-prod /opt/admin_be/helm/admin-prod \
               --namespace default \
               --create-namespace \
               --set image.repository=${{ secrets.DOCKER_USERNAME }}/admin-prod \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
           key: ${{ secrets.K8S_PRIVATE_KEY }}
           script: |
             set -e # 실패 시 즉시 중단
-            export KUBECONFIG=/etc/kubernetes/admin.conf
+            export KUBECONFIG=/etc/kubernetes/ci-deployer.conf
 
             echo "✅ 쿠버네티스 연결 테스트"
             kubectl get nodes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
           docker logout
 
       - name: 🚀 Helm을 통한 쿠버네티스 배포
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.K8S_HOST }}
           port: 8088


### PR DESCRIPTION
## Summary
- SSH `username`을 `toni` 하드코딩에서 `secrets.K8S_USERNAME`으로 변경
- kubeconfig 경로를 `/home/toni/.kube/config` → `/etc/kubernetes/ci-deployer.conf` (배포 전용 kubeconfig)로 변경
- Helm 차트 경로를 `/home/toni/admin_be/helm` → `/opt/admin_be/helm`로 변경
- `appleboy/ssh-action`을 `@master` → `@v1.2.5`로 핀닝 (공급망 보안)

### 서버 프로비저닝 사항
- `/etc/kubernetes/ci-deployer.conf`: `admin.conf`를 복사하여 생성 (`sudo cp /etc/kubernetes/admin.conf /etc/kubernetes/ci-deployer.conf`)
- SSH 사용자(K8S_USERNAME)가 해당 파일을 읽을 수 있도록 권한 설정 (`sudo chmod 644 /etc/kubernetes/ci-deployer.conf`)
- `/opt/admin_be/helm/admin-prod`: 기존 Helm 차트를 공용 경로로 복사

## Test plan
- [x] GitHub Secrets에 `K8S_USERNAME` 등록
- [ ] 서버에 `/etc/kubernetes/ci-deployer.conf` 생성 및 읽기 권한 확인
- [ ] 서버에 `/opt/admin_be/helm/admin-prod` 디렉토리 생성 및 Helm 차트 복사
- [ ] main push 후 CI/CD 배포 정상 동작 확인

closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 배포 워크플로우의 보안 및 안정성 개선을 위한 인프라 업데이트 실시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->