### PR TITLE
[refactor] #209 AcceptInfoResponseDTO에서 config-server 자체 보유 필드 제거

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/AcceptInfoResponseDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/AcceptInfoResponseDTO.java
@@ -1,6 +1,5 @@
 package DGU_AI_LAB.admin_be.domain.requests.dto.response;
 
-import DGU_AI_LAB.admin_be.domain.nodes.entity.Node;
 import DGU_AI_LAB.admin_be.domain.portRequests.entity.PortRequests;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -24,28 +23,9 @@ public record AcceptInfoResponseDTO(
         Long volume_size,
         @Schema(description = "GPU 필요 여부", example = "true")
         Boolean gpu_required,
-        @Schema(description = "GPU 그룹 설명", example = "High-performance GPU cluster with RTX 4090 cards")
-        String gpu_group,
-        @Schema(description = "서버 타입명", example = "LAB")
-        String server_type,
-        @Schema(description = "GPU 노드 목록")
-        List<NodeDTO> gpu_nodes,
         @Schema(description = "추가 포트 목록")
         List<AdditionalPortDTO> additional_ports
 ) {
-    @Schema(description = "GPU 노드 정보")
-    @Builder
-    public record NodeDTO(
-            @Schema(description = "노드 ID", example = "FARM1")
-            String node_name,
-            @Schema(description = "CPU 한도", example = "32000m")
-            String cpu_limit,
-            @Schema(description = "메모리 한도", example = "131072Mi")
-            String memory_limit,
-            @Schema(description = "GPU 수", example = "4")
-            Integer num_gpu
-    ) {}
-
     @Schema(description = "추가 포트 정보")
     @Builder
     public record AdditionalPortDTO(
@@ -55,18 +35,8 @@ public record AcceptInfoResponseDTO(
             String usage_purpose
     ) {}
 
-    public static AcceptInfoResponseDTO fromEntity(Request request, List<Node> nodes, List<PortRequests> portRequests) {
+    public static AcceptInfoResponseDTO fromEntity(Request request, List<PortRequests> portRequests) {
         var image = request.getContainerImage();
-        var group = request.getResourceGroup();
-
-        List<NodeDTO> nodeDTOList = nodes.stream()
-                .map(node -> NodeDTO.builder()
-                        .node_name(node.getNodeId())
-                        .cpu_limit(node.getCpuCoreCount() * 1000 + "m")
-                        .memory_limit(node.getMemorySizeGB() * 1024 + "Mi")
-                        .num_gpu(node.getNumberGpu())
-                        .build()
-                ).toList();
 
         List<AdditionalPortDTO> additionalPortDTOList = portRequests.stream()
                 .map(portRequest -> AdditionalPortDTO.builder()
@@ -86,9 +56,6 @@ public record AcceptInfoResponseDTO(
                 )
                 .volume_size(request.getVolumeSizeGiB())
                 .gpu_required(true)
-                .gpu_group(group.getDescription())
-                .server_type(group.getServerName())
-                .gpu_nodes(nodeDTOList)
                 .additional_ports(additionalPortDTOList)
                 .build();
     }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/ConfigRequestService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/ConfigRequestService.java
@@ -1,13 +1,10 @@
 package DGU_AI_LAB.admin_be.domain.requests.service;
 
-import DGU_AI_LAB.admin_be.domain.nodes.entity.Node;
-import DGU_AI_LAB.admin_be.domain.nodes.repository.NodeRepository;
 import DGU_AI_LAB.admin_be.domain.portRequests.entity.PortRequests;
 import DGU_AI_LAB.admin_be.domain.portRequests.repository.PortRequestRepository;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.AcceptInfoResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
-import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
 import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -24,7 +20,6 @@ import java.util.stream.Collectors;
 public class ConfigRequestService {
 
     private final RequestRepository requestRepository;
-    private final NodeRepository nodeRepository;
     private final PortRequestRepository portRequestRepository;
 
     /** ubuntu username 중복 검사 */
@@ -46,25 +41,12 @@ public class ConfigRequestService {
 
         log.debug("사용자 '{}'의 요청 정보를 성공적으로 찾았습니다. 요청 ID: {}", username, request.getRequestId());
 
-        // 리소스 그룹 및 노드 정보 조회
-        ResourceGroup group = request.getResourceGroup();
-        log.info("사용자 '{}'의 리소스 그룹 ID: {}", username, group.getRsgroupId());
-
-        List<Node> nodes = nodeRepository.findAllByResourceGroup(group);
-        log.debug("리소스 그룹 '{}'에 속한 노드 {}개를 조회했습니다.", group.getRsgroupId(), nodes.size());
-
-        // 조회된 노드 이름 목록을 로그에 기록
-        List<String> nodeNames = nodes.stream()
-                .map(Node::getNodeId)
-                .collect(Collectors.toList());
-        log.debug("조회된 노드 목록: {}", nodeNames);
-
         // 포트 요청 정보 조회
         List<PortRequests> portRequests = portRequestRepository.findByRequestRequestId(request.getRequestId());
         log.debug("요청 '{}'에 속한 포트 요청 {}개를 조회했습니다.", request.getRequestId(), portRequests.size());
 
         // 응답 DTO 생성 및 반환
-        AcceptInfoResponseDTO response = AcceptInfoResponseDTO.fromEntity(request, nodes, portRequests);
+        AcceptInfoResponseDTO response = AcceptInfoResponseDTO.fromEntity(request, portRequests);
         log.info("사용자 '{}'에 대한 AcceptInfoResponseDTO 생성을 완료했습니다.", username);
 
         return response;


### PR DESCRIPTION
## 관련 이슈
closes #209

## 변경 사항

### 문제
`GET /api/requests/config/{username}` 응답에 config-server가 이미 자체적으로 보유한 정보(`gpu_group`, `server_type`, `gpu_nodes`)가 포함되어 있어 불필요한 DB 쿼리(노드 조회)가 발생하고 있었습니다.

### 해결
config-server에서 불필요한 세 필드를 응답에서 제거했습니다.

## 변경 파일

| 파일 | 내용 |
|------|------|
| `AcceptInfoResponseDTO.java` | `gpu_group`, `server_type`, `gpu_nodes` 필드 및 `NodeDTO` record 제거, `fromEntity()` 파라미터에서 `nodes` 제거 |
| `ConfigRequestService.java` | `NodeRepository` 의존성 및 노드 조회 로직 제거 |