### PR TITLE
fix: 만료 요청 삭제 시 Pod 정리 선처리 및 컨테이너 응답에 Pod/노드 정보 추가

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/ContainerInfoDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/ContainerInfoDTO.java
@@ -16,6 +16,10 @@ public record ContainerInfoDTO(
         String userName,
         @Schema(description = "Ubuntu 사용자명", example = "test2014")
         String ubuntuUsername,
+        @Schema(description = "Pod 이름", example = "pod-test2014-mock")
+        String podName,
+        @Schema(description = "배포된 노드명", example = "farm1")
+        String nodeName,
         @Schema(description = "Ubuntu GID 목록", example = "[1005, 1006]")
         List<Long> ubuntuGids,
         @Schema(description = "리소스 그룹 ID", example = "1")
@@ -32,6 +36,8 @@ public record ContainerInfoDTO(
                 .userId(request.getUser().getUserId())
                 .userName(request.getUser().getName())
                 .ubuntuUsername(request.getUbuntuUsername())
+                .podName(request.getPodName())
+                .nodeName(request.getNodeName())
                 .ubuntuGids(
                         request.getRequestGroups().stream()
                                 .map(rg -> rg.getGroup().getUbuntuGid())

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestExpiryService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestExpiryService.java
@@ -20,6 +20,7 @@ public class RequestExpiryService {
 
     private final RequestRepository requestRepository;
     private final UbuntuAccountService ubuntuAccountService;
+    private final PodService podService;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
@@ -33,6 +34,7 @@ public class RequestExpiryService {
         String ubuntuUsername = request.getUbuntuUsername();
         User user = request.getUser();
 
+        podService.deletePod(request.getPodName());
         ubuntuAccountService.deleteUbuntuAccount(ubuntuUsername);
 
         request.delete();


### PR DESCRIPTION
## 🌱 관련 이슈
- 없음 (wiki known-issue `T-KI-01` — 만료 시 Pod/NodePort 누수)

## 🌱 작업 사항
- 만료 요청 삭제 처리에서 계정 삭제 전에 `podService.deletePod`를 먼저 호출하도록 수정했습니다. 만료 시 Pod/NodePort가 남는 문제(T-KI-01) 방지용 정리 순서 보강입니다.
- `ContainerInfoDTO`에 `podName`, `nodeName`을 추가해 `/api/admin/requests/containers` 응답으로 노출했습니다. 관리자 화면(DECS 콘솔)에서 컨테이너의 배정 노드를 표시하기 위함입니다.

## 🌱 참고 사항
- `PodService.deletePod`는 404를 정상 처리하므로 이미 삭제된 Pod에 대해서도 안전합니다.
- admin_fe의 DECS 콘솔 노드 표시(feat/decs-console-live)와 짝을 이루는 변경입니다. admin_be를 먼저 배포하는 것을 권장하지만, FE는 `nodeName`이 없어도 `—`로 표시하므로 순서가 뒤집혀도 화면은 깨지지 않습니다.
- 테스트: `./gradlew test` 기준 신규 실패 0 (기존 `RequestSchedulerServiceTest`/`UserSchedulerServiceTest` 2건은 `slack.bot-token` 미설정 환경 이슈로 이 변경과 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
