### PR TITLE
fix: UserScheduler D-7 알림 미발송 버그 수정 (#236)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/UserSchedulerService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/UserSchedulerService.java
@@ -47,9 +47,9 @@ public class UserSchedulerService {
      * 장기 미접속자 조회 및 처리 (경고 알림 OR Soft Delete)
      */
     private void processInactiveUsers(LocalDateTime now) {
-        // 기준일: 오늘 - 3개월 + 7일 (7일 전 알림을 위해 여유 있게 조회 후 로직에서 필터링)
-        // 사실상 3개월 전 즈음에 활동이 멈춘 사람들을 모두 가져옴
-        LocalDateTime searchThreshold = now.minusMonths(INACTIVE_MONTHS).plusDays(8);
+        // 기준일: (오늘 + 8일) - 3개월 (7일 전 알림을 위해 여유 있게 조회 후 로직에서 필터링)
+        // plusDays 후 minusMonths 순서여야 달력 연산 오차 없이 D-7 대상자를 정확히 포함함
+        LocalDateTime searchThreshold = now.plusDays(8).minusMonths(INACTIVE_MONTHS);
         List<User> inactiveCandidates = userRepository.findInactiveUsers(searchThreshold);
 
         for (User user : inactiveCandidates) {

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/scheduler/UserSchedulerServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/scheduler/UserSchedulerServiceTest.java
@@ -64,9 +64,10 @@ class UserSchedulerServiceTest {
         updateLastLogin(podUser, now.minusMonths(4));
         createRequestForUser(podUser, now.minusDays(1));
 
-        // 3. [경고 대상 D-7] (Login = Now - 3개월 + 7일)
+        // 3. [경고 대상 D-7] (Login = Now + 7일 - 3개월 → deleteDate = Now + 7일, daysLeft = 7)
+        // plusDays 후 minusMonths 순서여야 달력 연산 오차 없이 정확히 7일이 남음
         User d7User = createUser("d7@test.com", "D7User");
-        LocalDateTime d7LoginDate = now.minusMonths(3).plusDays(7);
+        LocalDateTime d7LoginDate = now.plusDays(7).minusMonths(3);
         updateLastLogin(d7User, d7LoginDate);
 
         // D-7 예상 메시지 생성


### PR DESCRIPTION
## 요약

- `UserSchedulerService`에서 D-7 경고 알림이 특정 날짜에 발송되지 않는 버그 수정
- `LocalDateTime` 달 연산 순서(`minusMonths` → `plusDays`) 오류로 인해 daysLeft가 7이 아닌 6으로 계산되어 알림 미발송
- `searchThreshold` 계산 순서도 동일하게 수정하여 D-7 대상자가 쿼리에서 누락되지 않도록 수정

## 테스트

- [ ] `./gradlew test` 전체 통과 확인 (133개)

resolves #236