### PR TITLE
[ refactor ] 포트 할당 기준 및 조회 응답 개선

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/portRequests/service/PortRequestService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/portRequests/service/PortRequestService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -21,14 +22,14 @@ public class PortRequestService {
 
     private final PortRequestRepository portRequestRepository;
 
-    private static final int PORT_RANGE_START = 10000;
-    private static final int PORT_RANGE_END = 20000;
+    private static final int NODE_PORT_RANGE_START = 30000;
+    private static final int NODE_PORT_RANGE_END = 32767;
 
     @Transactional
     public PortRequests createPortRequest(Request request, ResourceGroup resourceGroup,
                                         Integer internalPort, String usagePurpose) {
 
-        // Auto-assign external port number from range 10000-20000
+        // Auto-assign external NodePort from the Kubernetes default range.
         Integer assignedPortNumber = findNextAvailablePort(resourceGroup.getRsgroupId());
 
         if (assignedPortNumber == null) {
@@ -49,15 +50,15 @@ public class PortRequestService {
     private Integer findNextAvailablePort(Integer resourceGroupId) {
         // Get all used port numbers in ascending order
         List<Integer> usedPorts = portRequestRepository.findPortNumbersByResourceGroupRsgroupIdOrderByPortNumberAsc(resourceGroupId);
+        Set<Integer> usedPortSet = Set.copyOf(usedPorts);
 
-        // Find the first available port in range 10000-20000
-        for (int port = PORT_RANGE_START; port <= PORT_RANGE_END; port++) {
-            if (!usedPorts.contains(port)) {
+        // Find the first available port in range 30000-32767.
+        for (int port = NODE_PORT_RANGE_START; port <= NODE_PORT_RANGE_END; port++) {
+            if (!usedPortSet.contains(port)) {
                 return port;
             }
         }
 
-        // No available ports in range
         return null;
     }
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/PodExternalPortResponseDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/PodExternalPortResponseDTO.java
@@ -1,0 +1,30 @@
+package DGU_AI_LAB.admin_be.domain.requests.dto.response;
+
+import DGU_AI_LAB.admin_be.domain.pod.entity.PodExternalPort;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Schema(description = "Pod 외부 포트 응답 DTO")
+@Builder
+public record PodExternalPortResponseDTO(
+        @Schema(description = "Pod 외부 포트 ID", example = "1")
+        Long podExternalPortId,
+
+        @Schema(description = "컨테이너 내부 포트 번호", example = "8888")
+        Integer internalPort,
+
+        @Schema(description = "Kubernetes NodePort 외부 포트 번호 (30000-32767 범위)", example = "30888")
+        Integer externalPort,
+
+        @Schema(description = "포트 사용 목적", example = "jupyter")
+        String usagePurpose
+) {
+    public static PodExternalPortResponseDTO fromEntity(PodExternalPort podExternalPort) {
+        return PodExternalPortResponseDTO.builder()
+                .podExternalPortId(podExternalPort.getId())
+                .internalPort(podExternalPort.getInternalPort())
+                .externalPort(podExternalPort.getExternalPort())
+                .usagePurpose(podExternalPort.getUsagePurpose())
+                .build();
+    }
+}

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/PortMappingDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/PortMappingDTO.java
@@ -9,7 +9,7 @@ public record PortMappingDTO(
         @Schema(description = "포트 요청 ID", example = "1")
         Long portRequestId,
 
-        @Schema(description = "외부 포트 번호 (10000-20000 범위)", example = "10001")
+        @Schema(description = "외부 포트 번호 (30000-32767 범위)", example = "30001")
         Integer externalPort,
 
         @Schema(description = "내부 포트 번호 (컨테이너 포트)", example = "3000")

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/SaveRequestResponseDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/SaveRequestResponseDTO.java
@@ -6,6 +6,7 @@ import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
 import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -54,6 +55,9 @@ public record SaveRequestResponseDTO(
         String comment,
         @Schema(description = "포트 매핑 목록")
         List<PortMappingDTO> portMappings,
+        @Schema(description = "Pod 외부 포트 목록")
+        @JsonProperty("pod_external_ports")
+        List<PodExternalPortResponseDTO> podExternalPorts,
         @Schema(description = "신청 생성 일시", example = "2026-03-02T15:36:29")
         LocalDateTime createdAt,
         @Schema(description = "신청 수정 일시", example = "2026-03-02T15:36:29")
@@ -148,12 +152,21 @@ public record SaveRequestResponseDTO(
                 .approvedAt(request.getApprovedAt())
                 .comment(request.getAdminComment())
                 .portMappings(List.of())
+                .podExternalPorts(List.of())
                 .createdAt(request.getCreatedAt())
                 .updatedAt(request.getUpdatedAt())
                 .build();
     }
 
     public static SaveRequestResponseDTO fromEntityWithPortMappings(Request request, List<PortMappingDTO> portMappings) {
+        return fromEntityWithPorts(request, portMappings, List.of());
+    }
+
+    public static SaveRequestResponseDTO fromEntityWithPorts(
+            Request request,
+            List<PortMappingDTO> portMappings,
+            List<PodExternalPortResponseDTO> podExternalPorts
+    ) {
         if (request.getResourceGroup() == null) {
             throw new BusinessException(ErrorCode.RESOURCE_GROUP_NOT_FOUND);
         }
@@ -188,6 +201,7 @@ public record SaveRequestResponseDTO(
                 .approvedAt(request.getApprovedAt())
                 .comment(request.getAdminComment())
                 .portMappings(portMappings)
+                .podExternalPorts(podExternalPorts)
                 .createdAt(request.getCreatedAt())
                 .updatedAt(request.getUpdatedAt())
                 .build();

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryService.java
@@ -1,8 +1,10 @@
 package DGU_AI_LAB.admin_be.domain.requests.service;
 
 import DGU_AI_LAB.admin_be.domain.portRequests.service.PortRequestService;
+import DGU_AI_LAB.admin_be.domain.pod.repository.PodExternalPortRepository;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ChangeRequestResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ContainerInfoDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.PodExternalPortResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.PortMappingDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ResourceUsageDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.SaveRequestResponseDTO;
@@ -25,6 +27,7 @@ public class AdminRequestQueryService {
     private final RequestRepository requestRepository;
     private final ChangeRequestRepository changeRequestRepository;
     private final PortRequestService portRequestService;
+    private final PodExternalPortRepository podExternalPortRepository;
 
     public List<SaveRequestResponseDTO> getAllRequests() {
         return requestRepository.findAll().stream()
@@ -43,8 +46,12 @@ public class AdminRequestQueryService {
                 .stream()
                 .map(PortMappingDTO::fromEntity)
                 .toList();
+        List<PodExternalPortResponseDTO> podExternalPorts = podExternalPortRepository.findByRequestRequestId(request.getRequestId())
+                .stream()
+                .map(PodExternalPortResponseDTO::fromEntity)
+                .toList();
 
-        return SaveRequestResponseDTO.fromEntityWithPortMappings(request, portMappings);
+        return SaveRequestResponseDTO.fromEntityWithPorts(request, portMappings, podExternalPorts);
     }
 
     public List<ResourceUsageDTO> getAllFulfilledResourceUsage() {

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestQueryService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestQueryService.java
@@ -1,8 +1,10 @@
 package DGU_AI_LAB.admin_be.domain.requests.service;
 
 import DGU_AI_LAB.admin_be.domain.portRequests.service.PortRequestService;
+import DGU_AI_LAB.admin_be.domain.pod.repository.PodExternalPortRepository;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ChangeRequestResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ContainerInfoDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.PodExternalPortResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.PortMappingDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ResourceUsageDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.SaveRequestResponseDTO;
@@ -30,6 +32,7 @@ public class RequestQueryService {
     private final ChangeRequestRepository changeRequestRepository;
     private final UserRepository userRepository;
     private final PortRequestService portRequestService;
+    private final PodExternalPortRepository podExternalPortRepository;
 
     /** 내 신청 목록 */
     public List<SaveRequestResponseDTO> getRequestsByUserId(Long userId) {
@@ -46,8 +49,12 @@ public class RequestQueryService {
                 .stream()
                 .map(PortMappingDTO::fromEntity)
                 .toList();
+        List<PodExternalPortResponseDTO> podExternalPorts = podExternalPortRepository.findByRequestRequestId(request.getRequestId())
+                .stream()
+                .map(PodExternalPortResponseDTO::fromEntity)
+                .toList();
 
-        return SaveRequestResponseDTO.fromEntityWithPortMappings(request, portMappings);
+        return SaveRequestResponseDTO.fromEntityWithPorts(request, portMappings, podExternalPorts);
     }
 
     /** 승인 완료 자원 사용량 */

--- a/src/main/java/DGU_AI_LAB/admin_be/error/ErrorCode.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/error/ErrorCode.java
@@ -147,7 +147,7 @@ public enum ErrorCode {
      * Port Request Error
      */
     DUPLICATE_PORT_NUMBER(HttpStatus.CONFLICT, "이미 사용 중인 포트 번호입니다."),
-    NO_AVAILABLE_PORT(HttpStatus.CONFLICT, "사용 가능한 포트가 없습니다. (10000-20000 범위)")
+    NO_AVAILABLE_PORT(HttpStatus.CONFLICT, "사용 가능한 포트가 없습니다. (30000-32767 범위)")
 
 
     ;

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/portRequests/service/PortRequestServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/portRequests/service/PortRequestServiceTest.java
@@ -1,0 +1,86 @@
+package DGU_AI_LAB.admin_be.domain.portRequests.service;
+
+import DGU_AI_LAB.admin_be.domain.portRequests.entity.PortRequests;
+import DGU_AI_LAB.admin_be.domain.portRequests.repository.PortRequestRepository;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PortRequestServiceTest {
+
+    @InjectMocks
+    private PortRequestService portRequestService;
+
+    @Mock
+    private PortRequestRepository portRequestRepository;
+
+    @Test
+    @DisplayName("NodePort 기본 범위 30000부터 사용 가능한 포트를 할당한다")
+    void createPortRequest_assignsNodePortFromDefaultRange() {
+        ResourceGroup resourceGroup = ResourceGroup.builder()
+                .rsgroupId(1)
+                .build();
+        Request request = Request.builder()
+                .ubuntuUsername("testuser")
+                .ubuntuPassword("password")
+                .ubuntuPasswordBase64("cGFzc3dvcmQ=")
+                .volumeSizeGiB(10L)
+                .usagePurpose("학습")
+                .formAnswers("{}")
+                .resourceGroup(resourceGroup)
+                .build();
+
+        when(portRequestRepository.findPortNumbersByResourceGroupRsgroupIdOrderByPortNumberAsc(1))
+                .thenReturn(List.of(30000));
+        when(portRequestRepository.save(any(PortRequests.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        portRequestService.createPortRequest(request, resourceGroup, 8888, "jupyter");
+
+        ArgumentCaptor<PortRequests> captor = ArgumentCaptor.forClass(PortRequests.class);
+        verify(portRequestRepository).save(captor.capture());
+        assertThat(captor.getValue().getPortNumber()).isEqualTo(30001);
+    }
+
+    @Test
+    @DisplayName("30000-32767 범위가 모두 사용 중이면 BusinessException을 던진다")
+    void createPortRequest_throwsException_whenNoNodePortAvailable() {
+        ResourceGroup resourceGroup = ResourceGroup.builder()
+                .rsgroupId(1)
+                .build();
+        Request request = Request.builder()
+                .ubuntuUsername("testuser")
+                .ubuntuPassword("password")
+                .ubuntuPasswordBase64("cGFzc3dvcmQ=")
+                .volumeSizeGiB(10L)
+                .usagePurpose("학습")
+                .formAnswers("{}")
+                .resourceGroup(resourceGroup)
+                .build();
+        List<Integer> usedPorts = IntStream.rangeClosed(30000, 32767)
+                .boxed()
+                .toList();
+
+        when(portRequestRepository.findPortNumbersByResourceGroupRsgroupIdOrderByPortNumberAsc(1))
+                .thenReturn(usedPorts);
+
+        assertThatThrownBy(() -> portRequestService.createPortRequest(request, resourceGroup, 8888, "jupyter"))
+                .isInstanceOf(BusinessException.class);
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryServiceTest.java
@@ -1,10 +1,13 @@
 package DGU_AI_LAB.admin_be.domain.requests.service;
 
 import DGU_AI_LAB.admin_be.domain.portRequests.service.PortRequestService;
+import DGU_AI_LAB.admin_be.domain.pod.entity.PodExternalPort;
+import DGU_AI_LAB.admin_be.domain.pod.repository.PodExternalPortRepository;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ChangeRequestResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ContainerInfoDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ResourceUsageDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.SaveRequestResponseDTO;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
 import DGU_AI_LAB.admin_be.domain.requests.repository.ChangeRequestRepository;
 import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
@@ -36,6 +39,9 @@ class AdminRequestQueryServiceTest {
     @Mock
     private PortRequestService portRequestService;
 
+    @Mock
+    private PodExternalPortRepository podExternalPortRepository;
+
     @Nested
     @DisplayName("getAllRequests")
     class GetAllRequests {
@@ -49,6 +55,30 @@ class AdminRequestQueryServiceTest {
 
             assertThat(result).isEmpty();
             verify(requestRepository).findAll();
+        }
+
+        @Test
+        @DisplayName("관리자 요청 조회 시 pod_external_ports를 함께 반환한다")
+        void getAllRequests_returnsPodExternalPorts() {
+            Request request = mockRequest(1L);
+            PodExternalPort podExternalPort = PodExternalPort.builder()
+                    .request(request)
+                    .internalPort(22)
+                    .externalPort(30022)
+                    .usagePurpose("ssh")
+                    .build();
+
+            when(requestRepository.findAll()).thenReturn(List.of(request));
+            when(portRequestService.getPortRequestsByRequestId(1L)).thenReturn(List.of());
+            when(podExternalPortRepository.findByRequestRequestId(1L)).thenReturn(List.of(podExternalPort));
+
+            List<SaveRequestResponseDTO> result = adminRequestQueryService.getAllRequests();
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).podExternalPorts()).hasSize(1);
+            assertThat(result.get(0).podExternalPorts().get(0).internalPort()).isEqualTo(22);
+            assertThat(result.get(0).podExternalPorts().get(0).externalPort()).isEqualTo(30022);
+            assertThat(result.get(0).podExternalPorts().get(0).usagePurpose()).isEqualTo("ssh");
         }
     }
 
@@ -127,5 +157,37 @@ class AdminRequestQueryServiceTest {
 
             assertThat(result).isEmpty();
         }
+    }
+
+    private Request mockRequest(Long requestId) {
+        Request request = mock(Request.class);
+        var resourceGroup = mock(DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup.class);
+        var user = mock(DGU_AI_LAB.admin_be.domain.users.entity.User.class);
+        var containerImage = mock(DGU_AI_LAB.admin_be.domain.containerImage.entity.ContainerImage.class);
+
+        when(request.getRequestId()).thenReturn(requestId);
+        when(request.getResourceGroup()).thenReturn(resourceGroup);
+        when(resourceGroup.getRsgroupId()).thenReturn(1);
+        when(resourceGroup.getResourceGroupName()).thenReturn("RTX 4090 Cluster");
+        when(resourceGroup.getDescription()).thenReturn("GPU cluster");
+        when(resourceGroup.getServerName()).thenReturn("LAB");
+        when(request.getUser()).thenReturn(user);
+        when(user.getUserId()).thenReturn(1L);
+        when(user.getEmail()).thenReturn("user@example.com");
+        when(user.getName()).thenReturn("테스트유저");
+        when(user.getStudentId()).thenReturn("2023000001");
+        when(user.getDepartment()).thenReturn("컴퓨터공학과");
+        when(user.getPhone()).thenReturn("010-0000-0000");
+        when(user.getIsActive()).thenReturn(true);
+        when(request.getContainerImage()).thenReturn(containerImage);
+        when(containerImage.getImageId()).thenReturn(1L);
+        when(containerImage.getImageName()).thenReturn("cuda");
+        when(containerImage.getImageVersion()).thenReturn("11.8");
+        when(request.getRequestGroups()).thenReturn(java.util.Set.of());
+        when(request.getVolumeSizeGiB()).thenReturn(20L);
+        when(request.getUsagePurpose()).thenReturn("학습");
+        when(request.getFormAnswers()).thenReturn("{}");
+        when(request.getStatus()).thenReturn(Status.FULFILLED);
+        return request;
     }
 }

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestQueryServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestQueryServiceTest.java
@@ -1,9 +1,12 @@
 package DGU_AI_LAB.admin_be.domain.requests.service;
 
 import DGU_AI_LAB.admin_be.domain.portRequests.service.PortRequestService;
+import DGU_AI_LAB.admin_be.domain.pod.entity.PodExternalPort;
+import DGU_AI_LAB.admin_be.domain.pod.repository.PodExternalPortRepository;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ContainerInfoDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ResourceUsageDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.SaveRequestResponseDTO;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
 import DGU_AI_LAB.admin_be.domain.requests.repository.ChangeRequestRepository;
 import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
@@ -41,6 +44,9 @@ class RequestQueryServiceTest {
     @Mock
     private PortRequestService portRequestService;
 
+    @Mock
+    private PodExternalPortRepository podExternalPortRepository;
+
     @Nested
     @DisplayName("getRequestsByUserId")
     class GetRequestsByUserId {
@@ -54,6 +60,31 @@ class RequestQueryServiceTest {
             List<SaveRequestResponseDTO> result = requestQueryService.getRequestsByUserId(1L);
 
             assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("요청 조회 시 pod_external_ports를 함께 반환한다")
+        void getRequestsByUserId_returnsPodExternalPorts() {
+            Request request = mockRequest(1L);
+            PodExternalPort podExternalPort = PodExternalPort.builder()
+                    .request(request)
+                    .internalPort(8888)
+                    .externalPort(30888)
+                    .usagePurpose("jupyter")
+                    .build();
+
+            when(userRepository.existsById(1L)).thenReturn(true);
+            when(requestRepository.findAllByUser_UserId(1L)).thenReturn(List.of(request));
+            when(portRequestService.getPortRequestsByRequestId(1L)).thenReturn(List.of());
+            when(podExternalPortRepository.findByRequestRequestId(1L)).thenReturn(List.of(podExternalPort));
+
+            List<SaveRequestResponseDTO> result = requestQueryService.getRequestsByUserId(1L);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).podExternalPorts()).hasSize(1);
+            assertThat(result.get(0).podExternalPorts().get(0).internalPort()).isEqualTo(8888);
+            assertThat(result.get(0).podExternalPorts().get(0).externalPort()).isEqualTo(30888);
+            assertThat(result.get(0).podExternalPorts().get(0).usagePurpose()).isEqualTo("jupyter");
         }
 
         @Test
@@ -162,5 +193,37 @@ class RequestQueryServiceTest {
             assertThatThrownBy(() -> requestQueryService.getMyChangeRequests(99L))
                     .isInstanceOf(BusinessException.class);
         }
+    }
+
+    private Request mockRequest(Long requestId) {
+        Request request = mock(Request.class);
+        var resourceGroup = mock(DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup.class);
+        var user = mock(DGU_AI_LAB.admin_be.domain.users.entity.User.class);
+        var containerImage = mock(DGU_AI_LAB.admin_be.domain.containerImage.entity.ContainerImage.class);
+
+        when(request.getRequestId()).thenReturn(requestId);
+        when(request.getResourceGroup()).thenReturn(resourceGroup);
+        when(resourceGroup.getRsgroupId()).thenReturn(1);
+        when(resourceGroup.getResourceGroupName()).thenReturn("RTX 4090 Cluster");
+        when(resourceGroup.getDescription()).thenReturn("GPU cluster");
+        when(resourceGroup.getServerName()).thenReturn("LAB");
+        when(request.getUser()).thenReturn(user);
+        when(user.getUserId()).thenReturn(1L);
+        when(user.getEmail()).thenReturn("user@example.com");
+        when(user.getName()).thenReturn("테스트유저");
+        when(user.getStudentId()).thenReturn("2023000001");
+        when(user.getDepartment()).thenReturn("컴퓨터공학과");
+        when(user.getPhone()).thenReturn("010-0000-0000");
+        when(user.getIsActive()).thenReturn(true);
+        when(request.getContainerImage()).thenReturn(containerImage);
+        when(containerImage.getImageId()).thenReturn(1L);
+        when(containerImage.getImageName()).thenReturn("cuda");
+        when(containerImage.getImageVersion()).thenReturn("11.8");
+        when(request.getRequestGroups()).thenReturn(java.util.Set.of());
+        when(request.getVolumeSizeGiB()).thenReturn(20L);
+        when(request.getUsagePurpose()).thenReturn("학습");
+        when(request.getFormAnswers()).thenReturn("{}");
+        when(request.getStatus()).thenReturn(Status.FULFILLED);
+        return request;
     }
 }


### PR DESCRIPTION
  🌱 관련 이슈
  close: #220, #221


  🌱 작업 사항
  - 포트 자동 할당 범위를 Kubernetes NodePort 기본 범위인 `30000-32767`로 수정
  - `NO_AVAILABLE_PORT` 에러 메시지의 포트 범위 문구 수정
  - 포트 설명 Swagger 문구를 새 범위에 맞게 정리
  - Request 조회 응답에 `pod_external_ports` 추가
  - 사용자/관리자 Request 조회 API에서 `pod_external_ports`를 함께 반환하도록 수정
  - 관련 단위 테스트 추가 및 수정

  🌱 참고 사항
  - 기존 `portMappings` 응답은 호환성을 위해 유지
  - `pod_external_ports`는 승인 시 저장된 `pod_external_ports` 테이블 기준으로 내려감
  - 포트 범위 기준이 변경됐으므로 후속 작업에서 동일 기준을 유지해야 함