### PR TITLE
fix: Slack 큐 메시지 전송 실패 시 retry 메커니즘 추가

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/dto/SlackMessageDto.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/dto/SlackMessageDto.java
@@ -18,8 +18,8 @@ public class SlackMessageDto implements Serializable {
         DM       // 사용자 개인 DM
     }
 
-    private MessageType type;   // 메시지 타입 구분
-    private String message;     // 보낼 메시지 내용
+    private MessageType type;
+    private String message;
 
     // Webhook용 필드
     private String webhookUrl;
@@ -27,4 +27,11 @@ public class SlackMessageDto implements Serializable {
     // DM용 필드
     private String username;
     private String email;
+
+    @Builder.Default
+    private int retryCount = 0;
+
+    public void incrementRetryCount() {
+        this.retryCount++;
+    }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/SlackNotificationWorker.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/SlackNotificationWorker.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 /**
  * Consumer / Worker
  * Redis 큐에 쌓인 알림 요청을 하나씩 꺼내서 실제로 처리하는 Consumer입니다.
+ * 전송 실패 시 최대 MAX_RETRY_COUNT회 재시도합니다.
  */
 @Component
 @RequiredArgsConstructor
@@ -24,15 +25,22 @@ public class SlackNotificationWorker {
     private final ObjectMapper objectMapper;
 
     private static final String SLACK_QUEUE_KEY = "slack:notification:queue";
+    private static final int MAX_RETRY_COUNT = 3;
 
     @Scheduled(fixedDelay = 1000)
     public void processSlackQueue() {
+        Object messageObj = redisTemplate.opsForList().leftPop(SLACK_QUEUE_KEY);
+        if (messageObj == null) return;
+
+        SlackMessageDto dto;
         try {
-            Object messageObj = redisTemplate.opsForList().leftPop(SLACK_QUEUE_KEY);
-            if (messageObj == null) return;
+            dto = objectMapper.convertValue(messageObj, SlackMessageDto.class);
+        } catch (Exception e) {
+            log.error("Slack 큐 메시지 역직렬화 실패 (폐기): {}", e.getMessage());
+            return;
+        }
 
-            SlackMessageDto dto = objectMapper.convertValue(messageObj, SlackMessageDto.class);
-
+        try {
             if (dto.getType() == SlackMessageDto.MessageType.WEBHOOK) {
                 slackApiService.sendWebhook(dto.getWebhookUrl(), dto.getMessage());
                 log.info("Slack Webhook 전송 성공 (Queue)");
@@ -43,10 +51,23 @@ public class SlackNotificationWorker {
             }
 
         } catch (BusinessException e) {
-            log.warn("Slack 알림 처리 실패 (Business): {}", e.getMessage());
+            // 비즈니스 예외(유저 없음 등)는 재시도해도 동일하게 실패하므로 바로 폐기
+            log.warn("Slack 알림 처리 실패 (Business, 폐기): {}", e.getMessage());
 
         } catch (Exception e) {
-            log.error("Slack 큐 처리 중 시스템 오류 (재시도 필요 시 큐 복귀 고려)", e);
+            // 일시적 장애(네트워크, Slack API 다운 등)는 재시도
+            requeue(dto, e);
+        }
+    }
+
+    private void requeue(SlackMessageDto dto, Exception cause) {
+        if (dto.getRetryCount() < MAX_RETRY_COUNT) {
+            dto.incrementRetryCount();
+            redisTemplate.opsForList().rightPush(SLACK_QUEUE_KEY, dto);
+            log.warn("Slack 메시지 재시도 예약 ({}/{}회): {}", dto.getRetryCount(), MAX_RETRY_COUNT, cause.getMessage());
+        } else {
+            log.error("Slack 메시지 최대 재시도({}) 초과, 폐기: {} | 원인: {}",
+                    MAX_RETRY_COUNT, dto.getMessage(), cause.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈
- Closes #249 [H-10] Slack 큐 메시지 처리 실패 시 유실

## 변경 사항

### SlackMessageDto.java — retryCount 필드 추가
Jackson 직렬화/역직렬화에 대응하여 재시도 횟수를 메시지에 포함시킵니다.

```java
@Builder.Default
private int retryCount = 0;

public void incrementRetryCount() { this.retryCount++; }
```

### SlackNotificationWorker.java — retry 로직 추가
전송 실패 유형에 따라 재시도 여부를 결정합니다.

| 실패 유형 | 처리 방식 |
|---------|----------|
| 일시적 오류 (네트워크, Slack 다운 등) | 큐에 재삽입, 최대 3회 재시도 |
| `BusinessException` (유저 없음 등 영구 실패) | 즉시 폐기 |
| 역직렬화 실패 | 즉시 폐기 (큐 blocking 방지) |
| 최대 재시도 초과 | 에러 로그 후 폐기 |

> **JVM crash 시나리오**: leftPop 후 JVM이 죽으면 메시지는 여전히 유실됩니다.
> 완전한 at-least-once 보장을 위해서는 Redis의 LMOVE + processing list 패턴이 필요하나,
> 현재는 Slack 일시 장애 케이스(가장 빈번한 실패 원인)에 대한 retry를 우선 적용합니다.

## 테스트
- 기존 테스트 전체 통과 확인 (`./gradlew test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)