### PR TITLE
[L-3] 이메일 인증 코드 Redis 키에 email:verify: prefix 추가

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/global/util/EmailService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/global/util/EmailService.java
@@ -23,11 +23,13 @@ public class EmailService {
     private final RedisTemplate<String, String> redisTemplate;
 
     private static final long AUTH_CODE_EXPIRE_SECONDS = 60 * 5; // 5분
+    private static final String EMAIL_VERIFY_PREFIX = "email:verify:";
 
     public void sendEmailVerificationCode(String email) {
         String authCode = createRandomCode();
+        String redisKey = EMAIL_VERIFY_PREFIX + email;
 
-        redisTemplate.opsForValue().set(email, authCode, AUTH_CODE_EXPIRE_SECONDS, TimeUnit.SECONDS);
+        redisTemplate.opsForValue().set(redisKey, authCode, AUTH_CODE_EXPIRE_SECONDS, TimeUnit.SECONDS);
         log.info("이메일 [{}]에 인증번호 [{}] 저장 완료", email, authCode);
 
         sendEmail(email, "[DGU AI LAB 서버관리팀] 이메일 인증 코드입니다.",
@@ -35,12 +37,13 @@ public class EmailService {
     }
 
     public void confirmAuthCode(String email, String code) {
-        String stored = redisTemplate.opsForValue().get(email);
+        String redisKey = EMAIL_VERIFY_PREFIX + email;
+        String stored = redisTemplate.opsForValue().get(redisKey);
         if (!code.equals(stored)) {
             throw new BusinessException(ErrorCode.INVALID_AUTH_CODE);
         }
 
-        redisTemplate.delete(email); // 인증번호 제거
+        redisTemplate.delete(redisKey); // 인증번호 제거
         redisTemplate.opsForValue().set("VERIFIED:" + email, "true", 10, TimeUnit.MINUTES); // 인증 상태 저장
         log.info("이메일 [{}] 인증 성공. VERIFIED:{} 키 저장 완료", email, email);
     }
@@ -56,7 +59,8 @@ public class EmailService {
 
             mailSender.send(message);
         } catch (MessagingException e) {
-            throw new RuntimeException("이메일 전송 실패", e);
+            log.error("이메일 전송 실패: 수신자={}", to, e);
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/test/java/DGU_AI_LAB/admin_be/global/util/EmailServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/global/util/EmailServiceTest.java
@@ -1,0 +1,103 @@
+package DGU_AI_LAB.admin_be.global.util;
+
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+
+    @InjectMocks
+    private EmailService emailService;
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private MimeMessage mimeMessage;
+
+    @BeforeEach
+    void setUp() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Nested
+    @DisplayName("sendEmailVerificationCode")
+    class SendEmailVerificationCode {
+
+        @Test
+        @DisplayName("이메일 인증번호 발송 성공 시 email:verify: prefix가 포함된 키로 Redis에 저장된다")
+        void sendEmailVerificationCode_usesEmailVerifyPrefix() {
+            when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+            doNothing().when(mailSender).send(any(MimeMessage.class));
+
+            emailService.sendEmailVerificationCode("test@example.com");
+
+            ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+            verify(valueOperations).set(keyCaptor.capture(), anyString(), anyLong(), any());
+
+            String capturedKey = keyCaptor.getValue();
+            assertThat(capturedKey).startsWith("email:verify:");
+            assertThat(capturedKey).isEqualTo("email:verify:test@example.com");
+        }
+
+        @Test
+        @DisplayName("이메일 인증번호 발송 성공 시 정상 처리된다")
+        void sendEmailVerificationCode_success() {
+            when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+            doNothing().when(mailSender).send(any(MimeMessage.class));
+
+            assertThatCode(() -> emailService.sendEmailVerificationCode("test@example.com"))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("confirmAuthCode")
+    class ConfirmAuthCode {
+
+        @Test
+        @DisplayName("올바른 인증 코드 입력 시 email:verify: prefix 키가 삭제되고 VERIFIED: 키가 저장된다")
+        void confirmAuthCode_success_usesEmailVerifyPrefixForDelete() {
+            when(valueOperations.get("email:verify:test@example.com")).thenReturn("123456");
+
+            assertThatCode(() -> emailService.confirmAuthCode("test@example.com", "123456"))
+                    .doesNotThrowAnyException();
+
+            verify(redisTemplate).delete("email:verify:test@example.com");
+            verify(valueOperations).set(eq("VERIFIED:test@example.com"), eq("true"), anyLong(), any());
+        }
+
+        @Test
+        @DisplayName("잘못된 인증 코드 입력 시 BusinessException 발생")
+        void confirmAuthCode_wrongCode_throwsBusinessException() {
+            when(valueOperations.get("email:verify:test@example.com")).thenReturn("123456");
+
+            assertThatThrownBy(() -> emailService.confirmAuthCode("test@example.com", "000000"))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+}


### PR DESCRIPTION
## 변경 사항

`EmailService`의 이메일 인증 코드 Redis 키에 namespace prefix를 추가합니다.

## 수정 내용

- `email:verify:` prefix 상수 추가
- `sendEmailVerificationCode`: `email` → `email:verify:{email}` 키 사용
- `confirmAuthCode`: 동일한 prefix 키로 조회 및 삭제
- `VERIFIED:` prefix 키는 기존 유지

closes #286