### PR TITLE
fix: GroupService.createGroup() JSON 역직렬화 실패 시 GID 누출 경고 누락 수정

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
@@ -13,11 +13,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
 
 import java.util.Collections;
 import java.util.List;
@@ -97,33 +99,42 @@ public class GroupService {
                     .uri("/accounts/groups")
                     .bodyValue(apiDto)
                     .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, clientResponse ->
+                            clientResponse.bodyToMono(String.class).flatMap(body -> {
+                                log.error("[createGroup] 외부 API 4xx 오류: 상태 코드={}, 응답={}", clientResponse.statusCode(), body);
+                                if (clientResponse.statusCode() == HttpStatus.BAD_REQUEST) {
+                                    if (body.contains("invalid members")) {
+                                        return Mono.error(new BusinessException(ErrorCode.INVALID_GROUP_MEMBER));
+                                    }
+                                    return Mono.error(new BusinessException(ErrorCode.EXTERNAL_API_ERROR));
+                                } else if (clientResponse.statusCode() == HttpStatus.CONFLICT) {
+                                    if (body.contains("group already exists")) {
+                                        return Mono.error(new BusinessException(ErrorCode.DUPLICATE_GROUP_NAME));
+                                    }
+                                    return Mono.error(new BusinessException(ErrorCode.DUPLICATE_GROUP_ID));
+                                }
+                                return Mono.error(new BusinessException(ErrorCode.GROUP_CREATION_FAILED));
+                            })
+                    )
+                    .onStatus(HttpStatusCode::is5xxServerError, clientResponse ->
+                            clientResponse.bodyToMono(String.class).flatMap(body -> {
+                                log.error("[createGroup] 외부 API 5xx 오류: 상태 코드={}, 응답={}", clientResponse.statusCode(), body);
+                                return Mono.error(new BusinessException(ErrorCode.EXTERNAL_API_ERROR));
+                            })
+                    )
                     .bodyToMono(ConfigServerGroupResponse.class)
                     .block();
 
             log.info("[createGroup] 외부 API 호출 성공: {}", apiResponse);
 
