### PR TITLE
[fix] deploy.yml 기존 수정사항 복구

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -33,40 +33,27 @@ jobs:
           docker push ${{ secrets.DOCKER_USERNAME }}/admin-prod:latest
           docker logout
 
-      # 깃에 커밋된 Helm 차트 폴더를 서버의 deploy-temp 폴더로 복사
-      - name: 🚚 Helm 차트 서버로 전송 (SCP)
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.K8S_HOST }}
-          port: ${{ secrets.K8S_PORT }}
-          username: ${{ secrets.K8S_USERNAME }}
-          key: ${{ secrets.K8S_PRIVATE_KEY }}
-          source: "helm/admin-prod" # 깃 레포 내 Helm 경로
-          target: "~/deploy-temp"
-          strip_components: 0
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
 
-      # 서버 접속 후 Helm 배포 실행
+    steps:
       - name: 🚀 Helm을 통한 쿠버네티스 배포
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.K8S_HOST }}
           port: ${{ secrets.K8S_PORT }}
           username: ${{ secrets.K8S_USERNAME }}
           key: ${{ secrets.K8S_PRIVATE_KEY }}
           script: |
-            set -e
-
-            # 1. 쿠버네티스 설정 로드 (이미 설정되어 있으므로 경로만 명시)
-            export KUBECONFIG=$HOME/.kube/config
+            set -e # 실패 시 즉시 중단
+            export KUBECONFIG=/etc/kubernetes/ci-deployer.conf
 
             echo "✅ 쿠버네티스 연결 테스트"
             kubectl get nodes
 
-            echo "📦 Helm 차트 배포 시작"
-            # SCP로 보낸 차트 위치: ~/deploy-temp/helm/admin-prod
-            CHART_PATH="$HOME/deploy-temp/helm/admin-prod"
-
-            helm upgrade --install admin-prod $CHART_PATH \
+            echo "📦 Helm 차트 배포 (절대 경로 사용)"
+            helm upgrade --install admin-prod /opt/admin_be/helm/admin-prod \
               --namespace default \
               --create-namespace \
               --set image.repository=${{ secrets.DOCKER_USERNAME }}/admin-prod \


### PR DESCRIPTION
## Summary
PR #203 머지 시 기존 수정사항이 덮어써진 것을 복구합니다.

### 복구 항목
- build/deploy job 분리 (#195)
- `appleboy/ssh-action@v1.2.5` 핀닝 (#199)
- `KUBECONFIG=/etc/kubernetes/ci-deployer.conf` 배포 전용 kubeconfig (#198)
- Helm 차트 경로 `/opt/admin_be/helm/admin-prod` (#198)
- `username: ${{ secrets.K8S_USERNAME }}` 유지

### 유지 항목 (PR #203에서 추가)
- `port: ${{ secrets.K8S_PORT }}` (기존 8088 하드코딩 대체)

## Test plan
- [ ] CI/CD 배포 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)