### PR TITLE
[L-4] 만료 요청 조회 시 종료 시각을 LocalTime.MAX로 수정

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestSchedulerService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestSchedulerService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
 
@@ -69,7 +70,7 @@ public class RequestSchedulerService {
     @Transactional(readOnly = true)
     public void sendPreExpiryNotification(LocalDateTime targetDate, String dayLabel) {
         LocalDateTime start = targetDate.toLocalDate().atStartOfDay();
-        LocalDateTime end = targetDate.toLocalDate().atTime(23, 59, 59);
+        LocalDateTime end = targetDate.toLocalDate().atTime(LocalTime.MAX);
 
         List<Request> requests = requestRepository.findAllByExpiresAtBetweenAndStatus(start, end, Status.FULFILLED);
 

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestSchedulerServiceEndTimeTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestSchedulerServiceEndTimeTest.java
@@ -1,0 +1,101 @@
+package DGU_AI_LAB.admin_be.domain.scheduler;
+
+import DGU_AI_LAB.admin_be.domain.alarm.service.AlarmService;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import DGU_AI_LAB.admin_be.domain.requests.service.RequestExpiryService;
+import DGU_AI_LAB.admin_be.global.util.MessageUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RequestSchedulerService - 만료 조회 종료 시각 범위 검증")
+class RequestSchedulerServiceEndTimeTest {
+
+    @InjectMocks
+    private RequestSchedulerService schedulerService;
+
+    @Mock
+    private RequestRepository requestRepository;
+
+    @Mock
+    private AlarmService alarmService;
+
+    @Mock
+    private RequestExpiryService requestExpiryService;
+
+    @Mock
+    private MessageUtils messageUtils;
+
+    @Test
+    @DisplayName("종료 시각이 LocalTime.MAX(23:59:59.999999999)로 설정되어야 한다")
+    void sendPreExpiryNotification_endTime_isLocalTimeMax() {
+        LocalDateTime targetDate = LocalDateTime.of(2026, 12, 31, 10, 30, 0);
+        LocalDateTime expectedStart = targetDate.toLocalDate().atStartOfDay();
+        LocalDateTime expectedEnd = targetDate.toLocalDate().atTime(LocalTime.MAX);
+
+        ArgumentCaptor<LocalDateTime> startCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<LocalDateTime> endCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
+
+        when(requestRepository.findAllByExpiresAtBetweenAndStatus(
+                startCaptor.capture(), endCaptor.capture(), statusCaptor.capture()))
+                .thenReturn(Collections.emptyList());
+
+        schedulerService.sendPreExpiryNotification(targetDate, "7일");
+
+        assertThat(endCaptor.getValue()).isEqualTo(expectedEnd);
+        assertThat(endCaptor.getValue().toLocalTime()).isEqualTo(LocalTime.MAX);
+        assertThat(endCaptor.getValue().getNano()).isEqualTo(999_999_999);
+        assertThat(startCaptor.getValue()).isEqualTo(expectedStart);
+    }
+
+    @Test
+    @DisplayName("23:59:59.999 만료 요청이 조회 범위에 포함되어야 한다")
+    void sendPreExpiryNotification_includesRequestExpiringAt_23_59_59_999() {
+        LocalDateTime targetDate = LocalDateTime.of(2026, 12, 31, 10, 30, 0);
+        LocalDateTime expiresAt = LocalDateTime.of(2026, 12, 31, 23, 59, 59, 999_000_000);
+
+        LocalDateTime start = targetDate.toLocalDate().atStartOfDay();
+        LocalDateTime end = targetDate.toLocalDate().atTime(LocalTime.MAX);
+
+        assertThat(expiresAt.isAfter(start) || expiresAt.isEqual(start)).isTrue();
+        assertThat(expiresAt.isBefore(end) || expiresAt.isEqual(end)).isTrue();
+    }
+
+    @Test
+    @DisplayName("23:59:59.000 만료 요청이 조회 범위에 포함되어야 한다")
+    void sendPreExpiryNotification_includesRequestExpiringAt_23_59_59_000() {
+        LocalDateTime targetDate = LocalDateTime.of(2026, 12, 31, 10, 30, 0);
+        LocalDateTime expiresAt = LocalDateTime.of(2026, 12, 31, 23, 59, 59, 0);
+
+        LocalDateTime start = targetDate.toLocalDate().atStartOfDay();
+        LocalDateTime end = targetDate.toLocalDate().atTime(LocalTime.MAX);
+
+        assertThat(expiresAt.isAfter(start) || expiresAt.isEqual(start)).isTrue();
+        assertThat(expiresAt.isBefore(end) || expiresAt.isEqual(end)).isTrue();
+    }
+
+    @Test
+    @DisplayName("다음날 00:00:00 만료 요청은 조회 범위에 포함되지 않아야 한다")
+    void sendPreExpiryNotification_excludesRequestExpiringAt_nextDay_00_00_00() {
+        LocalDateTime targetDate = LocalDateTime.of(2026, 12, 31, 10, 30, 0);
+        LocalDateTime expiresAt = LocalDateTime.of(2027, 1, 1, 0, 0, 0);
+
+        LocalDateTime end = targetDate.toLocalDate().atTime(LocalTime.MAX);
+
+        assertThat(expiresAt.isAfter(end)).isTrue();
+    }
+}


### PR DESCRIPTION
## 관련 이슈

closes #266

## 변경 내용

`RequestSchedulerService.sendPreExpiryNotification()`의 조회 종료 시각 계산 버그 수정.

- `atTime(23, 59, 59)` → `atTime(LocalTime.MAX)` (23:59:59.999999999)
- `import java.time.LocalTime` 추가

## 원인

`atTime(23, 59, 59)`는 나노초가 0인 `23:59:59.000000000`을 생성한다. DB에 저장된 `expiresAt`이 나노초를 포함하는 경우(예: `23:59:59.999`) BETWEEN 쿼리의 상한보다 크므로 알림 대상에서 누락된다.

## 테스트

- `RequestSchedulerServiceEndTimeTest` 신규 추가
  - ArgumentCaptor로 `end` 파라미터가 `LocalTime.MAX`임을 검증
  - 23:59:59.999 타임스탬프가 범위에 포함되는지 검증
  - 23:59:59.000 타임스탬프가 범위에 포함되는지 검증
  - 다음날 00:00:00이 범위에서 제외되는지 검증