### PR TITLE
fix: FULFILLED 상태의 Request를 인프라 정리 없이 직접 삭제할 수 없도록 보호

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Request.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Request.java
@@ -200,10 +200,26 @@ public class Request extends BaseTimeEntity {
 
     /**
      * Request의 상태를 DELETED로 변경합니다. (soft delete)
+     * PENDING, DENIED 상태에서만 호출 가능합니다.
+     * FULFILLED 상태의 요청은 인프라 정리 후 deleteAfterCleanup()을 사용하세요.
      */
     public void delete() {
         if (this.status == Status.DELETED) {
             throw new BusinessException("이미 삭제된 요청입니다.", ErrorCode.INVALID_REQUEST_STATUS);
+        }
+        if (this.status == Status.FULFILLED) {
+            throw new BusinessException("컨테이너가 실행 중입니다. 인프라 정리 후 삭제해주세요.", ErrorCode.INVALID_REQUEST_STATUS);
+        }
+        this.status = Status.DELETED;
+    }
+
+    /**
+     * 인프라(Pod, 우분투 계정) 정리가 완료된 이후 FULFILLED 요청을 DELETED로 전환합니다.
+     * 반드시 외부 리소스 정리를 완료한 시스템 서비스(만료 처리, 사용자 삭제 등)에서만 호출하세요.
+     */
+    public void deleteAfterCleanup() {
+        if (this.status != Status.FULFILLED) {
+            throw new BusinessException("인프라 정리 후 삭제는 FULFILLED 상태에서만 가능합니다.", ErrorCode.INVALID_REQUEST_STATUS);
         }
         this.status = Status.DELETED;
     }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestExpiryService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestExpiryService.java
@@ -37,7 +37,7 @@ public class RequestExpiryService {
         podService.deletePod(request.getPodName());
         ubuntuAccountService.deleteUbuntuAccount(ubuntuUsername);
 
-        request.delete();
+        request.deleteAfterCleanup();
         eventPublisher.publishEvent(new RequestExpiredEvent(user, ubuntuUsername, serverName));
         log.info("삭제 트랜잭션 성공: {}", ubuntuUsername);
     }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserService.java
@@ -116,7 +116,7 @@ public class AdminUserService {
 
             log.info("Config Server's deletion successful for account: {}", username);
 
-            request.delete();
+            request.deleteAfterCleanup();
             requestRepository.save(request);
             log.info("[deleteUbuntuAccount] {}에 대한 Request 정보 상태를 DELETED로 변경 완료", username);
 

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/entity/RequestTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/entity/RequestTest.java
@@ -76,8 +76,18 @@ class RequestTest {
     class Delete {
 
         @Test
-        @DisplayName("삭제하면 상태가 DELETED로 변경된다")
-        void delete_changesStatusToDeleted() {
+        @DisplayName("PENDING 상태에서 삭제하면 상태가 DELETED로 변경된다")
+        void delete_changesStatusToDeleted_whenPending() {
+            request.delete();
+
+            assertThat(request.getStatus()).isEqualTo(Status.DELETED);
+        }
+
+        @Test
+        @DisplayName("DENIED 상태에서 삭제하면 상태가 DELETED로 변경된다")
+        void delete_changesStatusToDeleted_whenDenied() {
+            request.reject("리소스 부족");
+
             request.delete();
 
             assertThat(request.getStatus()).isEqualTo(Status.DELETED);
@@ -89,6 +99,50 @@ class RequestTest {
             request.delete();
 
             assertThatThrownBy(request::delete)
+                    .isInstanceOf(BusinessException.class);
+        }
+
+        @Test
+        @DisplayName("FULFILLED 상태의 Request를 delete()로 삭제하면 BusinessException을 던진다")
+        void delete_throwsException_whenFulfilled() {
+            ContainerImage image = mock(ContainerImage.class);
+            ResourceGroup rg = mock(ResourceGroup.class);
+            request.approve(image, rg, 50L, null);
+
+            assertThatThrownBy(request::delete)
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteAfterCleanup")
+    class DeleteAfterCleanup {
+
+        @Test
+        @DisplayName("FULFILLED 상태에서 인프라 정리 후 삭제하면 상태가 DELETED로 변경된다")
+        void deleteAfterCleanup_changesStatusToDeleted_whenFulfilled() {
+            ContainerImage image = mock(ContainerImage.class);
+            ResourceGroup rg = mock(ResourceGroup.class);
+            request.approve(image, rg, 50L, null);
+
+            request.deleteAfterCleanup();
+
+            assertThat(request.getStatus()).isEqualTo(Status.DELETED);
+        }
+
+        @Test
+        @DisplayName("FULFILLED 이외의 상태에서 deleteAfterCleanup을 호출하면 BusinessException을 던진다")
+        void deleteAfterCleanup_throwsException_whenNotFulfilled() {
+            assertThatThrownBy(request::deleteAfterCleanup)
+                    .isInstanceOf(BusinessException.class);
+        }
+
+        @Test
+        @DisplayName("DENIED 상태에서 deleteAfterCleanup을 호출하면 BusinessException을 던진다")
+        void deleteAfterCleanup_throwsException_whenDenied() {
+            request.reject("리소스 부족");
+
+            assertThatThrownBy(request::deleteAfterCleanup)
                     .isInstanceOf(BusinessException.class);
         }
     }

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestSchedulerServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestSchedulerServiceTest.java
@@ -212,7 +212,7 @@ public class RequestSchedulerServiceTest {
         }
 
         if (status == Status.DELETED) {
-            req.delete();
+            req.deleteAfterCleanup();
         }
 
         return requestRepository.saveAndFlush(req);


### PR DESCRIPTION
## 개요

`Request.delete()`가 컨테이너가 실행 중인 FULFILLED 상태에서도 예외 없이 soft-delete를 허용했다. 이를 수정해 인프라 정리 없는 직접 삭제를 방지한다.

## 변경 사항

### `Request.delete()` — FULFILLED 상태 가드 추가
```
PENDING/DENIED → DELETED  : 허용 (리소스 없음)
FULFILLED      → DELETED  : BusinessException ("컨테이너 실행 중, 인프라 정리 필요")
DELETED        → DELETED  : BusinessException ("이미 삭제")
```

### `Request.deleteAfterCleanup()` — 신규 메서드
인프라(Pod, 우분투 계정) 정리가 완료된 후 시스템 서비스만 호출하는 메서드.  
FULFILLED 상태에서만 동작하며, 그 외 상태에서는 BusinessException을 발생시킨다.

### 호출 측 변경
- `RequestExpiryService.deleteExpiredRequest()`: `request.delete()` → `request.deleteAfterCleanup()`
- `AdminUserService.deleteUbuntuAccount()`: `request.delete()` → `request.deleteAfterCleanup()`

## 테스트

- `RequestTest` — `Delete` 및 `DeleteAfterCleanup` 중첩 클래스 보강
  - PENDING/DENIED 상태에서 delete() 성공
  - FULFILLED 상태에서 delete() → BusinessException
  - FULFILLED 상태에서 deleteAfterCleanup() 성공
  - PENDING/DENIED 상태에서 deleteAfterCleanup() → BusinessException
- `RequestSchedulerServiceTest` 통합 테스트: 테스트 헬퍼 `deleteAfterCleanup()` 호출로 수정 후 통과

closes #297