### PR TITLE
fix: 양식 관리 목록에 DB 전용 메시지 키 노출

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/messageTemplate/service/MessageTemplateService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/messageTemplate/service/MessageTemplateService.java
@@ -53,10 +53,14 @@ public class MessageTemplateService {
         Map<String, MessageTemplate> overrides = new HashMap<>();
         repository.findAll().forEach(t -> overrides.put(t.getKey(), t));
 
-        // 3. 기본값 기준으로 순회하면서 DB 오버라이드와 머지
+        // 3. properties 키 ∪ DB 키 순회 — properties에 없고 DB에만 있는 키(email.*)도 노출.
+        //    (기존엔 properties 키만 돌아서 DB 전용 키가 누락됐음.) TreeSet이라 자동 정렬.
+        Set<String> allKeys = new TreeSet<>(defaults.stringPropertyNames());
+        allKeys.addAll(overrides.keySet());
+
         List<TemplateView> result = new ArrayList<>();
-        for (String key : defaults.stringPropertyNames()) {
-            String def = defaults.getProperty(key);
+        for (String key : allKeys) {
+            String def = defaults.getProperty(key);            // DB 전용 키면 null
             MessageTemplate override = overrides.get(key);
             result.add(new TemplateView(
                     key, def,
@@ -64,8 +68,6 @@ public class MessageTemplateService {
                     override != null                                // DB에 row가 있는지 여부
             ));
         }
-        // ponytail스킬: O(n) scan, ~20개 템플릿이라 정렬 비용 무시 가능
-        result.sort(Comparator.comparing(TemplateView::key));
         return result;
     }
 


### PR DESCRIPTION
getAll()이 messages.properties 키만 순회해 DB에만 존재하는 키(email.*)가 양식 관리 UI 목록에서 누락되던 문제 수정. properties 키 ∪ DB 키 합집합으로 순회하도록 변경.

## 🌱 관련 이슈
- close : #[Issue number]

## 🌱 작업 사항
해당 Pull Request에서 수행한 작업 목록을 제시해야 합니다.

## 🌱 참고 사항
기능을 만들 때 생긴 이슈에 대해서 다른사람들이 참고해야 할 사항을 적습니다.