### PR TITLE
[C-3] Pod 생성 API 빈 응답 시 NPE 방지 및 보상 트랜잭션 보장

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/PodService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/PodService.java
@@ -48,7 +48,11 @@ public class PodService {
                     .bodyToMono(CreatePodResponseDTO.class)
                     .block();
 
-            log.info("Pod 생성 API 요청 성공: 사용자: {}, pod: {}", username, response != null ? response.podName() : "null");
+            if (response == null || response.podName() == null) {
+                log.error("Pod 생성 API가 빈 응답을 반환했습니다. 사용자: {}", username);
+                throw new BusinessException(ErrorCode.POD_CREATION_FAILED);
+            }
+            log.info("Pod 생성 API 요청 성공: 사용자: {}, pod: {}", username, response.podName());
             return response;
 
         } catch (BusinessException e) {

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandServiceTest.java
@@ -18,9 +18,13 @@ import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
 import DGU_AI_LAB.admin_be.domain.resourceGroups.repository.ResourceGroupRepository;
 import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
+import DGU_AI_LAB.admin_be.domain.requests.dto.request.RejectRequestDTO;
+import DGU_AI_LAB.admin_be.error.ErrorCode;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -36,6 +40,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -216,5 +221,225 @@ class AdminRequestCommandServiceTest {
 
         // Then - PodService.createPod()가 username으로 정확히 1회 호출
         verify(podService, times(1)).createPod("testuser");
+    }
+
+    // ── C-3: Pod 생성 null 응답 / NPE 보상 트랜잭션 테스트 ─────────────────
+
+    @Nested
+    @DisplayName("C-3: Pod 생성 실패 시 보상 트랜잭션")
+    class PodCreationFailureCompensation {
+
+        @Test
+        @DisplayName("createPod()가 BusinessException을 던지면 Ubuntu 계정 삭제가 호출된다")
+        void approveRequest_podThrowsBusinessException_compensatesWithAccountDeletion() {
+            // Given
+            Long requestId = 10L;
+            buildMockedRequest(requestId);
+            stubWebClientPut();
+
+            when(podService.createPod("testuser"))
+                    .thenThrow(new BusinessException(ErrorCode.POD_CREATION_FAILED));
+
+            ApproveRequestDTO dto = new ApproveRequestDTO(requestId, 1L, 1, 10L, "승인");
+
+            // When & Then
+            assertThatThrownBy(() -> service.approveRequest(dto))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.POD_CREATION_FAILED);
+
+            // Ubuntu 계정 보상 삭제가 반드시 호출되어야 함
+            verify(ubuntuAccountService).deleteUbuntuAccount("testuser");
+        }
+
+        @Test
+        @DisplayName("createPod()가 null을 반환하면 BusinessException이 발생하고 Ubuntu 계정이 삭제된다")
+        void approveRequest_podReturnsNull_throwsAndCompensates() {
+            // Given
+            Long requestId = 11L;
+            buildMockedRequest(requestId);
+            stubWebClientPut();
+
+            // PodService가 null을 반환하면 내부에서 BusinessException을 던져야 함 (수정 후 동작)
+            when(podService.createPod("testuser"))
+                    .thenThrow(new BusinessException(ErrorCode.POD_CREATION_FAILED));
+
+            ApproveRequestDTO dto = new ApproveRequestDTO(requestId, 1L, 1, 10L, "승인");
+
+            // When & Then
+            assertThatThrownBy(() -> service.approveRequest(dto))
+                    .isInstanceOf(BusinessException.class);
+
+            // 보상 트랜잭션이 동작해야 함
+            verify(ubuntuAccountService).deleteUbuntuAccount("testuser");
+            // DB 상태 변경(assignPodInfo 등)은 실행되지 않아야 함
+            verify(containerImageRepository, never()).findById(any());
+        }
+
+        @Test
+        @DisplayName("createPod() 실패 시 보상 Ubuntu 계정 삭제 자체가 실패해도 원래 예외가 전파된다")
+        void approveRequest_podFails_compensationAlsoFails_originalExceptionPropagates() {
+            // Given
+            Long requestId = 12L;
+            buildMockedRequest(requestId);
+            stubWebClientPut();
+
+            when(podService.createPod("testuser"))
+                    .thenThrow(new BusinessException(ErrorCode.POD_CREATION_FAILED));
+            doThrow(new RuntimeException("계정 삭제 실패"))
+                    .when(ubuntuAccountService).deleteUbuntuAccount("testuser");
+
+            ApproveRequestDTO dto = new ApproveRequestDTO(requestId, 1L, 1, 10L, "승인");
+
+            // When & Then - 보상 실패해도 원래 예외(POD_CREATION_FAILED)가 전파되어야 함
+            assertThatThrownBy(() -> service.approveRequest(dto))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.POD_CREATION_FAILED);
+        }
+
+        @Test
+        @DisplayName("createPod() 정상 응답이면 보상 트랜잭션은 실행되지 않는다")
+        void approveRequest_podSucceeds_noCompensation() {
+            // Given
+            Long requestId = 13L;
+            buildMockedRequest(requestId);
+            stubWebClientPut();
+
+            CreatePodResponseDTO podResponse = new CreatePodResponseDTO(
+                    "running", "farm1", "pod-testuser-ok", List.of()
+            );
+            when(podService.createPod("testuser")).thenReturn(podResponse);
+            when(containerImageRepository.findById(1L)).thenReturn(Optional.of(mockImage));
+            when(resourceGroupRepository.findById(1)).thenReturn(Optional.of(mockRg));
+
+            ApproveRequestDTO dto = new ApproveRequestDTO(requestId, 1L, 1, 10L, "승인");
+
+            // When
+            service.approveRequest(dto);
+
+            // Then - 보상 트랜잭션 미실행
+            verify(ubuntuAccountService, never()).deleteUbuntuAccount(any());
+            verify(podService, never()).deletePod(any());
+        }
+
+        @Test
+        @DisplayName("PENDING 상태가 아닌 요청 승인 시 BusinessException 발생")
+        void approveRequest_nonPendingStatus_throwsBusinessException() {
+            // Given
+            Long requestId = 14L;
+            Request request = mock(Request.class);
+            when(request.getStatus()).thenReturn(Status.FULFILLED);
+            when(requestRepository.findById(requestId)).thenReturn(Optional.of(request));
+
+            ApproveRequestDTO dto = new ApproveRequestDTO(requestId, 1L, 1, 10L, "승인");
+
+            // When & Then
+            assertThatThrownBy(() -> service.approveRequest(dto))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_REQUEST_STATUS);
+
+            // Pod 생성, Ubuntu 계정 생성 모두 호출되지 않아야 함
+            verify(podService, never()).createPod(any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 requestId 승인 시 BusinessException 발생")
+        void approveRequest_requestNotFound_throwsBusinessException() {
+            // Given
+            when(requestRepository.findById(999L)).thenReturn(Optional.empty());
+
+            ApproveRequestDTO dto = new ApproveRequestDTO(999L, 1L, 1, 10L, "승인");
+
+            // When & Then
+            assertThatThrownBy(() -> service.approveRequest(dto))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+        }
+    }
+
+    // ── rejectRequest 테스트 ───────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("rejectRequest 기본 동작")
+    class RejectRequest {
+
+        /** rejectRequest용 Request mock — fromEntity()가 요구하는 필드를 모두 스텁 */
+        private Request buildRejectableMock(Long requestId, Status status) {
+            Request request = mock(Request.class);
+            when(request.getStatus()).thenReturn(status);
+            when(request.getResourceGroup()).thenReturn(mockRg);
+            when(request.getUser()).thenReturn(mockUser);
+            when(request.getContainerImage()).thenReturn(mockImage);
+            when(request.getRequestGroups()).thenReturn(new LinkedHashSet<>());
+            when(requestRepository.findById(requestId)).thenReturn(Optional.of(request));
+
+            when(mockRg.getRsgroupId()).thenReturn(1);
+            when(mockUser.getName()).thenReturn("테스트유저");
+            when(mockImage.getImageId()).thenReturn(1L);
+            return request;
+        }
+
+        @Test
+        @DisplayName("PENDING 상태 요청 거절 시 reject()가 호출된다")
+        void rejectRequest_pendingStatus_callsReject() {
+            // Given
+            Long requestId = 20L;
+            Request request = buildRejectableMock(requestId, Status.PENDING);
+            RejectRequestDTO dto = new RejectRequestDTO(requestId, "부적절한 신청");
+
+            // When
+            service.rejectRequest(dto);
+
+            // Then
+            verify(request).reject("부적절한 신청");
+        }
+
+        @Test
+        @DisplayName("FULFILLED 상태 요청도 거절 가능하다")
+        void rejectRequest_fulfilledStatus_callsReject() {
+            // Given
+            Long requestId = 21L;
+            Request request = buildRejectableMock(requestId, Status.FULFILLED);
+            RejectRequestDTO dto = new RejectRequestDTO(requestId, "관리자 거절");
+
+            // When
+            service.rejectRequest(dto);
+
+            // Then
+            verify(request).reject("관리자 거절");
+        }
+
+        @Test
+        @DisplayName("DENIED 상태 요청 거절 시 BusinessException 발생")
+        void rejectRequest_alreadyDenied_throwsBusinessException() {
+            // Given
+            Long requestId = 22L;
+            buildRejectableMock(requestId, Status.DENIED);
+            RejectRequestDTO dto = new RejectRequestDTO(requestId, "재거절 시도");
+
+            // When & Then
+            assertThatThrownBy(() -> service.rejectRequest(dto))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_REQUEST_STATUS);
+        }
+
+        @Test
+        @DisplayName("DELETED 상태 요청 거절 시 BusinessException 발생")
+        void rejectRequest_deletedStatus_throwsBusinessException() {
+            // Given
+            Long requestId = 23L;
+            buildRejectableMock(requestId, Status.DELETED);
+            RejectRequestDTO dto = new RejectRequestDTO(requestId, "삭제된 요청 거절 시도");
+
+            // When & Then
+            assertThatThrownBy(() -> service.rejectRequest(dto))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_REQUEST_STATUS);
+        }
     }
 }

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/PodServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/PodServiceTest.java
@@ -1,0 +1,170 @@
+package DGU_AI_LAB.admin_be.domain.requests.service;
+
+import DGU_AI_LAB.admin_be.domain.requests.dto.request.CreatePodRequestDTO;
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.CreatePodResponseDTO;
+import DGU_AI_LAB.admin_be.error.ErrorCode;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PodServiceTest {
+
+    @Mock private WebClient webClient;
+    @Mock private WebClient.RequestBodyUriSpec postUriSpec;
+    @Mock private WebClient.RequestBodySpec postBodySpec;
+    @Mock private WebClient.RequestHeadersSpec<?> postHeadersSpec;
+    @Mock private WebClient.ResponseSpec postResponseSpec;
+
+    private PodService podService;
+
+    @BeforeEach
+    void setUp() {
+        podService = new PodService(webClient);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubWebClientPost(Mono<?> responseMono) {
+        when(webClient.post()).thenReturn(postUriSpec);
+        when(postUriSpec.uri(anyString())).thenReturn(postBodySpec);
+        doReturn(postHeadersSpec).when(postBodySpec).bodyValue(any());
+        when(postHeadersSpec.retrieve()).thenReturn(postResponseSpec);
+        when(postResponseSpec.onStatus(any(), any())).thenReturn(postResponseSpec);
+        doReturn(responseMono).when(postResponseSpec).bodyToMono(CreatePodResponseDTO.class);
+    }
+
+    @Nested
+    @DisplayName("createPod 정상 케이스")
+    class CreatePodSuccess {
+
+        @Test
+        @DisplayName("정상 응답이면 CreatePodResponseDTO를 반환한다")
+        void createPod_validResponse_returnsDto() {
+            // Given
+            CreatePodResponseDTO expected = new CreatePodResponseDTO(
+                    "running", "farm1", "pod-alice-abc",
+                    List.of(new CreatePodResponseDTO.PortInfo("ssh", 22, 30022))
+            );
+            stubWebClientPost(Mono.just(expected));
+
+            // When
+            CreatePodResponseDTO result = podService.createPod("alice");
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.podName()).isEqualTo("pod-alice-abc");
+            assertThat(result.node()).isEqualTo("farm1");
+            assertThat(result.ports()).hasSize(1);
+            assertThat(result.ports().get(0).usagePurpose()).isEqualTo("ssh");
+        }
+
+        @Test
+        @DisplayName("포트가 없는 정상 응답도 정상 처리된다")
+        void createPod_noPortsInResponse_returnsDto() {
+            // Given
+            CreatePodResponseDTO expected = new CreatePodResponseDTO(
+                    "running", "lab1", "pod-bob-xyz", List.of()
+            );
+            stubWebClientPost(Mono.just(expected));
+
+            // When
+            CreatePodResponseDTO result = podService.createPod("bob");
+
+            // Then
+            assertThat(result.podName()).isEqualTo("pod-bob-xyz");
+            assertThat(result.ports()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("C-3: createPod null/빈 응답 처리")
+    class CreatePodNullResponse {
+
+        @Test
+        @DisplayName("외부 API가 null을 반환하면 POD_CREATION_FAILED 예외가 발생한다")
+        void createPod_nullResponse_throwsBusinessException() {
+            // Given - bodyToMono가 null을 반환하는 경우 (빈 응답 바디)
+            stubWebClientPost(Mono.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> podService.createPod("charlie"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.POD_CREATION_FAILED);
+        }
+
+        @Test
+        @DisplayName("podName이 null인 응답도 POD_CREATION_FAILED 예외가 발생한다")
+        void createPod_responsePodNameNull_throwsBusinessException() {
+            // Given - podName 필드가 null인 응답
+            CreatePodResponseDTO badResponse = new CreatePodResponseDTO(
+                    "unknown", "farm1", null, List.of()
+            );
+            stubWebClientPost(Mono.just(badResponse));
+
+            // When & Then
+            assertThatThrownBy(() -> podService.createPod("dave"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.POD_CREATION_FAILED);
+        }
+    }
+
+    @Nested
+    @DisplayName("createPod 외부 API 오류 처리")
+    class CreatePodApiError {
+
+        @Test
+        @DisplayName("BusinessException이 발생하면 그대로 재전파된다")
+        void createPod_businessException_rethrows() {
+            // Given
+            when(webClient.post()).thenReturn(postUriSpec);
+            when(postUriSpec.uri(anyString())).thenReturn(postBodySpec);
+            doReturn(postHeadersSpec).when(postBodySpec).bodyValue(any());
+            when(postHeadersSpec.retrieve()).thenReturn(postResponseSpec);
+            when(postResponseSpec.onStatus(any(), any())).thenReturn(postResponseSpec);
+            doReturn(Mono.error(new BusinessException(ErrorCode.POD_CREATION_FAILED)))
+                    .when(postResponseSpec).bodyToMono(CreatePodResponseDTO.class);
+
+            // When & Then
+            assertThatThrownBy(() -> podService.createPod("eve"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.POD_CREATION_FAILED);
+        }
+
+        @Test
+        @DisplayName("예상치 못한 RuntimeException은 POD_CREATION_FAILED로 래핑된다")
+        void createPod_unexpectedRuntimeException_wrapsToBusinessException() {
+            // Given
+            when(webClient.post()).thenReturn(postUriSpec);
+            when(postUriSpec.uri(anyString())).thenReturn(postBodySpec);
+            doReturn(postHeadersSpec).when(postBodySpec).bodyValue(any());
+            when(postHeadersSpec.retrieve()).thenReturn(postResponseSpec);
+            when(postResponseSpec.onStatus(any(), any())).thenReturn(postResponseSpec);
+            doReturn(Mono.error(new RuntimeException("네트워크 오류")))
+                    .when(postResponseSpec).bodyToMono(CreatePodResponseDTO.class);
+
+            // When & Then
+            assertThatThrownBy(() -> podService.createPod("frank"))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.POD_CREATION_FAILED);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `PodService.createPod()`가 null 또는 podName이 null인 응답을 반환할 때 즉시 `BusinessException(POD_CREATION_FAILED)`을 던지도록 수정
- 이로써 `AdminRequestCommandService`의 보상 트랜잭션(`tryCompensateDeleteUser`)이 항상 정상 실행되어 Ubuntu 계정 누수 방지
- `PodServiceTest` 신규 추가, `AdminRequestCommandServiceTest`에 C-3 관련 케이스 및 rejectRequest 경계 케이스 추가

## Test plan

- [ ] `PodServiceTest` — null 응답, podName null 응답, 정상 응답, RuntimeException 래핑 검증
- [ ] `AdminRequestCommandServiceTest` — Pod 실패 시 보상 삭제 호출 확인, 보상 자체 실패 시 원래 예외 전파 확인
- [ ] `./gradlew test --tests "*.PodServiceTest" --tests "*.AdminRequestCommandServiceTest"` 전체 통과 확인

Closes #260