### PR TITLE
fix: 관리자 API 권한 체크 활성화 및 Redis 리프레시 토큰 TTL 단위 수정

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/TokenService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/TokenService.java
@@ -48,7 +48,7 @@ public class TokenService {
 
         if (storedRefreshToken == null) {
             storedRefreshToken = issueNewRefreshToken(userId);
-            redisTemplate.opsForValue().set(redisKey, storedRefreshToken, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.SECONDS);
+            redisTemplate.opsForValue().set(redisKey, storedRefreshToken, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.MILLISECONDS);
         }
 
         return UserTokenResponseDTO.of(accessToken, storedRefreshToken);
@@ -73,7 +73,7 @@ public class TokenService {
         String newAccessToken = issueNewAccessToken(userId);
         String newRefreshToken = issueNewRefreshToken(userId);
 
-        redisTemplate.opsForValue().set(redisKey, newRefreshToken, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.SECONDS);
+        redisTemplate.opsForValue().set(redisKey, newRefreshToken, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.MILLISECONDS);
 
         return UserTokenResponseDTO.of(newAccessToken, newRefreshToken);
     }

--- a/src/main/java/DGU_AI_LAB/admin_be/global/auth/SecurityConfig.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/global/auth/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                 .exceptionHandling(config -> config.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(SecurityWhitelist.UNPROTECTED_PATHS.toArray(new String[0])).permitAll()
-                        // .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .addFilter(corsConfig.corsFilter())


### PR DESCRIPTION
## 관련 이슈
- Closes #243 [C-1] 관리자 API 권한 체크 누락
- Closes #244 [C-2] Redis 리프레시 토큰 TTL 약 19년 버그

## 변경 사항

### [C-1] SecurityConfig.java — 관리자 API 권한 체크 활성화
주석 처리되어 있던 `/api/admin/**` 경로의 ADMIN 롤 체크를 활성화합니다.
일반 USER 토큰으로 관리자 API 호출이 가능했던 보안 취약점을 제거합니다.

```java
// Before
// .requestMatchers("/api/admin/**").hasRole("ADMIN")

// After
.requestMatchers("/api/admin/**").hasRole("ADMIN")
```

### [C-2] TokenService.java — Redis TTL 단위 수정
`application.yml`의 `refresh-token-expire-time: 604800000` 값은 밀리초(7일) 기준입니다.
`TimeUnit.SECONDS`로 처리하면 약 19.2년이 되는 버그를 `TimeUnit.MILLISECONDS`로 수정합니다.

```java
// Before (604,800,000초 ≈ 19.2년)
redisTemplate.opsForValue().set(redisKey, token, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.SECONDS);

// After (604,800,000밀리초 = 7일)
redisTemplate.opsForValue().set(redisKey, token, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.MILLISECONDS);
```

## 테스트
- 기존 테스트 전체 통과 확인 (`./gradlew test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)