### PR TITLE
[M-11] ApproveRequestDTO volumeSizeGiB에 @Positive 검증 추가

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/ApproveRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/ApproveRequestDTO.java
@@ -2,6 +2,7 @@ package DGU_AI_LAB.admin_be.domain.requests.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 @Schema(description = "관리자용 요청 승인 요청 DTO")
 public record ApproveRequestDTO(
@@ -20,6 +21,7 @@ public record ApproveRequestDTO(
 
         @Schema(description = "할당할 볼륨 크기 (GiB)", example = "20")
         @NotNull(message = "볼륨 크기는 필수로 입력해야 합니다.")
+        @Positive(message = "볼륨 크기는 양수여야 합니다.")
         Long volumeSizeGiB,
 
         @Schema(description = "관리자 승인 코멘트 (선택 사항)", example = "사용 목적에 따라 리소스를 할당함")

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/ApproveRequestDTOTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/ApproveRequestDTOTest.java
@@ -1,0 +1,76 @@
+package DGU_AI_LAB.admin_be.domain.requests.dto.request;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApproveRequestDTOTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            validator = factory.getValidator();
+        }
+    }
+
+    @Test
+    @DisplayName("volumeSizeGiB가 양수이면 유효성 검증을 통과한다")
+    void validate_success_whenVolumeSizePositive() {
+        ApproveRequestDTO dto = new ApproveRequestDTO(1L, 1L, 1, 10L, "승인합니다");
+
+        Set<ConstraintViolation<ApproveRequestDTO>> violations = validator.validate(dto);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("volumeSizeGiB가 0이면 @Positive 위반으로 검증에 실패한다")
+    void validate_fails_whenVolumeSizeIsZero() {
+        ApproveRequestDTO dto = new ApproveRequestDTO(1L, 1L, 1, 0L, "승인합니다");
+
+        Set<ConstraintViolation<ApproveRequestDTO>> violations = validator.validate(dto);
+
+        assertThat(violations).isNotEmpty();
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("volumeSizeGiB") &&
+                v.getMessage().equals("볼륨 크기는 양수여야 합니다.")
+        );
+    }
+
+    @Test
+    @DisplayName("volumeSizeGiB가 음수이면 @Positive 위반으로 검증에 실패한다")
+    void validate_fails_whenVolumeSizeIsNegative() {
+        ApproveRequestDTO dto = new ApproveRequestDTO(1L, 1L, 1, -1L, "승인합니다");
+
+        Set<ConstraintViolation<ApproveRequestDTO>> violations = validator.validate(dto);
+
+        assertThat(violations).isNotEmpty();
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("volumeSizeGiB") &&
+                v.getMessage().equals("볼륨 크기는 양수여야 합니다.")
+        );
+    }
+
+    @Test
+    @DisplayName("volumeSizeGiB가 null이면 @NotNull 위반으로 검증에 실패한다")
+    void validate_fails_whenVolumeSizeIsNull() {
+        ApproveRequestDTO dto = new ApproveRequestDTO(1L, 1L, 1, null, "승인합니다");
+
+        Set<ConstraintViolation<ApproveRequestDTO>> violations = validator.validate(dto);
+
+        assertThat(violations).isNotEmpty();
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("volumeSizeGiB")
+        );
+    }
+}


### PR DESCRIPTION
## 요약

- `ApproveRequestDTO.volumeSizeGiB`에 `@Positive` 제약 추가
- 0 또는 음수 볼륨 크기가 PVC 생성 API로 전달되는 것을 방지
- `SaveRequestRequestDTO`와 동일한 검증 정책 적용

Closes #276

## 변경 파일

- `ApproveRequestDTO.java`: `@Positive` 추가, `import` 추가
- `ApproveRequestDTOTest.java`: 신규 테스트 클래스 (Jakarta Validator 직접 사용)

## 테스트 계획

- [x] `volumeSizeGiB = 10` → 검증 통과
- [x] `volumeSizeGiB = 0` → `@Positive` 위반 (`볼륨 크기는 양수여야 합니다.`)
- [x] `volumeSizeGiB = -1` → `@Positive` 위반
- [x] `volumeSizeGiB = null` → `@NotNull` 위반