### PR TITLE
[M-5] 토큰 재발급 시 액세스 토큰 서명 검증 누락 수정

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/TokenService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/TokenService.java
@@ -2,9 +2,7 @@ package DGU_AI_LAB.admin_be.domain.users.service;
 
 import DGU_AI_LAB.admin_be.domain.users.dto.request.UserTokenRequestDTO;
 import DGU_AI_LAB.admin_be.domain.users.dto.response.UserTokenResponseDTO;
-import DGU_AI_LAB.admin_be.error.exception.UnauthorizedException;
 import DGU_AI_LAB.admin_be.global.auth.jwt.JwtProvider;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -12,8 +10,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.concurrent.TimeUnit;
-
-import static DGU_AI_LAB.admin_be.error.ErrorCode.JSON_PARSING_FAILED;
 
 @Service
 @Transactional(readOnly = true)
@@ -55,12 +51,7 @@ public class TokenService {
     }
 
     public UserTokenResponseDTO reissue(UserTokenRequestDTO userTokenRequest) {
-        Long userId;
-        try {
-            userId = Long.valueOf(jwtProvider.decodeJwtPayloadSubject(userTokenRequest.accessToken()));
-        } catch (JsonProcessingException e) {
-            throw new UnauthorizedException(JSON_PARSING_FAILED);
-        }
+        Long userId = jwtProvider.getSubjectFromExpiredToken(userTokenRequest.accessToken());
 
         String refreshToken = userTokenRequest.refreshToken();
         String redisKey = "RT:" + userId;

--- a/src/main/java/DGU_AI_LAB/admin_be/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/global/auth/jwt/JwtProvider.java
@@ -2,19 +2,15 @@ package DGU_AI_LAB.admin_be.global.auth.jwt;
 
 import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.UnauthorizedException;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
-import java.util.Map;
 
 @Getter
 @Component
@@ -25,8 +21,6 @@ public class JwtProvider {
     private long ACCESS_TOKEN_EXPIRE_TIME;
     @Value("${jwt.refresh-token-expire-time}")
     private long REFRESH_TOKEN_EXPIRE_TIME;
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public String getIssueToken(Long userId, boolean isAccessToken) {
         if (isAccessToken) return generateToken(userId, ACCESS_TOKEN_EXPIRE_TIME);
@@ -89,11 +83,15 @@ public class JwtProvider {
     }
 
 
-    public String decodeJwtPayloadSubject(String oldAccessToken) throws JsonProcessingException {
-        return objectMapper.readValue(
-                new String(Base64.getDecoder().decode(oldAccessToken.split("\\.")[1]), StandardCharsets.UTF_8),
-                Map.class
-        ).get("sub").toString();
+    public Long getSubjectFromExpiredToken(String token) {
+        try {
+            return Long.valueOf(getJwtParser().parseClaimsJws(token).getBody().getSubject());
+        } catch (ExpiredJwtException e) {
+            // Token is expired but signature is valid — extract subject safely
+            return Long.valueOf(e.getClaims().getSubject());
+        } catch (Exception e) {
+            throw new UnauthorizedException(ErrorCode.INVALID_ACCESS_TOKEN_VALUE);
+        }
     }
 
 }

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/TokenServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/TokenServiceTest.java
@@ -4,7 +4,6 @@ import DGU_AI_LAB.admin_be.domain.users.dto.request.UserTokenRequestDTO;
 import DGU_AI_LAB.admin_be.domain.users.dto.response.UserTokenResponseDTO;
 import DGU_AI_LAB.admin_be.error.exception.UnauthorizedException;
 import DGU_AI_LAB.admin_be.global.auth.jwt.JwtProvider;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -93,10 +92,10 @@ class TokenServiceTest {
     class Reissue {
 
         @Test
-        @DisplayName("유효한 리프레시 토큰으로 재발급하면 새 토큰을 반환한다")
-        void reissue_success() throws JsonProcessingException {
+        @DisplayName("만료되었지만 서명이 유효한 액세스 토큰으로 재발급하면 새 토큰을 반환한다")
+        void reissue_success_withExpiredButValidToken() {
             ReflectionTestUtils.setField(tokenService, "REFRESH_TOKEN_EXPIRE_TIME", 604800L);
-            when(jwtProvider.decodeJwtPayloadSubject("accessToken")).thenReturn("1");
+            when(jwtProvider.getSubjectFromExpiredToken("accessToken")).thenReturn(1L);
             when(redisTemplate.opsForValue()).thenReturn(valueOperations);
             when(valueOperations.get("RT:1")).thenReturn("storedRefreshToken");
             doNothing().when(jwtProvider).validateRefreshToken("refreshToken");
@@ -109,6 +108,18 @@ class TokenServiceTest {
 
             assertThat(result.accessToken()).isEqualTo("newAccessToken");
             assertThat(result.refreshToken()).isEqualTo("newRefreshToken");
+        }
+
+        @Test
+        @DisplayName("서명이 위조된 액세스 토큰으로 재발급 시 UnauthorizedException을 던진다")
+        void reissue_throwsUnauthorizedException_whenTokenSignatureTampered() {
+            when(jwtProvider.getSubjectFromExpiredToken("tamperedToken"))
+                    .thenThrow(new UnauthorizedException(DGU_AI_LAB.admin_be.error.ErrorCode.INVALID_ACCESS_TOKEN_VALUE));
+
+            UserTokenRequestDTO dto = new UserTokenRequestDTO("tamperedToken", "refreshToken");
+
+            assertThatThrownBy(() -> tokenService.reissue(dto))
+                    .isInstanceOf(UnauthorizedException.class);
         }
     }
 


### PR DESCRIPTION
## 요약

- `decodeJwtPayloadSubject()`는 서명 검증 없이 Base64 디코딩만 수행하여 userId 위조가 가능했음
- `getSubjectFromExpiredToken()`을 새로 추가하여 서명 검증 후 subject를 추출하도록 수정
- 만료된 토큰의 경우 `ExpiredJwtException`의 claims에서 안전하게 subject를 추출

Closes #264

## 변경 파일

- `JwtProvider.java`: `decodeJwtPayloadSubject()` 제거, `getSubjectFromExpiredToken()` 추가
- `TokenService.java`: `reissue()`에서 새 메서드 사용, 불필요한 `JsonProcessingException` 처리 제거
- `TokenServiceTest.java`: 서명 위조 토큰 거부 케이스 추가

## 테스트 계획

- [x] 만료되었지만 서명이 유효한 토큰으로 재발급 → 성공
- [x] 서명이 위조된 토큰으로 재발급 → `UnauthorizedException` 발생
- [x] 기존 토큰 발급/로그아웃 테스트 통과