### PR TITLE
fix: mailSender.send() MailException도 BusinessException으로 래핑

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/global/util/EmailService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/global/util/EmailService.java
@@ -58,7 +58,7 @@ public class EmailService {
             helper.setText(text, false);
 
             mailSender.send(message);
-        } catch (MessagingException e) {
+        } catch (MessagingException | RuntimeException e) {
             log.error("이메일 전송 실패: 수신자={}", to, e);
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
         }


### PR DESCRIPTION
## 요약
- M-7 머지 이후 테스트 실행 중 발견된 누락 사항
- `EmailService.sendEmail()`의 catch 블록이 `MessagingException`만 처리하고 있어, `mailSender.send()` 호출 시 발생하는 `MailException`(extends RuntimeException)은 잡히지 않아 500으로 누출됨
- `catch (MessagingException | RuntimeException e)`로 확장하여 SMTP 연결 실패 등 모든 전송 오류를 `BusinessException`으로 래핑