### PR TITLE
fix: PodService.deletePod Propagation.MANDATORY 제거

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/PodService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/PodService.java
@@ -10,8 +10,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -59,7 +57,6 @@ public class PodService {
         }
     }
 
-    @Transactional(propagation = Propagation.MANDATORY)
     public void deletePod(String podName) {
         if (podName == null) {
             log.warn("pod_name이 없어 Pod 삭제를 건너뜁니다.");

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/PodServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/PodServiceTest.java
@@ -1,0 +1,191 @@
+package DGU_AI_LAB.admin_be.domain.requests.service;
+
+import DGU_AI_LAB.admin_be.domain.requests.dto.response.CreatePodResponseDTO;
+import DGU_AI_LAB.admin_be.error.ErrorCode;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("PodService")
+class PodServiceTest {
+
+    @InjectMocks
+    private PodService podService;
+
+    @Mock private WebClient webClient;
+    @Mock private WebClient.RequestBodyUriSpec requestBodyUriSpec;
+    @Mock private WebClient.RequestBodySpec requestBodySpec;
+    @Mock private WebClient.RequestHeadersSpec<?> requestHeadersSpec;
+    @Mock private WebClient.ResponseSpec responseSpec;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        when(webClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
+        doReturn(requestHeadersSpec).when(requestBodySpec).bodyValue(any());
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.onStatus(any(), any())).thenReturn(responseSpec);
+    }
+
+    // ───────────────────────────────────────────────────────────────
+    // deletePod
+    // ───────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("deletePod")
+    class DeletePod {
+
+        @Test
+        @DisplayName("podName이 null이면 API를 호출하지 않고 정상 반환한다")
+        void deletePod_skipsApiCall_whenPodNameIsNull() {
+            assertThatCode(() -> podService.deletePod(null))
+                    .doesNotThrowAnyException();
+
+            verify(webClient, never()).post();
+        }
+
+        @Test
+        @DisplayName("정상 응답이면 Pod 삭제에 성공한다")
+        void deletePod_success_whenApiReturnsOk() {
+            when(responseSpec.bodyToMono(Map.class))
+                    .thenReturn(Mono.just(Map.of("status", "ok")));
+
+            assertThatCode(() -> podService.deletePod("test-pod-name"))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("빈 문자열 podName도 API를 호출한다")
+        void deletePod_callsApi_whenPodNameIsEmpty() {
+            when(responseSpec.bodyToMono(Map.class))
+                    .thenReturn(Mono.just(Map.of()));
+
+            assertThatCode(() -> podService.deletePod(""))
+                    .doesNotThrowAnyException();
+
+            verify(webClient).post();
+        }
+
+        @Test
+        @DisplayName("API 호출 중 BusinessException이 발생하면 그대로 전파한다")
+        void deletePod_propagatesBusinessException() {
+            when(responseSpec.bodyToMono(Map.class))
+                    .thenReturn(Mono.error(new BusinessException("Pod 삭제 실패", ErrorCode.POD_DELETION_FAILED)));
+
+            assertThatThrownBy(() -> podService.deletePod("error-pod"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("Pod 삭제 실패");
+        }
+
+        @Test
+        @DisplayName("API 호출 중 일반 예외가 발생하면 BusinessException으로 래핑한다")
+        void deletePod_wrapsGeneralException_asBusinessException() {
+            when(responseSpec.bodyToMono(Map.class))
+                    .thenReturn(Mono.error(new RuntimeException("connection timeout")));
+
+            assertThatThrownBy(() -> podService.deletePod("timeout-pod"))
+                    .isInstanceOf(BusinessException.class);
+        }
+
+        @Test
+        @DisplayName("deletePod 메서드에 @Transactional 어노테이션이 없다")
+        void deletePod_hasNoTransactionalAnnotation() throws NoSuchMethodException {
+            var method = PodService.class.getMethod("deletePod", String.class);
+            var txAnnotation = method.getAnnotation(Transactional.class);
+
+            assertThat(txAnnotation)
+                    .as("Propagation.MANDATORY 등 트랜잭션 어노테이션이 제거되어야 함")
+                    .isNull();
+        }
+    }
+
+    // ───────────────────────────────────────────────────────────────
+    // createPod
+    // ───────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("createPod")
+    class CreatePod {
+
+        @Test
+        @DisplayName("Pod 생성 API가 성공 응답을 반환하면 CreatePodResponseDTO를 반환한다")
+        void createPod_returnsDto_whenApiSucceeds() {
+            CreatePodResponseDTO mockResponse = new CreatePodResponseDTO(
+                    "running", "node-01", "pod-testuser-abc",
+                    List.of(new CreatePodResponseDTO.PortInfo("ssh", 22, 30022))
+            );
+            when(responseSpec.bodyToMono(CreatePodResponseDTO.class))
+                    .thenReturn(Mono.just(mockResponse));
+
+            CreatePodResponseDTO result = podService.createPod("testuser");
+
+            assertThat(result).isEqualTo(mockResponse);
+            assertThat(result.podName()).isEqualTo("pod-testuser-abc");
+        }
+
+        @Test
+        @DisplayName("Pod 생성 API가 빈 응답을 반환하면 null을 반환한다")
+        void createPod_returnsNull_whenApiReturnsEmpty() {
+            when(responseSpec.bodyToMono(CreatePodResponseDTO.class))
+                    .thenReturn(Mono.empty());
+
+            CreatePodResponseDTO result = podService.createPod("testuser");
+
+            assertThat(result).isNull();
+        }
+
+        @Test
+        @DisplayName("Pod 생성 API 호출 중 BusinessException이 발생하면 그대로 전파한다")
+        void createPod_propagatesBusinessException() {
+            when(responseSpec.bodyToMono(CreatePodResponseDTO.class))
+                    .thenReturn(Mono.error(new BusinessException("Pod 생성 실패", ErrorCode.POD_CREATION_FAILED)));
+
+            assertThatThrownBy(() -> podService.createPod("testuser"))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining("Pod 생성 실패");
+        }
+
+        @Test
+        @DisplayName("Pod 생성 API 호출 중 일반 예외가 발생하면 BusinessException으로 래핑한다")
+        void createPod_wrapsGeneralException_asBusinessException() {
+            when(responseSpec.bodyToMono(CreatePodResponseDTO.class))
+                    .thenReturn(Mono.error(new RuntimeException("network error")));
+
+            assertThatThrownBy(() -> podService.createPod("testuser"))
+                    .isInstanceOf(BusinessException.class);
+        }
+
+        @Test
+        @DisplayName("올바른 username으로 /create-pod URI에 요청한다")
+        void createPod_callsCorrectUri() {
+            when(responseSpec.bodyToMono(CreatePodResponseDTO.class))
+                    .thenReturn(Mono.just(new CreatePodResponseDTO("running", "node", "pod-user", List.of())));
+
+            podService.createPod("myuser");
+
+            verify(requestBodyUriSpec).uri("/create-pod");
+        }
+    }
+}


### PR DESCRIPTION
## 개요

`PodService.deletePod()`의 `@Transactional(propagation = Propagation.MANDATORY)`를 제거한다.

## 변경 사항

### 문제
- `Propagation.MANDATORY`는 호출 시점에 반드시 활성 트랜잭션이 있어야 함
- 트랜잭션 없는 컨텍스트(예: 이벤트 리스너, 비동기 호출)에서 호출 시 `IllegalTransactionStateException` 즉시 발생
- `deletePod`는 DB 작업이 전혀 없고 외부 WebClient HTTP 호출만 수행 → 트랜잭션 자체가 불필요
- 외부 HTTP 대기 시간 동안 DB 커넥션을 점유하는 낭비 발생

### 수정
- `PodService.deletePod()`의 `@Transactional` 어노테이션 제거
- 미사용 import (`Propagation`, `Transactional`) 제거

## 테스트

- `PodServiceTest` 신규 작성 (12개 케이스)
  - `deletePod`: null podName 처리, 성공, 빈 문자열, BusinessException 전파, 일반 예외 래핑, 어노테이션 제거 검증
  - `createPod`: 성공, 빈 응답, BusinessException 전파, 일반 예외 래핑, 올바른 URI 호출

closes #288