### PR TITLE
docs: 활성 컨테이너 목록 Swagger 응답 스키마 명시

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/AdminRequestApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/controller/docs/AdminRequestApi.java
@@ -2,6 +2,7 @@ package DGU_AI_LAB.admin_be.domain.requests.controller.docs;
 
 import DGU_AI_LAB.admin_be.domain.requests.dto.request.ApproveRequestDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.request.RejectRequestDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.ContainerInfoDTO;
 import DGU_AI_LAB.admin_be.error.dto.ErrorResponse;
 import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+
+import java.util.List;
 
 @Tag(name = "1. 관리자 서버 사용 신청 관리", description = "서버 신규 신청 조회 및 승인/거절 API")
 public interface AdminRequestApi {
@@ -46,9 +49,13 @@ public interface AdminRequestApi {
     @Operation(summary = "모든 활성 컨테이너 조회", description = "현재 활성화된 모든 컨테이너 정보를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공",
-                    content = @Content(schema = @Schema(implementation = SuccessResponse.class)))
+                    content = @Content(schema = @Schema(implementation = ContainerListResponseDoc.class)))
     })
     ResponseEntity<SuccessResponse<?>> getAllActiveContainers();
+
+    // Swagger 문서 전용 스키마: SuccessResponse<?> 와일드카드라 data 타입이 추론되지 않아 명시한다. 런타임 미사용.
+    @Schema(name = "SuccessResponseListContainerInfoDTO", description = "활성 컨테이너 목록 응답")
+    record ContainerListResponseDoc(int status, String message, List<ContainerInfoDTO> data) {}
 
     @Operation(summary = "사용 신청 승인", description = "PENDING 상태의 사용 신청을 승인합니다.")
     @ApiResponses({


### PR DESCRIPTION
## 🌱 관련 이슈
- 없음

## 🌱 작업 사항
- `GET /api/admin/requests/containers`의 Swagger 응답이 generic `SuccessResponse{status,message,data}`로만 노출되던 것을 수정했습니다.
- docs 전용 record(`SuccessResponseListContainerInfoDTO`)를 선언해 `data: ContainerInfoDTO[]`(podName/nodeName 포함) 스키마가 문서에 등록되게 했습니다. 런타임 코드 무변경.

## 🌱 참고 사항
- 원인: `SuccessResponse.ok()`이 `ResponseEntity<SuccessResponse<?>>` 와일드카드를 반환해 springdoc이 data 타입을 추론하지 못함. 반환 타입 전면 구체화는 전 컨트롤러 파급이라 문서 전용 스키마로 최소 처리했습니다. 같은 패턴의 다른 엔드포인트도 필요해지면 동일 방식으로 추가하면 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)