+        } catch (BusinessException e) {
+            throw e;
         } catch (WebClientResponseException e) {
             log.error("[createGroup] 외부 API 호출 실패: 상태 코드={}, 응답={}", e.getStatusCode(), e.getResponseBodyAsString(), e);
-            String responseBody = e.getResponseBodyAsString();
-
-            if (e.getStatusCode() == HttpStatus.BAD_REQUEST) {
-                if (responseBody.contains("invalid members")) {
-                    throw new BusinessException(ErrorCode.INVALID_GROUP_MEMBER);
-                }
-                throw new BusinessException(ErrorCode.EXTERNAL_API_ERROR);
-            } else if (e.getStatusCode() == HttpStatus.CONFLICT) {
-                if (responseBody.contains("group already exists")) {
-                    throw new BusinessException(ErrorCode.DUPLICATE_GROUP_NAME);
-                }
-                throw new BusinessException(ErrorCode.DUPLICATE_GROUP_ID);
-            } else if (e.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR) {
-                throw new BusinessException(ErrorCode.EXTERNAL_API_ERROR);
-            }
-
             throw new BusinessException(ErrorCode.GROUP_CREATION_FAILED);
-
         } catch (Exception e) {
-            log.error("[createGroup] 외부 API 호출 중 예상치 못한 오류 발생", e);
+            log.error("[createGroup] 외부 API 응답 파싱 또는 통신 오류 발생 — " +
+                    "외부 시스템에 그룹이 생성되었을 수 있습니다. 수동 확인이 필요합니다. groupName={}", dto.groupName(), e);
             throw new BusinessException(ErrorCode.GROUP_CREATION_FAILED);
         }
 

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupServiceTest.java
@@ -5,6 +5,7 @@ import DGU_AI_LAB.admin_be.domain.groups.dto.response.GroupResponseDTO;
 import DGU_AI_LAB.admin_be.domain.groups.entity.Group;
 import DGU_AI_LAB.admin_be.domain.groups.repository.GroupRepository;
 import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -13,7 +14,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -69,15 +72,9 @@ class GroupServiceTest {
     @DisplayName("createGroup")
     class CreateGroup {
 
-        @Test
-        @DisplayName("유효한 요청으로 그룹을 생성하면 GroupResponseDTO를 반환한다")
         @SuppressWarnings("unchecked")
-        void createGroup_success() {
-            // Arrange
-            when(groupRepository.existsByGroupName("developers")).thenReturn(false);
-            when(groupRepository.existsByUbuntuGid(2000L)).thenReturn(false);
-
-            // Mock WebClient chain
+        private WebClient.ResponseSpec mockWebClientSuccess(
+                GroupService.ConfigServerGroupResponse response) {
             WebClient.RequestBodyUriSpec uriSpec = mock(WebClient.RequestBodyUriSpec.class);
             WebClient.RequestBodySpec bodySpec = mock(WebClient.RequestBodySpec.class);
             WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
@@ -85,23 +82,30 @@ class GroupServiceTest {
             doReturn(bodySpec).when(uriSpec).uri(anyString());
             doReturn(bodySpec).when(bodySpec).bodyValue(any());
             doReturn(responseSpec).when(bodySpec).retrieve();
-            doReturn(Mono.just(new GroupService.ConfigServerGroupResponse(
-                    new GroupService.ConfigServerGroupInfo("developers", 2000L)
-            )))
+            doReturn(responseSpec).when(responseSpec).onStatus(any(), any());
+            doReturn(Mono.just(response))
                     .when(responseSpec).bodyToMono(GroupService.ConfigServerGroupResponse.class);
+            return responseSpec;
+        }
+
+        @Test
+        @DisplayName("유효한 요청으로 그룹을 생성하면 GroupResponseDTO를 반환한다")
+        void createGroup_success() {
+            when(groupRepository.existsByGroupName("developers")).thenReturn(false);
+            when(groupRepository.existsByUbuntuGid(2000L)).thenReturn(false);
+
+            mockWebClientSuccess(new GroupService.ConfigServerGroupResponse(
+                    new GroupService.ConfigServerGroupInfo("developers", 2000L)));
 
             Group savedGroup = Group.builder().groupName("developers").ubuntuGid(2000L).build();
             when(groupRepository.save(any(Group.class))).thenReturn(savedGroup);
 
             CreateGroupRequestDTO dto = new CreateGroupRequestDTO("developers", null);
 
-            // Act
             GroupResponseDTO result = groupService.createGroup(dto, 1L);
 
-            // Assert
             assertThat(result.groupName()).isEqualTo("developers");
             assertThat(result.ubuntuGid()).isEqualTo(2000L);
-            verify(bodySpec).bodyValue(new GroupService.ConfigServerGroupRequest("developers", List.of()));
         }
 
         @Test
@@ -127,9 +131,38 @@ class GroupServiceTest {
         }
 
         @Test
-        @DisplayName("infra가 유효하지 않은 GID를 반환하면 BusinessException을 던진다")
-        @SuppressWarnings("unchecked")
+        @DisplayName("infra가 유효하지 않은 GID(0)를 반환하면 BusinessException을 던진다")
         void createGroup_throwsException_whenInfraReturnsInvalidGid() {
+            when(groupRepository.existsByGroupName("developers")).thenReturn(false);
+
+            mockWebClientSuccess(new GroupService.ConfigServerGroupResponse(
+                    new GroupService.ConfigServerGroupInfo("developers", 0L)));
+
+            CreateGroupRequestDTO dto = new CreateGroupRequestDTO("developers", null);
+
+            assertThatThrownBy(() -> groupService.createGroup(dto, 1L))
+                    .isInstanceOf(BusinessException.class);
+            verify(groupRepository, never()).save(any(Group.class));
+        }
+
+        @Test
+        @DisplayName("infra가 null GID를 반환하면 BusinessException을 던진다")
+        void createGroup_throwsException_whenInfraReturnsNullGid() {
+            when(groupRepository.existsByGroupName("developers")).thenReturn(false);
+
+            mockWebClientSuccess(new GroupService.ConfigServerGroupResponse(null));
+
+            CreateGroupRequestDTO dto = new CreateGroupRequestDTO("developers", null);
+
+            assertThatThrownBy(() -> groupService.createGroup(dto, 1L))
+                    .isInstanceOf(BusinessException.class);
+            verify(groupRepository, never()).save(any(Group.class));
+        }
+
+        @Test
+        @DisplayName("onStatus 핸들러에서 4xx 에러 발생 시 BusinessException을 던진다")
+        @SuppressWarnings("unchecked")
+        void createGroup_throwsException_when4xxFromOnStatus() {
             when(groupRepository.existsByGroupName("developers")).thenReturn(false);
 
             WebClient.RequestBodyUriSpec uriSpec = mock(WebClient.RequestBodyUriSpec.class);
@@ -139,10 +172,74 @@ class GroupServiceTest {
             doReturn(bodySpec).when(uriSpec).uri(anyString());
             doReturn(bodySpec).when(bodySpec).bodyValue(any());
             doReturn(responseSpec).when(bodySpec).retrieve();
-            doReturn(Mono.just(new GroupService.ConfigServerGroupResponse(
-                    new GroupService.ConfigServerGroupInfo("developers", 0L)
-            )))
+            doReturn(responseSpec).when(responseSpec).onStatus(any(), any());
+            doReturn(Mono.error(new BusinessException(ErrorCode.DUPLICATE_GROUP_NAME)))
                     .when(responseSpec).bodyToMono(GroupService.ConfigServerGroupResponse.class);
+
+            CreateGroupRequestDTO dto = new CreateGroupRequestDTO("developers", null);
+
+            assertThatThrownBy(() -> groupService.createGroup(dto, 1L))
+                    .isInstanceOf(BusinessException.class);
+            verify(groupRepository, never()).save(any(Group.class));
+        }
+
+        @Test
+        @DisplayName("WebClientResponseException 발생 시 GROUP_CREATION_FAILED BusinessException을 던진다")
+        @SuppressWarnings("unchecked")
+        void createGroup_throwsException_whenWebClientThrowsResponseException() {
+            when(groupRepository.existsByGroupName("developers")).thenReturn(false);
+
+            WebClient.RequestBodyUriSpec uriSpec = mock(WebClient.RequestBodyUriSpec.class);
+            WebClient.RequestBodySpec bodySpec = mock(WebClient.RequestBodySpec.class);
+            WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
+            doReturn(uriSpec).when(groupCreationWebClient).put();
+            doReturn(bodySpec).when(uriSpec).uri(anyString());
+            doReturn(bodySpec).when(bodySpec).bodyValue(any());
+            doReturn(responseSpec).when(bodySpec).retrieve();
+            doReturn(responseSpec).when(responseSpec).onStatus(any(), any());
+            doReturn(Mono.error(WebClientResponseException.create(
+                    HttpStatus.INTERNAL_SERVER_ERROR.value(), "Server Error", null, null, null)))
+                    .when(responseSpec).bodyToMono(GroupService.ConfigServerGroupResponse.class);
+
+            CreateGroupRequestDTO dto = new CreateGroupRequestDTO("developers", null);
+
+            assertThatThrownBy(() -> groupService.createGroup(dto, 1L))
+                    .isInstanceOf(BusinessException.class);
+            verify(groupRepository, never()).save(any(Group.class));
+        }
+
+        @Test
+        @DisplayName("응답 파싱 오류(예: 역직렬화 실패) 시 GROUP_CREATION_FAILED BusinessException을 던진다")
+        @SuppressWarnings("unchecked")
+        void createGroup_throwsException_whenDeserializationFails() {
+            when(groupRepository.existsByGroupName("developers")).thenReturn(false);
+
+            WebClient.RequestBodyUriSpec uriSpec = mock(WebClient.RequestBodyUriSpec.class);
+            WebClient.RequestBodySpec bodySpec = mock(WebClient.RequestBodySpec.class);
+            WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
+            doReturn(uriSpec).when(groupCreationWebClient).put();
+            doReturn(bodySpec).when(uriSpec).uri(anyString());
+            doReturn(bodySpec).when(bodySpec).bodyValue(any());
+            doReturn(responseSpec).when(bodySpec).retrieve();
+            doReturn(responseSpec).when(responseSpec).onStatus(any(), any());
+            doReturn(Mono.error(new RuntimeException("JSON parse error")))
+                    .when(responseSpec).bodyToMono(GroupService.ConfigServerGroupResponse.class);
+
+            CreateGroupRequestDTO dto = new CreateGroupRequestDTO("developers", null);
+
+            assertThatThrownBy(() -> groupService.createGroup(dto, 1L))
+                    .isInstanceOf(BusinessException.class);
+            verify(groupRepository, never()).save(any(Group.class));
+        }
+
+        @Test
+        @DisplayName("이미 DB에 존재하는 GID를 외부 API가 반환하면 BusinessException을 던진다")
+        void createGroup_throwsException_whenGidAlreadyExistsInDb() {
+            when(groupRepository.existsByGroupName("developers")).thenReturn(false);
+            when(groupRepository.existsByUbuntuGid(2000L)).thenReturn(true);
+
+            mockWebClientSuccess(new GroupService.ConfigServerGroupResponse(
+                    new GroupService.ConfigServerGroupInfo("developers", 2000L)));
 
             CreateGroupRequestDTO dto = new CreateGroupRequestDTO("developers", null);
 


### PR DESCRIPTION
## 개요

`GroupService.createGroup()`의 외부 API 호출 중 JSON 역직렬화 또는 네트워크 오류 시, 외부 시스템에 그룹이 생성되었을 수 있음에도 경고 로그가 없었다.

## 변경 사항

### 1. `onStatus()` 핸들러 추가

기존 코드에는 `onStatus()` 핸들러가 없어 4xx/5xx 에러 처리가 암묵적이었다.  
`createPod()`처럼 `onStatus(4xx)`, `onStatus(5xx)` 핸들러를 명시적으로 추가하여 에러 처리 흐름을 가시화했다.

### 2. `catch (Exception e)` — GID 누출 경고 로그 추가

`WebClientResponseException`이 아닌 예외(HTTP 200 이후 역직렬화 실패, 코덱 오류 등)는 외부 시스템이 그룹을 생성했을 가능성이 있다.  
이 경우 `groupName`을 포함한 경고 로그를 남겨 수동 확인이 가능하도록 했다.

```
[createGroup] 외부 API 응답 파싱 또는 통신 오류 발생 — 외부 시스템에 그룹이 생성되었을 수 있습니다. 수동 확인이 필요합니다. groupName=...
```

### 3. 예외 처리 순서 수정

`onStatus()` 핸들러에서 `BusinessException`을 throw할 경우 `catch (Exception e)` 블록이 가로채는 문제를 방지하기 위해 `catch (BusinessException e)` → `catch (WebClientResponseException e)` → `catch (Exception e)` 순서로 재배치했다.

## 테스트

- 기존 테스트: `onStatus()` stubbing 추가 후 모두 통과
- 신규 테스트 추가 (4개)
  - null GID 반환 시 BusinessException
  - `onStatus` 핸들러에서 BusinessException 전파 시 올바르게 처리
  - `WebClientResponseException` catch → BusinessException 변환
  - 역직렬화 실패 → BusinessException + GID 누출 경고 경로
  - DB에 이미 존재하는 GID 반환 시 BusinessException

closes #299