### PR TITLE
[ fix ]copliot 수정 사항 반영 

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SaveRequestRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SaveRequestRequestDTO.java
@@ -77,7 +77,7 @@ public record SaveRequestRequestDTO(
                 .containerImage(image)
                 .ubuntuUsername(ubuntuUsername)
                 .ubuntuPassword(ubuntuPasswordBase64)
-                .ubuntuPasswordBase64(ubuntuPassword)
+                .ubuntuPasswordBase64(ubuntuPasswordBase64)
                 .volumeSizeGiB(volumeSizeGiB)
                 .usagePurpose(usagePurpose)
                 .formAnswers(formAnswersJson)

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/repository/RequestRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/repository/RequestRepository.java
@@ -19,7 +19,7 @@ public interface RequestRepository extends JpaRepository<Request, Long> {
     Optional<Request> findByUbuntuUsername(String username);
     List<Request> findAllByUser_UserId(Long userId);
     List<Request> findAllByStatus(Status status);
-    Optional<Request> findByUbuntuUsernameAndUbuntuPassword(String username, String passwordBase64);
+    Optional<Request> findByUbuntuUsernameAndUbuntuPasswordBase64(String username, String passwordBase64);
     List<Request> findByUserUserIdAndStatus(Long userId, Status status);
     boolean existsByUbuntuUsername(String ubuntuUsername);
     List<Request> findAllByUser_UserIdAndStatus(Long userId, Status status);

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/UserService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/UserService.java
@@ -61,11 +61,11 @@ public class UserService {
         log.info("사용자 인증을 시작합니다. username: {}", dto.username());
 
         // 2. 비밀번호 확인
-        String encodedPassword = dto.passwordBase64();
+        String passwordBase64 = dto.passwordBase64();
         log.debug("비밀번호를 확인합니다. username: {}", dto.username());
 
         // 3. 사용자 및 비밀번호 일치 여부 확인
-        Request request = requestRepository.findByUbuntuUsernameAndUbuntuPassword(dto.username(), encodedPassword)
+        Request request = requestRepository.findByUbuntuUsernameAndUbuntuPasswordBase64(dto.username(), passwordBase64)
                 .orElseThrow(() -> {
                     // 3-1. 사용자 정보를 찾을 수 없을 때의 로그
                     log.warn("사용자 '{}'를 찾을 수 없거나 비밀번호가 일치하지 않습니다.", dto.username());
@@ -73,7 +73,7 @@ public class UserService {
                 });
 
         // 4. 추가 비밀번호 일치 확인 (Optional: Optional로 처리되었기 때문에 이중 확인)
-        if (!encodedPassword.equals(request.getUbuntuPassword())) {
+        if (!passwordBase64.equals(request.getUbuntuPasswordBase64())) {
             // 4-1. 비밀번호 불일치 로그
             log.error("사용자 '{}'에 대해 데이터베이스 비밀번호와 암호화된 비밀번호가 일치하지 않습니다. (내부 로직 오류 가능성)", dto.username());
             throw new UnauthorizedException(ErrorCode.INVALID_LOGIN_INFO);

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/UserServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/UserServiceTest.java
@@ -196,8 +196,8 @@ class UserServiceTest {
 
             Request request = mock(Request.class);
             when(request.getUbuntuUsername()).thenReturn("testuser");
-            when(request.getUbuntuPassword()).thenReturn(passwordBase64);
-            when(requestRepository.findByUbuntuUsernameAndUbuntuPassword("testuser", passwordBase64))
+            when(request.getUbuntuPasswordBase64()).thenReturn(passwordBase64);
+            when(requestRepository.findByUbuntuUsernameAndUbuntuPasswordBase64("testuser", passwordBase64))
                     .thenReturn(Optional.of(request));
 
             UserAuthRequestDTO dto = new UserAuthRequestDTO("testuser", passwordBase64);
@@ -210,7 +210,7 @@ class UserServiceTest {
         @Test
         @DisplayName("존재하지 않는 username으로 인증하면 UnauthorizedException을 던진다")
         void userAuth_throwsException_whenUsernameNotFound() {
-            when(requestRepository.findByUbuntuUsernameAndUbuntuPassword(anyString(), anyString()))
+            when(requestRepository.findByUbuntuUsernameAndUbuntuPasswordBase64(anyString(), anyString()))
                     .thenReturn(Optional.empty());
 
             UserAuthRequestDTO dto = new UserAuthRequestDTO("unknownuser", "dGVzdA==");


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #214 

## 🌱 작업 사항
  - SaveRequestRequestDTO.toEntity()에서 ubuntuPasswordBase64에 같은 base64 값을 저장하도록 수정됨
      - ubuntuPassword(ubuntuPasswordBase64)
      - ubuntuPasswordBase64(ubuntuPasswordBase64)

  - RequestRepository 조회 메서드 변경
      - findByUbuntuUsernameAndUbuntuPassword(...)
      - → findByUbuntuUsernameAndUbuntuPasswordBase64(...)

  - UserService.userAuth()도 **ubuntu_password_base64 기준으로 조회/검증**하도록 수정됨
  - UserServiceTest mock도 새 메서드/필드 기준으로 수정됨

## 🌱 참고 사항
기능을 만들 때 생긴 이슈에 대해서 다른사람들이 참고해야 할 사항을 적습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 사용자 인증 프로세스에서 비밀번호 처리 메커니즘 개선
  * 내부 저장소 및 로그인 검증 로직의 일관성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->