### PR TITLE
[M-6] Ubuntu 계정 삭제 요청을 config-server 명세(DELETE /accounts/users)에 맞게 수정

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestSchedulerService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestSchedulerService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
 
@@ -69,7 +70,7 @@ public class RequestSchedulerService {
     @Transactional(readOnly = true)
     public void sendPreExpiryNotification(LocalDateTime targetDate, String dayLabel) {
         LocalDateTime start = targetDate.toLocalDate().atStartOfDay();
-        LocalDateTime end = targetDate.toLocalDate().atTime(23, 59, 59);
+        LocalDateTime end = targetDate.toLocalDate().atTime(LocalTime.MAX);
 
         List<Request> requests = requestRepository.findAllByExpiresAtBetweenAndStatus(start, end, Status.FULFILLED);
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserService.java
@@ -14,10 +14,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -97,8 +97,8 @@ public class AdminUserService {
 
         try {
             log.info("Starting Config Server API call to delete ubuntu account: {}", username);
-            userWebClient.post()
-                    .uri("/accounts/deleteuser/{username}", username)
+            userWebClient.delete()
+                    .uri("/accounts/users/{username}", username)
                     .retrieve()
                     .onStatus(HttpStatus.BAD_REQUEST::equals, clientResponse ->
                             Mono.error(new BusinessException(ErrorCode.INVALID_USERNAME_FORMAT))
@@ -107,7 +107,7 @@ public class AdminUserService {
                         log.warn("외부 서버에 {} 계정이 이미 존재하지 않아 삭제가 불필요합니다.", username);
                         return Mono.empty();
                     })
-                    .onStatus(WebClientResponseException.class::isInstance, clientResponse ->
+                    .onStatus(HttpStatusCode::isError, clientResponse ->
                             clientResponse.bodyToMono(String.class)
                                     .flatMap(body -> Mono.error(new BusinessException("우분투 계정 삭제 실패: " + body, ErrorCode.UBUNTU_USER_DELETION_FAILED)))
                     )

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestSchedulerServiceEndTimeTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestSchedulerServiceEndTimeTest.java
@@ -1,0 +1,101 @@
+package DGU_AI_LAB.admin_be.domain.scheduler;
+
+import DGU_AI_LAB.admin_be.domain.alarm.service.AlarmService;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import DGU_AI_LAB.admin_be.domain.requests.service.RequestExpiryService;
+import DGU_AI_LAB.admin_be.global.util.MessageUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RequestSchedulerService - 만료 조회 종료 시각 범위 검증")
+class RequestSchedulerServiceEndTimeTest {
+
+    @InjectMocks
+    private RequestSchedulerService schedulerService;
+
+    @Mock
+    private RequestRepository requestRepository;
+
+    @Mock
+    private AlarmService alarmService;
+
+    @Mock
+    private RequestExpiryService requestExpiryService;
+
+    @Mock
+    private MessageUtils messageUtils;
+
+    @Test
+    @DisplayName("종료 시각이 LocalTime.MAX(23:59:59.999999999)로 설정되어야 한다")
+    void sendPreExpiryNotification_endTime_isLocalTimeMax() {
+        LocalDateTime targetDate = LocalDateTime.of(2026, 12, 31, 10, 30, 0);
+        LocalDateTime expectedStart = targetDate.toLocalDate().atStartOfDay();
+        LocalDateTime expectedEnd = targetDate.toLocalDate().atTime(LocalTime.MAX);
+
+        ArgumentCaptor<LocalDateTime> startCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<LocalDateTime> endCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<Status> statusCaptor = ArgumentCaptor.forClass(Status.class);
+
+        when(requestRepository.findAllByExpiresAtBetweenAndStatus(
+                startCaptor.capture(), endCaptor.capture(), statusCaptor.capture()))
+                .thenReturn(Collections.emptyList());
+
+        schedulerService.sendPreExpiryNotification(targetDate, "7일");
+
+        assertThat(endCaptor.getValue()).isEqualTo(expectedEnd);
+        assertThat(endCaptor.getValue().toLocalTime()).isEqualTo(LocalTime.MAX);
+        assertThat(endCaptor.getValue().getNano()).isEqualTo(999_999_999);
+        assertThat(startCaptor.getValue()).isEqualTo(expectedStart);
+    }
+
+    @Test
+    @DisplayName("23:59:59.999 만료 요청이 조회 범위에 포함되어야 한다")
+    void sendPreExpiryNotification_includesRequestExpiringAt_23_59_59_999() {
+        LocalDateTime targetDate = LocalDateTime.of(2026, 12, 31, 10, 30, 0);
+        LocalDateTime expiresAt = LocalDateTime.of(2026, 12, 31, 23, 59, 59, 999_000_000);
+
+        LocalDateTime start = targetDate.toLocalDate().atStartOfDay();
+        LocalDateTime end = targetDate.toLocalDate().atTime(LocalTime.MAX);
+
+        assertThat(expiresAt.isAfter(start) || expiresAt.isEqual(start)).isTrue();
+        assertThat(expiresAt.isBefore(end) || expiresAt.isEqual(end)).isTrue();
+    }
+
+    @Test
+    @DisplayName("23:59:59.000 만료 요청이 조회 범위에 포함되어야 한다")
+    void sendPreExpiryNotification_includesRequestExpiringAt_23_59_59_000() {
+        LocalDateTime targetDate = LocalDateTime.of(2026, 12, 31, 10, 30, 0);
+        LocalDateTime expiresAt = LocalDateTime.of(2026, 12, 31, 23, 59, 59, 0);
+
+        LocalDateTime start = targetDate.toLocalDate().atStartOfDay();
+        LocalDateTime end = targetDate.toLocalDate().atTime(LocalTime.MAX);
+
+        assertThat(expiresAt.isAfter(start) || expiresAt.isEqual(start)).isTrue();
+        assertThat(expiresAt.isBefore(end) || expiresAt.isEqual(end)).isTrue();
+    }
+
+    @Test
+    @DisplayName("다음날 00:00:00 만료 요청은 조회 범위에 포함되지 않아야 한다")
+    void sendPreExpiryNotification_excludesRequestExpiringAt_nextDay_00_00_00() {
+        LocalDateTime targetDate = LocalDateTime.of(2026, 12, 31, 10, 30, 0);
+        LocalDateTime expiresAt = LocalDateTime.of(2027, 1, 1, 0, 0, 0);
+
+        LocalDateTime end = targetDate.toLocalDate().atTime(LocalTime.MAX);
+
+        assertThat(expiresAt.isAfter(end)).isTrue();
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserServiceTest.java
@@ -1,11 +1,13 @@
 package DGU_AI_LAB.admin_be.domain.users.service;
 
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
 import DGU_AI_LAB.admin_be.domain.users.dto.request.UserUpdateRequestDTO;
 import DGU_AI_LAB.admin_be.domain.users.dto.response.UserResponseDTO;
 import DGU_AI_LAB.admin_be.domain.users.dto.response.UserSummaryDTO;
 import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import DGU_AI_LAB.admin_be.error.exception.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,16 +17,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AdminUserServiceTest {
 
     @InjectMocks
@@ -38,6 +47,14 @@ class AdminUserServiceTest {
 
     @Mock
     private WebClient userWebClient;
+
+    // WebClient DELETE 체이닝 mock
+    @Mock
+    private WebClient.RequestHeadersUriSpec<?> deleteUriSpec;
+    @Mock
+    private WebClient.RequestHeadersSpec<?> deleteHeadersSpec;
+    @Mock
+    private WebClient.ResponseSpec deleteResponseSpec;
 
     private User mockUser;
 
@@ -135,6 +152,69 @@ class AdminUserServiceTest {
             when(userRepository.findById(99L)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> adminUserService.deleteUser(99L))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteUbuntuAccount")
+    class DeleteUbuntuAccount {
+
+        @SuppressWarnings("unchecked")
+        private void stubDeleteSuccess() {
+            when(userWebClient.delete()).thenReturn((WebClient.RequestHeadersUriSpec) deleteUriSpec);
+            when(deleteUriSpec.uri(anyString(), anyString())).thenReturn((WebClient.RequestHeadersSpec) deleteHeadersSpec);
+            when(deleteHeadersSpec.retrieve()).thenReturn(deleteResponseSpec);
+            when(deleteResponseSpec.onStatus(any(), any())).thenReturn(deleteResponseSpec);
+            when(deleteResponseSpec.toBodilessEntity()).thenReturn(Mono.empty());
+        }
+
+        @Test
+        @DisplayName("DELETE /accounts/users/{username}으로 요청을 전송한다")
+        void deleteUbuntuAccount_sendsDELETERequest() {
+            Request mockRequest = mock(Request.class);
+            when(requestRepository.findByUbuntuUsername("testuser")).thenReturn(Optional.of(mockRequest));
+            stubDeleteSuccess();
+
+            adminUserService.deleteUbuntuAccount("testuser");
+
+            verify(userWebClient).delete();
+            verify(deleteUriSpec).uri("/accounts/users/{username}", "testuser");
+        }
+
+        @Test
+        @DisplayName("config-server가 400을 응답하면 INVALID_USERNAME_FORMAT BusinessException을 던진다")
+        void deleteUbuntuAccount_throws_whenBadRequest() {
+            Request mockRequest = mock(Request.class);
+            when(requestRepository.findByUbuntuUsername("baduser")).thenReturn(Optional.of(mockRequest));
+
+            when(userWebClient.delete()).thenReturn((WebClient.RequestHeadersUriSpec) deleteUriSpec);
+            when(deleteUriSpec.uri(anyString(), anyString())).thenReturn((WebClient.RequestHeadersSpec) deleteHeadersSpec);
+            when(deleteHeadersSpec.retrieve()).thenReturn(deleteResponseSpec);
+            when(deleteResponseSpec.onStatus(any(), any())).thenAnswer(inv -> {
+                java.util.function.Predicate<org.springframework.http.HttpStatusCode> predicate = inv.getArgument(0);
+                if (predicate.test(HttpStatus.BAD_REQUEST)) {
+                    org.springframework.web.reactive.function.client.ClientResponse clientResponse =
+                            mock(org.springframework.web.reactive.function.client.ClientResponse.class);
+                    when(inv.<java.util.function.Function<org.springframework.web.reactive.function.client.ClientResponse, reactor.core.publisher.Mono<? extends Throwable>>>getArgument(1)
+                            .apply(clientResponse))
+                            .thenReturn(Mono.error(new BusinessException(DGU_AI_LAB.admin_be.error.ErrorCode.INVALID_USERNAME_FORMAT)));
+                }
+                return deleteResponseSpec;
+            });
+            when(deleteResponseSpec.toBodilessEntity())
+                    .thenReturn(Mono.error(new BusinessException(DGU_AI_LAB.admin_be.error.ErrorCode.INVALID_USERNAME_FORMAT)));
+
+            assertThatThrownBy(() -> adminUserService.deleteUbuntuAccount("baduser"))
+                    .isInstanceOf(BusinessException.class);
+        }
+
+        @Test
+        @DisplayName("Request가 없으면 EntityNotFoundException을 던진다")
+        void deleteUbuntuAccount_throws_whenRequestNotFound() {
+            when(requestRepository.findByUbuntuUsername("unknown")).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> adminUserService.deleteUbuntuAccount("unknown"))
                     .isInstanceOf(EntityNotFoundException.class);
         }
     }


### PR DESCRIPTION
## 요약

- 기존: `POST /accounts/deleteuser/{username}` → 명세 불일치
- 수정: `DELETE /accounts/users/{username}` → config-server 명세 준수
- `WebClient.delete()`로 변경하여 body 없이 DELETE 요청 전송
- `onStatus` 마지막 조건을 `HttpStatusCode::isError`로 교체

Closes #270

## 변경 파일

- `AdminUserService.java`: `deleteUbuntuAccount()` 메서드 수정
- `AdminUserServiceTest.java`: DELETE 요청 전송 및 오류 처리 테스트 추가

## 테스트 계획

- [x] DELETE `/accounts/users/{username}` 요청 전송 확인
- [x] 404 응답 → 이미 삭제된 계정으로 간주하여 정상 처리
- [x] 400 응답 → `INVALID_USERNAME_FORMAT` BusinessException
- [x] Request 없음 → `EntityNotFoundException`