### PR TITLE
[L-10] 로그인 BCrypt 비밀번호 검증 중복 제거

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/UserLoginService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/UserLoginService.java
@@ -68,10 +68,6 @@ public class UserLoginService {
             throw new UnauthorizedException(ErrorCode.INVALID_LOGIN_INFO);
         }
 
-        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
-            throw new UnauthorizedException(ErrorCode.INVALID_LOGIN_INFO);
-        }
-
         user.recordLogin();
 
         String accessToken = jwtProvider.getIssueToken(user.getUserId(), true);

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/UserLoginServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/UserLoginServiceTest.java
@@ -120,7 +120,7 @@ class UserLoginServiceTest {
     class Login {
 
         @Test
-        @DisplayName("올바른 이메일과 비밀번호로 로그인하면 토큰을 반환한다")
+        @DisplayName("올바른 이메일과 비밀번호로 로그인하면 토큰을 반환하고 BCrypt 검증은 정확히 1회 실행된다")
         void login_success() {
             when(userRepository.findByEmail("test@dgu.ac.kr")).thenReturn(Optional.of(activeUser));
             when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(true);
@@ -134,6 +134,7 @@ class UserLoginServiceTest {
             assertThat(result).isNotNull();
             assertThat(result.accessToken()).isEqualTo("accessToken");
             assertThat(result.refreshToken()).isEqualTo("refreshToken");
+            verify(passwordEncoder, times(1)).matches("password123", "encodedPassword");
         }
 
         @Test
@@ -169,7 +170,7 @@ class UserLoginServiceTest {
         }
 
         @Test
-        @DisplayName("비밀번호가 틀리면 UnauthorizedException을 던진다")
+        @DisplayName("비밀번호가 틀리면 UnauthorizedException을 던지고 BCrypt 검증은 정확히 1회 실행된다")
         void login_throwsException_whenPasswordWrong() {
             when(userRepository.findByEmail("test@dgu.ac.kr")).thenReturn(Optional.of(activeUser));
             when(passwordEncoder.matches("wrongPw", "encodedPassword")).thenReturn(false);
@@ -178,6 +179,7 @@ class UserLoginServiceTest {
 
             assertThatThrownBy(() -> userLoginService.login(dto))
                     .isInstanceOf(UnauthorizedException.class);
+            verify(passwordEncoder, times(1)).matches("wrongPw", "encodedPassword");
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈

closes #280

## 변경 내용

`UserLoginService.login()`에서 `passwordEncoder.matches()`를 두 번 호출하는 중복 블록 제거.

## 원인

```java
// 기존 (중복)
if (!passwordEncoder.matches(request.password(), user.getPassword())) { ... }
if (!passwordEncoder.matches(request.password(), user.getPassword())) { ... } // 중복 제거
```

BCrypt는 해시 연산 비용이 수백ms에 달하도록 의도적으로 설계되어 있다. 동일한 검증을 두 번 수행하면 로그인마다 불필요한 지연이 발생한다.

## 테스트

- `login_success`: `passwordEncoder.matches()` 정확히 1회 호출 검증 추가 (`verify(times(1))`)
- `login_throwsException_whenPasswordWrong`: 오류 시에도 1회만 호출됨 검증