### PR TITLE
fix: DB 제약 위반 예외 처리 및 신청 DTO 필드 검증 추가

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SaveRequestRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SaveRequestRequestDTO.java
@@ -11,8 +11,10 @@ import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
@@ -41,15 +43,20 @@ public record SaveRequestRequestDTO(
         String ubuntuPassword,
 
         @Schema(description = "볼륨 사이즈 (GiB)", example = "20")
+        @NotNull(message = "Volume size cannot be null")
+        @Positive(message = "Volume size must be positive")
         Long volumeSizeGiB,
 
         @Schema(description = "사용 목적", example = "딥러닝 모델 학습")
+        @NotBlank(message = "Usage purpose cannot be blank")
         String usagePurpose,
 
         @Schema(description = "폼 응답", example = "{\"question\": \"answer\"}")
         Map<String, Object> formAnswers,
 
         @Schema(description = "서버 만료 일시", example = "2026-12-31T23:59:59")
+        @NotNull(message = "Expires date cannot be null")
+        @Future(message = "Expires date must be in the future")
         LocalDateTime expiresAt,
         @Schema(description = "Ubuntu GID 목록", example = "[1005, 1006]")
         Set<Long> ubuntuGids,

--- a/src/main/java/DGU_AI_LAB/admin_be/error/GlobalExceptionHandler.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/error/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import DGU_AI_LAB.admin_be.error.dto.ErrorResponse;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import DGU_AI_LAB.admin_be.error.exception.UnauthorizedException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -103,6 +104,16 @@ public class GlobalExceptionHandler {
         log.error(">>> handle: MaxUploadSizeExceededException (파일 크기 초과)", e);
         final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.FILE_SIZE_EXCEEDED);
         return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(errorResponse);
+    }
+
+    /**
+     * DB unique 제약 위반(race condition 등)을 handling합니다.
+     */
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    protected ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        log.warn(">>> handle: DataIntegrityViolationException - {}", e.getMessage());
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.CONFLICT);
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
     }
 
     /**


### PR DESCRIPTION
## 관련 이슈
- Closes #245 [H-5] username 중복 체크 race condition → HTTP 500
- Closes #248 [H-8] SaveRequestRequestDTO 핵심 필드 validation 누락

## 변경 사항

### [H-5] GlobalExceptionHandler.java — DataIntegrityViolationException 핸들러 추가
동시 요청으로 인한 DB unique 제약 위반 시 HTTP 500 대신 409 CONFLICT를 반환합니다.

```java
@ExceptionHandler(DataIntegrityViolationException.class)
protected ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(...) {
    return ResponseEntity.status(HttpStatus.CONFLICT).body(ErrorResponse.of(ErrorCode.CONFLICT));
}
```

### [H-8] SaveRequestRequestDTO.java — validation 어노테이션 추가

| 필드 | 추가된 어노테이션 | 이유 |
|------|----------------|------|
| `volumeSizeGiB` | `@NotNull`, `@Positive` | null/0/음수 시 PVC API 오류 방지 |
| `usagePurpose` | `@NotBlank` | null 시 DB constraint violation 방지 |
| `expiresAt` | `@NotNull`, `@Future` | null 또는 과거 날짜 차단 |

## 테스트
- 기존 테스트 전체 통과 확인 (`./gradlew test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)