### PR TITLE
fix: Access Token 재발급 시 서명 검증 없이 sub 읽는 취약점 수정

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/TokenService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/TokenService.java
@@ -2,9 +2,9 @@ package DGU_AI_LAB.admin_be.domain.users.service;
 
 import DGU_AI_LAB.admin_be.domain.users.dto.request.UserTokenRequestDTO;
 import DGU_AI_LAB.admin_be.domain.users.dto.response.UserTokenResponseDTO;
+import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.UnauthorizedException;
 import DGU_AI_LAB.admin_be.global.auth.jwt.JwtProvider;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -12,8 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.concurrent.TimeUnit;
-
-import static DGU_AI_LAB.admin_be.error.ErrorCode.JSON_PARSING_FAILED;
 
 @Service
 @Transactional(readOnly = true)
@@ -57,9 +55,9 @@ public class TokenService {
     public UserTokenResponseDTO reissue(UserTokenRequestDTO userTokenRequest) {
         Long userId;
         try {
-            userId = Long.valueOf(jwtProvider.decodeJwtPayloadSubject(userTokenRequest.accessToken()));
-        } catch (JsonProcessingException e) {
-            throw new UnauthorizedException(JSON_PARSING_FAILED);
+            userId = jwtProvider.getSubjectFromExpiredToken(userTokenRequest.accessToken());
+        } catch (Exception e) {
+            throw new UnauthorizedException(ErrorCode.INVALID_ACCESS_TOKEN_VALUE);
         }
 
         String refreshToken = userTokenRequest.refreshToken();

--- a/src/main/java/DGU_AI_LAB/admin_be/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/global/auth/jwt/JwtProvider.java
@@ -2,19 +2,15 @@ package DGU_AI_LAB.admin_be.global.auth.jwt;
 
 import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.UnauthorizedException;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
-import java.util.Map;
 
 @Getter
 @Component
@@ -25,8 +21,6 @@ public class JwtProvider {
     private long ACCESS_TOKEN_EXPIRE_TIME;
     @Value("${jwt.refresh-token-expire-time}")
     private long REFRESH_TOKEN_EXPIRE_TIME;
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public String getIssueToken(Long userId, boolean isAccessToken) {
         if (isAccessToken) return generateToken(userId, ACCESS_TOKEN_EXPIRE_TIME);
@@ -89,11 +83,21 @@ public class JwtProvider {
     }
 
 
-    public String decodeJwtPayloadSubject(String oldAccessToken) throws JsonProcessingException {
-        return objectMapper.readValue(
-                new String(Base64.getDecoder().decode(oldAccessToken.split("\\.")[1]), StandardCharsets.UTF_8),
-                Map.class
-        ).get("sub").toString();
+    /**
+     * 만료된 accessToken에서 서명 검증 후 userId(subject)를 추출한다.
+     *
+     * parseClaimsJws()는 만료 여부와 무관하게 서명을 항상 검증한다.
+     * 토큰이 만료된 경우 ExpiredJwtException에서 claims를 꺼내 subject를 반환하고,
+     * 서명이 유효하지 않거나 토큰 형식이 깨진 경우에는 예외가 그대로 전파된다.
+     */
+    public Long getSubjectFromExpiredToken(String accessToken) {
+        try {
+            return Long.valueOf(
+                    getJwtParser().parseClaimsJws(accessToken).getBody().getSubject()
+            );
+        } catch (ExpiredJwtException e) {
+            return Long.valueOf(e.getClaims().getSubject());
+        }
     }
 
 }

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/TokenServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/TokenServiceTest.java
@@ -4,7 +4,8 @@ import DGU_AI_LAB.admin_be.domain.users.dto.request.UserTokenRequestDTO;
 import DGU_AI_LAB.admin_be.domain.users.dto.response.UserTokenResponseDTO;
 import DGU_AI_LAB.admin_be.error.exception.UnauthorizedException;
 import DGU_AI_LAB.admin_be.global.auth.jwt.JwtProvider;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -94,9 +95,9 @@ class TokenServiceTest {
 
         @Test
         @DisplayName("유효한 리프레시 토큰으로 재발급하면 새 토큰을 반환한다")
-        void reissue_success() throws JsonProcessingException {
+        void reissue_success() {
             ReflectionTestUtils.setField(tokenService, "REFRESH_TOKEN_EXPIRE_TIME", 604800L);
-            when(jwtProvider.decodeJwtPayloadSubject("accessToken")).thenReturn("1");
+            when(jwtProvider.getSubjectFromExpiredToken("accessToken")).thenReturn(1L);
             when(redisTemplate.opsForValue()).thenReturn(valueOperations);
             when(valueOperations.get("RT:1")).thenReturn("storedRefreshToken");
             doNothing().when(jwtProvider).validateRefreshToken("refreshToken");
@@ -109,6 +110,59 @@ class TokenServiceTest {
 
             assertThat(result.accessToken()).isEqualTo("newAccessToken");
             assertThat(result.refreshToken()).isEqualTo("newRefreshToken");
+        }
+
+        @Test
+        @DisplayName("서명이 유효하지 않은 accessToken이면 UnauthorizedException을 던진다")
+        void reissue_throwsUnauthorized_whenSignatureInvalid() {
+            when(jwtProvider.getSubjectFromExpiredToken("forgedToken"))
+                    .thenThrow(new SignatureException("JWT signature does not match"));
+
+            UserTokenRequestDTO dto = new UserTokenRequestDTO("forgedToken", "refreshToken");
+
+            assertThatThrownBy(() -> tokenService.reissue(dto))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("형식이 잘못된 accessToken이면 UnauthorizedException을 던진다")
+        void reissue_throwsUnauthorized_whenTokenMalformed() {
+            when(jwtProvider.getSubjectFromExpiredToken("bad.token"))
+                    .thenThrow(new MalformedJwtException("Malformed JWT"));
+
+            UserTokenRequestDTO dto = new UserTokenRequestDTO("bad.token", "refreshToken");
+
+            assertThatThrownBy(() -> tokenService.reissue(dto))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("getSubjectFromExpiredToken이 일반 예외를 던지면 UnauthorizedException으로 변환한다")
+        void reissue_throwsUnauthorized_whenUnexpectedExceptionOccurs() {
+            when(jwtProvider.getSubjectFromExpiredToken(any()))
+                    .thenThrow(new RuntimeException("unexpected"));
+
+            UserTokenRequestDTO dto = new UserTokenRequestDTO("anyToken", "refreshToken");
+
+            assertThatThrownBy(() -> tokenService.reissue(dto))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("재발급 시 getSubjectFromExpiredToken을 통해 서명 검증 후 userId를 추출한다")
+        void reissue_usesGetSubjectFromExpiredToken() {
+            ReflectionTestUtils.setField(tokenService, "REFRESH_TOKEN_EXPIRE_TIME", 604800L);
+            when(jwtProvider.getSubjectFromExpiredToken("accessToken")).thenReturn(1L);
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get("RT:1")).thenReturn("storedRefreshToken");
+            doNothing().when(jwtProvider).validateRefreshToken("refreshToken");
+            doNothing().when(jwtProvider).equalsRefreshToken("refreshToken", "storedRefreshToken");
+            when(jwtProvider.getIssueToken(1L, true)).thenReturn("newAccess");
+            when(jwtProvider.getIssueToken(1L, false)).thenReturn("newRefresh");
+
+            tokenService.reissue(new UserTokenRequestDTO("accessToken", "refreshToken"));
+
+            verify(jwtProvider).getSubjectFromExpiredToken("accessToken");
         }
     }
 

--- a/src/test/java/DGU_AI_LAB/admin_be/global/auth/jwt/JwtProviderTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/global/auth/jwt/JwtProviderTest.java
@@ -1,0 +1,207 @@
+package DGU_AI_LAB.admin_be.global.auth.jwt;
+
+import DGU_AI_LAB.admin_be.error.exception.UnauthorizedException;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("JwtProvider")
+class JwtProviderTest {
+
+    private JwtProvider jwtProvider;
+
+    private static final String SECRET = "dguailab-test-secret-key-1234567890-1234567890-1234567890";
+    private static final long ACCESS_TTL  = 3_600_000L;  // 1시간
+    private static final long REFRESH_TTL = 604_800_000L; // 7일
+
+    @BeforeEach
+    void setUp() {
+        jwtProvider = new JwtProvider();
+        ReflectionTestUtils.setField(jwtProvider, "secretKey", SECRET);
+        ReflectionTestUtils.setField(jwtProvider, "ACCESS_TOKEN_EXPIRE_TIME", ACCESS_TTL);
+        ReflectionTestUtils.setField(jwtProvider, "REFRESH_TOKEN_EXPIRE_TIME", REFRESH_TTL);
+    }
+
+    // ─── 헬퍼: 이미 만료된 토큰 직접 생성 ───────────────────────────────────────
+    private String buildExpiredToken(Long userId) {
+        String encoded = Base64.getEncoder().encodeToString(SECRET.getBytes());
+        Key key = Keys.hmacShaKeyFor(encoded.getBytes());
+        Date past = new Date(System.currentTimeMillis() - 10_000);
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(past)
+                .setExpiration(past)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // ─── 헬퍼: 완전히 다른 키로 서명된 위조 토큰 생성 ────────────────────────────
+    private String buildTokenWithDifferentKey(Long userId) {
+        String fakeSecret = "completely-different-secret-key-abcdefghijklmnop-xyz";
+        String encoded = Base64.getEncoder().encodeToString(fakeSecret.getBytes());
+        Key key = Keys.hmacShaKeyFor(encoded.getBytes());
+        Date now = new Date();
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + ACCESS_TTL))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // ───────────────────────────────────────────────────────────────
+    // getSubjectFromExpiredToken
+    // ───────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("getSubjectFromExpiredToken")
+    class GetSubjectFromExpiredToken {
+
+        @Test
+        @DisplayName("유효한 토큰이면 서명 검증 후 userId를 반환한다")
+        void returnsUserId_fromValidToken() {
+            String token = jwtProvider.getIssueToken(42L, true);
+
+            Long userId = jwtProvider.getSubjectFromExpiredToken(token);
+
+            assertThat(userId).isEqualTo(42L);
+        }
+
+        @Test
+        @DisplayName("만료된 토큰이어도 서명이 유효하면 userId를 반환한다")
+        void returnsUserId_fromExpiredButValidToken() {
+            String expiredToken = buildExpiredToken(99L);
+
+            Long userId = jwtProvider.getSubjectFromExpiredToken(expiredToken);
+
+            assertThat(userId).isEqualTo(99L);
+        }
+
+        @Test
+        @DisplayName("서명이 다른 위조 토큰이면 예외를 던진다")
+        void throwsException_whenSignatureIsInvalid() {
+            String forgedToken = buildTokenWithDifferentKey(1L);
+
+            assertThatThrownBy(() -> jwtProvider.getSubjectFromExpiredToken(forgedToken))
+                    .isNotInstanceOf(ExpiredJwtException.class);
+        }
+
+        @Test
+        @DisplayName("형식이 잘못된 토큰이면 예외를 던진다")
+        void throwsException_whenTokenIsMalformed() {
+            assertThatThrownBy(() -> jwtProvider.getSubjectFromExpiredToken("not.a.valid.token"))
+                    .isNotInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("점(.)이 없는 토큰이면 예외를 던진다")
+        void throwsException_whenTokenHasNoParts() {
+            assertThatThrownBy(() -> jwtProvider.getSubjectFromExpiredToken("invalidtoken"))
+                    .isInstanceOf(Exception.class);
+        }
+
+        @Test
+        @DisplayName("빈 문자열 토큰이면 예외를 던진다")
+        void throwsException_whenTokenIsEmpty() {
+            assertThatThrownBy(() -> jwtProvider.getSubjectFromExpiredToken(""))
+                    .isInstanceOf(Exception.class);
+        }
+
+        @Test
+        @DisplayName("payload의 sub만 바꾼 위조 토큰은 서명 불일치로 예외를 던진다")
+        void throwsException_whenPayloadIsManipulated() {
+            String realToken = jwtProvider.getIssueToken(1L, true);
+            String[] parts = realToken.split("\\.");
+            // payload의 sub를 999로 변조 (재인코딩, 서명은 그대로)
+            String fakePayload = Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString("{\"sub\":\"999\",\"iat\":0,\"exp\":9999999999}".getBytes());
+            String forgedToken = parts[0] + "." + fakePayload + "." + parts[2];
+
+            assertThatThrownBy(() -> jwtProvider.getSubjectFromExpiredToken(forgedToken))
+                    .isInstanceOf(Exception.class);
+        }
+    }
+
+    // ───────────────────────────────────────────────────────────────
+    // validateAccessToken
+    // ───────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("validateAccessToken")
+    class ValidateAccessToken {
+
+        @Test
+        @DisplayName("유효한 액세스 토큰은 예외를 던지지 않는다")
+        void doesNotThrow_whenTokenIsValid() {
+            String token = jwtProvider.getIssueToken(1L, true);
+
+            assertThatCode(() -> jwtProvider.validateAccessToken(token))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("만료된 액세스 토큰은 UnauthorizedException을 던진다")
+        void throwsUnauthorized_whenTokenIsExpired() {
+            String expiredToken = buildExpiredToken(1L);
+
+            assertThatThrownBy(() -> jwtProvider.validateAccessToken(expiredToken))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("서명이 잘못된 토큰은 UnauthorizedException을 던진다")
+        void throwsUnauthorized_whenSignatureIsInvalid() {
+            String forgedToken = buildTokenWithDifferentKey(1L);
+
+            assertThatThrownBy(() -> jwtProvider.validateAccessToken(forgedToken))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("형식이 잘못된 토큰은 UnauthorizedException을 던진다")
+        void throwsUnauthorized_whenTokenIsMalformed() {
+            assertThatThrownBy(() -> jwtProvider.validateAccessToken("bad.token"))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+    }
+
+    // ───────────────────────────────────────────────────────────────
+    // getIssueToken / getSubject
+    // ───────────────────────────────────────────────────────────────
+    @Nested
+    @DisplayName("getIssueToken")
+    class GetIssueToken {
+
+        @Test
+        @DisplayName("액세스 토큰 발급 후 subject로 userId를 꺼낼 수 있다")
+        void accessToken_containsCorrectUserId() {
+            String token = jwtProvider.getIssueToken(7L, true);
+
+            Long subject = jwtProvider.getSubject(token);
+
+            assertThat(subject).isEqualTo(7L);
+        }
+
+        @Test
+        @DisplayName("리프레시 토큰 발급 후 subject로 userId를 꺼낼 수 있다")
+        void refreshToken_containsCorrectUserId() {
+            String token = jwtProvider.getIssueToken(7L, false);
+
+            Long subject = jwtProvider.getSubject(token);
+
+            assertThat(subject).isEqualTo(7L);
+        }
+    }
+}


### PR DESCRIPTION
## 개요

토큰 재발급 시 accessToken의 서명을 검증하지 않고 payload를 Base64 디코딩만 하여 userId를 추출하던 취약점을 수정한다.

## 변경 사항

### 문제
- `JwtProvider.decodeJwtPayloadSubject()`: 서명 검증 없이 payload를 Base64 디코딩하여 sub 추출
- 공격자가 임의의 userId가 담긴 위조 accessToken으로 재발급 요청 시 서버가 신뢰 → 계정 탈취 가능
- `TokenService.reissue()`에서 `JsonProcessingException`만 잡아 `ArrayIndexOutOfBoundsException` 등이 HTTP 500으로 누출

### 수정
- `JwtProvider`에 `getSubjectFromExpiredToken()` 추가
  - `parseClaimsJws()`로 서명 검증 → 만료된 경우 `ExpiredJwtException.getClaims()`에서 subject 추출
  - 서명 불일치·형식 오류 등 모든 이상 토큰은 예외 전파
- `TokenService.reissue()`에서 `decodeJwtPayloadSubject` → `getSubjectFromExpiredToken`으로 교체
  - 모든 예외를 `UnauthorizedException`으로 일관 처리
- `JwtProvider.decodeJwtPayloadSubject()` 제거

## 테스트

- `JwtProviderTest` 신규 작성 (12개 케이스)
  - `getSubjectFromExpiredToken`: 유효 토큰, 만료 토큰, 위조 서명, 형식 오류, payload 변조 등
  - `validateAccessToken`: 정상/만료/서명 불일치/형식 오류
  - `getIssueToken`: subject 정확성 검증
- `TokenServiceTest` 보강 (reissue 케이스 4개 추가)
  - 서명 불일치, 형식 오류, 일반 예외 → UnauthorizedException 변환
  - `getSubjectFromExpiredToken` 호출 검증

closes #289