### PR TITLE
fix: UserUpdateRequestDTO에서 사용되지 않는 username 필드 제거

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/dto/request/UserUpdateRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/dto/request/UserUpdateRequestDTO.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record UserUpdateRequestDTO(
-        @NotBlank String username,
         @NotBlank String password,
         @NotNull Boolean isActive
 ) {}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserServiceTest.java
@@ -96,7 +96,7 @@ class AdminUserServiceTest {
         void updateUser_success() {
             when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
 
-            UserUpdateRequestDTO request = new UserUpdateRequestDTO("홍길동", "newPw", false);
+            UserUpdateRequestDTO request = new UserUpdateRequestDTO("newPw", false);
             UserResponseDTO result = adminUserService.updateUser(1L, request);
 
             assertThat(result).isNotNull();
@@ -107,7 +107,7 @@ class AdminUserServiceTest {
         void updateUser_throwsException_whenUserNotFound() {
             when(userRepository.findById(99L)).thenReturn(Optional.empty());
 
-            UserUpdateRequestDTO request = new UserUpdateRequestDTO("홍길동", "newPw", false);
+            UserUpdateRequestDTO request = new UserUpdateRequestDTO("newPw", false);
 
             assertThatThrownBy(() -> adminUserService.updateUser(99L, request))
                     .isInstanceOf(EntityNotFoundException.class);


### PR DESCRIPTION
## 개요

`UserUpdateRequestDTO`의 `username` 필드는 `AdminUserService.updateUser()`에서 전혀 사용되지 않는다. username은 변경 불가 정책이므로 불필요한 필드를 제거한다.

## 변경 사항

- `UserUpdateRequestDTO`: `@NotBlank String username` 제거
- `AdminUserServiceTest`: `new UserUpdateRequestDTO(...)` 호출에서 username 인수 제거

## 영향 범위

- `UserUpdateRequestDTO`를 직접 인스턴스화하는 테스트 코드만 수정 필요
- `updateUser()` 서비스 로직은 username을 사용하지 않으므로 동작 변경 없음

closes #301