### PR TITLE
[L-9] 회원가입 API 응답 코드를 200에서 201 Created로 수정

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/controller/AuthController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/controller/AuthController.java
@@ -10,6 +10,7 @@ import DGU_AI_LAB.admin_be.domain.users.service.UserLoginService;
 import DGU_AI_LAB.admin_be.domain.users.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,7 +31,7 @@ public class AuthController implements AuthApi {
     @PostMapping("/register")
     public ResponseEntity<Void> register(@RequestBody @Valid UserRegisterRequestDTO request) {
         userLoginService.register(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
 

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/controller/AuthControllerTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/controller/AuthControllerTest.java
@@ -47,7 +47,7 @@ class AuthControllerTest extends WebMvcTestSupport {
     class Register {
 
         @Test
-        @DisplayName("유효한 요청으로 회원가입하면 200 OK를 반환한다")
+        @DisplayName("유효한 요청으로 회원가입하면 201 Created를 반환한다")
         void register_returns200_whenSuccess() throws Exception {
             doNothing().when(userLoginService).register(any());
 
@@ -58,7 +58,7 @@ class AuthControllerTest extends WebMvcTestSupport {
             mockMvc.perform(post("/api/auth/register")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(dto)))
-                    .andExpect(status().isOk());
+                    .andExpect(status().isCreated());
         }
 
         @Test


### PR DESCRIPTION
## 관련 이슈

closes #272

## 변경 내용

- `AuthController.register()` 반환값을 `ResponseEntity.ok()` → `ResponseEntity.status(HttpStatus.CREATED)`로 수정
- `import org.springframework.http.HttpStatus` 추가
- `AuthControllerTest` 기대 상태 코드를 `isOk()` → `isCreated()`로 업데이트

## 원인

`POST /api/auth/register`는 신규 사용자 리소스를 생성하는 엔드포인트이므로 REST 관례에 따라 `201 Created`를 반환해야 한다. 기존 `200 OK` 반환은 게이트웨이 및 프론트엔드에서 성공 응답 코드 기반 분기 시 혼란을 야기할 수 있다.

⚠️ 프론트엔드 팀과 공유 필요: `/api/auth/register` 응답 코드가 200 → 201로 변경됩니다.