### PR TITLE
[ fix ] 유저 생성 DTO 수정 및 username 검사 조건 변경

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/repository/RequestRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/repository/RequestRepository.java
@@ -22,6 +22,7 @@ public interface RequestRepository extends JpaRepository<Request, Long> {
     Optional<Request> findByUbuntuUsernameAndUbuntuPasswordBase64(String username, String passwordBase64);
     List<Request> findByUserUserIdAndStatus(Long userId, Status status);
     boolean existsByUbuntuUsername(String ubuntuUsername);
+    boolean existsByUbuntuUsernameAndStatusIn(String ubuntuUsername, List<Status> statuses);
     List<Request> findAllByUser_UserIdAndStatus(Long userId, Status status);
     boolean existsByUbuntuUsernameAndUser_UserId(String ubuntuUsername, Long userId);
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
@@ -329,11 +329,19 @@ public class AdminRequestCommandService {
     }
 
     record UserCreationResponse(
-            @JsonProperty("uid")
-            @JsonAlias({"ubuntuUid", "ubuntu_uid"})
-            Long uid,
-            @JsonProperty("gid")
-            @JsonAlias({"ubuntuGid", "ubuntu_gid"})
-            Long gid
-    ) {}
+            String status,
+            UserInfo user
+    ) {
+        Long uid() { return user != null ? user.uid() : null; }
+        Long gid() { return user != null ? user.gid() : null; }
+
+        record UserInfo(
+                @JsonProperty("uid")
+                @JsonAlias({"ubuntuUid", "ubuntu_uid"})
+                Long uid,
+                @JsonProperty("gid")
+                @JsonAlias({"ubuntuGid", "ubuntu_gid"})
+                Long gid
+        ) {}
+    }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestCommandService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestCommandService.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -170,7 +171,8 @@ public class RequestCommandService {
         ResourceGroup rg = resourceGroupRepository.findById(dto.resourceGroupId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
-        if (requestRepository.existsByUbuntuUsername(dto.ubuntuUsername())) {
+        if (requestRepository.existsByUbuntuUsernameAndStatusIn(
+                dto.ubuntuUsername(), List.of(Status.PENDING, Status.FULFILLED))) {
             throw new BusinessException(ErrorCode.DUPLICATE_USERNAME);
         }
 

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandServiceTest.java
@@ -100,7 +100,10 @@ class AdminRequestCommandServiceTest {
         when(putHeadersSpec.retrieve()).thenReturn(putResponseSpec);
         when(putResponseSpec.onStatus(any(), any())).thenReturn(putResponseSpec);
         when(putResponseSpec.bodyToMono(AdminRequestCommandService.UserCreationResponse.class))
-                .thenReturn(Mono.just(new AdminRequestCommandService.UserCreationResponse(2001L, 2001L)));
+                .thenReturn(Mono.just(new AdminRequestCommandService.UserCreationResponse(
+                        "created",
+                        new AdminRequestCommandService.UserCreationResponse.UserInfo(2001L, 2001L)
+                )));
     }
 
     /** PVC 생성 POST 요청 WebClient 모킹

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestCommandServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestCommandServiceTest.java
@@ -25,7 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -76,7 +76,7 @@ class RequestCommandServiceTest {
 
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
             when(resourceGroupRepository.findById(any())).thenReturn(Optional.of(rg));
-            when(requestRepository.existsByUbuntuUsername("existinguser")).thenReturn(true);
+            when(requestRepository.existsByUbuntuUsernameAndStatusIn(eq("existinguser"), anyList())).thenReturn(true);
 
             SaveRequestRequestDTO dto = mock(SaveRequestRequestDTO.class);
             when(dto.resourceGroupId()).thenReturn(1);


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #227 

## 🌱 작업 사항

### 1. UserCreationResponse DTO 구조 수정

* infra-server의 실제 응답은 다음과 같이 `user` 객체 내부에 `uid`, `gid` 정보를 포함한다.

```json
{
  "status": "created",
  "user": {
    "uid": 10010,
    "gid": 10010
  }
}
```

* 기존 DTO는 `uid`, `gid`를 최상위 필드에서 조회하도록 구현되어 있어 값이 정상적으로 매핑되지 않았으며, 결과적으로 `UID_ALLOCATION_FAILED` 예외가 발생하고 있었다.
* 실제 응답 구조에 맞춰 `UserInfo` 내부 record를 추가하였다.
* 기존 호출부와의 호환성을 위해 `uid()`, `gid()` 편의 메서드는 유지하였다.

### 2. Username 중복 검사 정책 개선

* 기존에는 username 존재 여부만 확인하여 중복을 판단하였다.
* `DENIED`, `DELETED` 상태는 실제 계정이 생성되지 않았거나 이미 삭제된 상태이므로 username 재사용이 가능하도록 정책을 수정하였다.
* 중복 검사 로직을 다음과 같이 변경하였다.

  * 기존: `existsByUbuntuUsername(...)`
  * 변경: `existsByUbuntuUsernameAndStatusIn(PENDING, FULFILLED)`
* 이를 위해 `RequestRepository`에 `existsByUbuntuUsernameAndStatusIn(...)` 메서드를 추가하였다.

### 3. 테스트 코드 수정

* `AdminRequestCommandServiceTest`

  * Mock 응답을 실제 config-server 응답 구조와 동일한 중첩 형태로 수정
* `RequestCommandServiceTest`

  * 변경된 username 중복 검사 로직에 맞게 테스트 코드 수정

---

## 🌱 참고 사항

* infra-server의 전체 응답 구조

```json
{
  "status": "created",
  "user": {
    "name": "username",
    "uid": 10010,
    "gid": 10010,
    "home": "/home/username",
    "shell": "/bin/bash"
  },
  "group": {
    "name": "username",
    "gid": 10010
  },
  "supplementary_groups": [],
  "sudoers": null
}
```

* 현재 애플리케이션에서 필요한 정보는 `uid`, `gid`뿐이며, 나머지 필드는 사용하지 않는다.
* Jackson이 unknown property를 무시하므로 추가 DTO 매핑은 필요하지 않다.
* `DENIED`, `DELETED` 상태는 infra-server에 실제 계정이 존재하지 않는 상태를 의미
* 만약 계정이 남아 있는 비정상적인 상황이 발생하더라도 infra-server에서 `409 CONFLICT`를 반환하므로 안전하게 처리
