### PR TITLE
[H-9] Actuator health 상세 정보 미인증 노출 차단

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 
 	//spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 
 	// Actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/src/test/java/DGU_AI_LAB/admin_be/global/actuator/ActuatorHealthSecurityTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/global/actuator/ActuatorHealthSecurityTest.java
@@ -1,0 +1,80 @@
+package DGU_AI_LAB.admin_be.global.actuator;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * H-9: Actuator health show-details: when_authorized 검증
+ *
+ * 테스트 환경에서는 Redis/DB가 완전히 기동되지 않으므로 status는 DOWN(503)이 될 수 있음.
+ * 중요한 것은 HTTP 상태 코드가 아니라, 미인증 요청에서 components(상세 정보)가 노출되지 않는 것.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "management.endpoints.web.exposure.include=health",
+        "management.endpoint.health.show-details=when_authorized"
+})
+class ActuatorHealthSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Nested
+    @DisplayName("미인증 요청 — 상세 정보 미노출")
+    class Unauthenticated {
+
+        @Test
+        @DisplayName("미인증 상태에서 /actuator/health는 status 필드만 반환한다")
+        void health_unauthenticated_returnsStatusOnly() throws Exception {
+            mockMvc.perform(get("/actuator/health"))
+                    .andExpect(jsonPath("$.status").exists())
+                    .andExpect(jsonPath("$.components").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("미인증 상태에서 DB 연결 정보(components.db)가 응답에 포함되지 않는다")
+        void health_unauthenticated_doesNotExposeDatasource() throws Exception {
+            mockMvc.perform(get("/actuator/health"))
+                    .andExpect(jsonPath("$.components.db").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("미인증 상태에서 Redis 정보(components.redis)가 응답에 포함되지 않는다")
+        void health_unauthenticated_doesNotExposeRedis() throws Exception {
+            mockMvc.perform(get("/actuator/health"))
+                    .andExpect(jsonPath("$.components.redis").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("미인증 상태에서 diskSpace 정보가 응답에 포함되지 않는다")
+        void health_unauthenticated_doesNotExposeDiskSpace() throws Exception {
+            mockMvc.perform(get("/actuator/health"))
+                    .andExpect(jsonPath("$.components.diskSpace").doesNotExist());
+        }
+    }
+
+    @Nested
+    @DisplayName("ADMIN 인증 요청 — 상세 정보 포함")
+    class AuthenticatedAdmin {
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("ADMIN 인증 시 /actuator/health에서 components(상세 정보)가 포함된다")
+        void health_authenticatedAdmin_returnsComponents() throws Exception {
+            mockMvc.perform(get("/actuator/health"))
+                    .andExpect(jsonPath("$.status").exists())
+                    .andExpect(jsonPath("$.components").exists());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Actuator `/actuator/health` 엔드포인트가 미인증 상태에서 DB 연결 정보, Redis 상태, diskSpace 등 내부 인프라 정보를 노출하는 문제를 수정
- `application.yml`: `show-details: always` → `when_authorized` (git 미추적 파일, 운영 ConfigMap 별도 적용 필요)
- `build.gradle`: `spring-security-test` 의존성 추가
- `ActuatorHealthSecurityTest` 신규 추가
- `test/application.yml`: 누락된 `slack-webhook-url.error-log`, `slack-webhook-url.noti` 프로퍼티 추가 (SpringBootTest 컨텍스트 로딩 오류 해결)

## 운영 환경 적용

`application.yml`은 git 미추적 파일이므로 K8s ConfigMap 또는 환경 변수로 별도 적용:
```
MANAGEMENT_ENDPOINT_HEALTH_SHOW-DETAILS=when_authorized
```

## Test plan

- [ ] `ActuatorHealthSecurityTest` — 미인증 시 `components` 미포함 4개 케이스 통과 확인
- [ ] `ActuatorHealthSecurityTest` — `@WithMockUser(roles = "ADMIN")` 시 `components` 포함 확인
- [ ] `./gradlew test --tests "*.ActuatorHealthSecurityTest"` 전체 통과 확인

Closes #262