### PR TITLE
[L-1] Status enum에서 ALL sentinel 분리 (StatusFilter enum 신규 생성)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/service/AlarmService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/service/AlarmService.java
@@ -163,7 +163,8 @@ public class AlarmService {
             }
 
             // Fallback이 작동했다는 건 시스템이 불안정하다는 뜻이므로 에러 로그 채널에 알립니다.
-            if (!dto.getWebhookUrl().equals(errorLogWebhookUrl)) {
+            String webhookUrl = dto.getWebhookUrl();
+            if (webhookUrl == null || !webhookUrl.equals(errorLogWebhookUrl)) {
                 slackApiService.sendWebhook(errorLogWebhookUrl, "⚠️ Redis 장애 발생 (Direct Send 작동됨)");
             }
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/dashboard/controller/DashboardController.java
@@ -3,7 +3,7 @@ package DGU_AI_LAB.admin_be.domain.dashboard.controller;
 import DGU_AI_LAB.admin_be.domain.dashboard.controller.docs.DashBoardApi;
 import DGU_AI_LAB.admin_be.domain.dashboard.service.DashboardService;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.UserServerResponseDTO;
-import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import DGU_AI_LAB.admin_be.domain.requests.entity.StatusFilter;
 import DGU_AI_LAB.admin_be.global.auth.CustomUserDetails;
 import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -28,15 +28,15 @@ public class DashboardController implements DashBoardApi {
     /**
      * 사용자 신청 현황 서버 목록 조회 API
      *
-     * @param principal 현재 로그인한 사용자의 인증 정보 (CustomUserDetails)
-     * @param status    조회할 서버 요청의 상태 (필수 값: PENDING, FULFILLED, DENIED, ALL)
+     * @param principal    현재 로그인한 사용자의 인증 정보 (CustomUserDetails)
+     * @param statusFilter 조회할 서버 요청의 상태 필터 (PENDING, FULFILLED, DENIED, DELETED, ALL)
      */
     @GetMapping("/me/servers")
     public ResponseEntity<SuccessResponse<?>> getUserServers(
             @AuthenticationPrincipal CustomUserDetails principal,
-            @RequestParam(name = "status") Status status
+            @RequestParam(name = "status") StatusFilter statusFilter
     ) {
-        List<UserServerResponseDTO> userServers = dashboardService.getUserServers(principal.getUserId(), status);
+        List<UserServerResponseDTO> userServers = dashboardService.getUserServers(principal.getUserId(), statusFilter);
         return SuccessResponse.ok(userServers);
     }
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/dashboard/controller/docs/DashBoardApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/dashboard/controller/docs/DashBoardApi.java
@@ -1,7 +1,7 @@
 package DGU_AI_LAB.admin_be.domain.dashboard.controller.docs;
 
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.UserServerResponseDTO;
-import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import DGU_AI_LAB.admin_be.domain.requests.entity.StatusFilter;
 import DGU_AI_LAB.admin_be.error.dto.ErrorResponse;
 import DGU_AI_LAB.admin_be.global.auth.CustomUserDetails;
 import DGU_AI_LAB.admin_be.global.common.SuccessResponse;
@@ -53,7 +53,7 @@ public interface DashBoardApi {
     ResponseEntity<SuccessResponse<?>> getUserServers(
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails principal,
-            @Parameter(description = "조회할 서버 신청 상태 (PENDING, FULFILLED, DENIED 등)", required = true, example = "FULFILLED")
-            @RequestParam(name = "status") Status status
+            @Parameter(description = "조회할 서버 신청 상태 필터 (PENDING, FULFILLED, DENIED, DELETED, ALL)", required = true, example = "FULFILLED")
+            @RequestParam(name = "status") StatusFilter statusFilter
     );
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/dashboard/service/DashboardService.java
@@ -6,6 +6,7 @@ import DGU_AI_LAB.admin_be.domain.nodes.repository.NodeRepository;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.UserServerResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import DGU_AI_LAB.admin_be.domain.requests.entity.StatusFilter;
 import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
 import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
 import lombok.RequiredArgsConstructor;
@@ -29,13 +30,14 @@ public class DashboardService {
      * 사용자 대시보드 서버 목록 조회
      * 승인받은 서버 및 승인 대기중인 신청 목록을 필터링하여 반환합니다.
      */
-    public List<UserServerResponseDTO> getUserServers(Long userId, Status status) {
-        log.info("[getUserServers] userId={}의 status={} 서버 목록 조회 시작", userId, status);
+    public List<UserServerResponseDTO> getUserServers(Long userId, StatusFilter statusFilter) {
+        log.info("[getUserServers] userId={}의 statusFilter={} 서버 목록 조회 시작", userId, statusFilter);
 
         List<Request> requests;
-        if (status == Status.ALL) {
+        if (statusFilter == StatusFilter.ALL) {
             requests = requestRepository.findAllByUser_UserId(userId);
         } else {
+            Status status = Status.valueOf(statusFilter.name());
             requests = requestRepository.findByUserUserIdAndStatus(userId, status);
         }
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Status.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Status.java
@@ -1,5 +1,5 @@
 package DGU_AI_LAB.admin_be.domain.requests.entity;
 
 public enum Status {
-    PENDING, DENIED, FULFILLED, ALL, DELETED
+    PENDING, DENIED, FULFILLED, DELETED
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/StatusFilter.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/StatusFilter.java
@@ -1,0 +1,9 @@
+package DGU_AI_LAB.admin_be.domain.requests.entity;
+
+/**
+ * 필터링 쿼리용 enum. DB에 저장되지 않으며 API 파라미터 전용입니다.
+ * ALL은 "모든 상태 조회" 의미의 sentinel 값입니다.
+ */
+public enum StatusFilter {
+    PENDING, DENIED, FULFILLED, DELETED, ALL
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/alarm/service/AlarmServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/alarm/service/AlarmServiceTest.java
@@ -1,0 +1,108 @@
+package DGU_AI_LAB.admin_be.domain.alarm.service;
+
+import DGU_AI_LAB.admin_be.global.util.MessageUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AlarmServiceTest {
+
+    @InjectMocks
+    private AlarmService alarmService;
+
+    @Mock
+    private SlackApiService slackApiService;
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    @Mock
+    private MessageUtils messageUtils;
+
+    @Mock
+    private ListOperations<String, Object> listOperations;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(alarmService, "notiLogWebhookUrl", "https://hooks.slack.com/noti");
+        ReflectionTestUtils.setField(alarmService, "errorLogWebhookUrl", "https://hooks.slack.com/error");
+        ReflectionTestUtils.setField(alarmService, "farmAdminWebhookUrl", "https://hooks.slack.com/farm");
+        ReflectionTestUtils.setField(alarmService, "labAdminWebhookUrl", "https://hooks.slack.com/lab");
+        ReflectionTestUtils.setField(alarmService, "from", "noreply@dgu.ac.kr");
+    }
+
+    @Nested
+    @DisplayName("sendSlackAlert")
+    class SendSlackAlert {
+
+        @Test
+        @DisplayName("Redis 정상 시 큐에 메시지가 적재된다")
+        void sendSlackAlert_queuesMessage_whenRedisWorks() {
+            when(redisTemplate.opsForList()).thenReturn(listOperations);
+            when(listOperations.rightPush(anyString(), any())).thenReturn(1L);
+
+            assertThatCode(() -> alarmService.sendSlackAlert("test message", "https://hooks.slack.com/test"))
+                    .doesNotThrowAnyException();
+
+            verify(listOperations).rightPush(anyString(), any());
+        }
+
+        @Test
+        @DisplayName("Redis 장애 시 WEBHOOK 타입은 직접 전송하며 NPE가 발생하지 않는다")
+        void sendSlackAlert_fallback_doesNotThrowNPE_whenRedisDown() {
+            when(redisTemplate.opsForList()).thenThrow(new RuntimeException("Redis 연결 실패"));
+            when(messageUtils.get("notification.error.redis-fallback")).thenReturn(" [Redis 장애]");
+            doNothing().when(slackApiService).sendWebhook(anyString(), anyString());
+
+            assertThatCode(() -> alarmService.sendSlackAlert("test message", "https://hooks.slack.com/error"))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("sendDMAlert")
+    class SendDMAlert {
+
+        @Test
+        @DisplayName("Redis 정상 시 DM 큐에 메시지가 적재된다")
+        void sendDMAlert_queuesMessage_whenRedisWorks() {
+            when(redisTemplate.opsForList()).thenReturn(listOperations);
+            when(listOperations.rightPush(anyString(), any())).thenReturn(1L);
+
+            assertThatCode(() -> alarmService.sendDMAlert("testuser", "test@example.com", "hello"))
+                    .doesNotThrowAnyException();
+
+            verify(listOperations).rightPush(anyString(), any());
+        }
+
+        @Test
+        @DisplayName("Redis 장애 시 DM 타입은 webhookUrl이 null이어도 NPE 없이 직접 전송된다")
+        void sendDMAlert_fallback_doesNotThrowNPE_whenWebhookUrlIsNull() {
+            when(redisTemplate.opsForList()).thenThrow(new RuntimeException("Redis 연결 실패"));
+            when(messageUtils.get("notification.error.redis-fallback")).thenReturn(" [Redis 장애]");
+            doNothing().when(slackApiService).sendDM(anyString(), anyString(), anyString());
+            doNothing().when(slackApiService).sendWebhook(anyString(), anyString());
+
+            // DM 타입은 webhookUrl이 null → 이전에는 NPE 발생했음
+            assertThatCode(() -> alarmService.sendDMAlert("testuser", "test@example.com", "hello"))
+                    .doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/dashboard/service/DashboardServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/dashboard/service/DashboardServiceTest.java
@@ -3,6 +3,7 @@ package DGU_AI_LAB.admin_be.domain.dashboard.service;
 import DGU_AI_LAB.admin_be.domain.nodes.repository.NodeRepository;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.UserServerResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
+import DGU_AI_LAB.admin_be.domain.requests.entity.StatusFilter;
 import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -12,7 +13,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -34,11 +38,11 @@ class DashboardServiceTest {
     class GetUserServers {
 
         @Test
-        @DisplayName("Status.ALL이면 userId의 모든 요청을 반환한다")
+        @DisplayName("StatusFilter.ALL이면 userId의 모든 요청을 반환한다")
         void getUserServers_returnsAllRequests_whenStatusAll() {
             when(requestRepository.findAllByUser_UserId(1L)).thenReturn(List.of());
 
-            List<UserServerResponseDTO> result = dashboardService.getUserServers(1L, Status.ALL);
+            List<UserServerResponseDTO> result = dashboardService.getUserServers(1L, StatusFilter.ALL);
 
             assertThat(result).isEmpty();
             verify(requestRepository).findAllByUser_UserId(1L);
@@ -46,25 +50,52 @@ class DashboardServiceTest {
         }
 
         @Test
-        @DisplayName("Status.FULFILLED이면 FULFILLED 요청만 반환한다")
+        @DisplayName("StatusFilter.FULFILLED이면 FULFILLED 요청만 반환한다")
         void getUserServers_returnsFulfilledRequests_whenStatusFulfilled() {
             when(requestRepository.findByUserUserIdAndStatus(1L, Status.FULFILLED)).thenReturn(List.of());
 
-            List<UserServerResponseDTO> result = dashboardService.getUserServers(1L, Status.FULFILLED);
+            List<UserServerResponseDTO> result = dashboardService.getUserServers(1L, StatusFilter.FULFILLED);
 
             assertThat(result).isEmpty();
             verify(requestRepository).findByUserUserIdAndStatus(1L, Status.FULFILLED);
         }
 
         @Test
-        @DisplayName("Status.PENDING이면 PENDING 요청만 반환한다")
+        @DisplayName("StatusFilter.PENDING이면 PENDING 요청만 반환한다")
         void getUserServers_returnsPendingRequests_whenStatusPending() {
             when(requestRepository.findByUserUserIdAndStatus(1L, Status.PENDING)).thenReturn(List.of());
 
-            List<UserServerResponseDTO> result = dashboardService.getUserServers(1L, Status.PENDING);
+            List<UserServerResponseDTO> result = dashboardService.getUserServers(1L, StatusFilter.PENDING);
 
             assertThat(result).isEmpty();
             verify(requestRepository).findByUserUserIdAndStatus(1L, Status.PENDING);
+        }
+    }
+
+    @Nested
+    @DisplayName("Status enum")
+    class StatusEnumTest {
+
+        @Test
+        @DisplayName("Status enum은 DB 저장 가능한 값만 포함하고 ALL을 포함하지 않는다")
+        void status_containsOnlyValidDbValues() {
+            Set<String> names = Arrays.stream(Status.values())
+                    .map(Enum::name)
+                    .collect(Collectors.toSet());
+
+            assertThat(names).containsExactlyInAnyOrder("PENDING", "DENIED", "FULFILLED", "DELETED");
+            assertThat(names).doesNotContain("ALL");
+        }
+
+        @Test
+        @DisplayName("StatusFilter enum은 ALL을 포함한다")
+        void statusFilter_containsAll() {
+            Set<String> names = Arrays.stream(StatusFilter.values())
+                    .map(Enum::name)
+                    .collect(Collectors.toSet());
+
+            assertThat(names).contains("ALL");
+            assertThat(names).containsExactlyInAnyOrder("PENDING", "DENIED", "FULFILLED", "DELETED", "ALL");
         }
     }
 }


### PR DESCRIPTION
## 요약

- `Status.ALL`은 DB 저장 enum에 포함되어선 안 되는 필터링 sentinel
- `Status`에서 `ALL` 제거 → DB 저장값만 유지 (`PENDING`, `DENIED`, `FULFILLED`, `DELETED`)
- `StatusFilter` enum 신규 생성 → API 파라미터 전용 (`ALL` 포함)
- `DashboardService`/`Controller`/`DashBoardApi`에서 `StatusFilter` 사용

Closes #284

## 변경 파일

- `Status.java`: `ALL` 제거
- `StatusFilter.java`: 신규 생성 (API 파라미터 전용)
- `DashboardService.java`: 파라미터 `Status` → `StatusFilter`, `Status.valueOf()` 변환 추가
- `DashboardController.java`: `@RequestParam` 타입 변경
- `DashBoardApi.java`: 인터페이스 시그니처 변경
- `DashboardServiceTest.java`: `StatusFilter` 기반 테스트, `Status` 값 검증 추가

## 테스트 계획

- [x] `StatusFilter.ALL` → `findAllByUser_UserId()` 호출
- [x] `StatusFilter.FULFILLED` → `findByUserUserIdAndStatus()` 호출
- [x] `StatusFilter.PENDING` → `findByUserUserIdAndStatus()` 호출
- [x] `Status` enum이 `ALL`을 포함하지 않음을 검증
- [x] `StatusFilter` enum이 `ALL`을 포함함을 검증