### PR TITLE
test: 기존 로그인 테스트에 BCrypt 1회 호출 verify 추가

### DIFF
--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/UserLoginServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/UserLoginServiceTest.java
@@ -116,7 +116,7 @@ class UserLoginServiceTest {
     class Login {
 
         @Test
-        @DisplayName("올바른 이메일과 비밀번호로 로그인하면 토큰을 반환한다")
+        @DisplayName("올바른 이메일과 비밀번호로 로그인하면 토큰을 반환하고 BCrypt 검증은 정확히 1회 실행된다")
         void login_success() {
             when(userRepository.findByEmail("test@dgu.ac.kr")).thenReturn(Optional.of(activeUser));
             when(passwordEncoder.matches("password123", "encodedPassword")).thenReturn(true);
@@ -130,6 +130,7 @@ class UserLoginServiceTest {
             assertThat(result).isNotNull();
             assertThat(result.accessToken()).isEqualTo("accessToken");
             assertThat(result.refreshToken()).isEqualTo("refreshToken");
+            verify(passwordEncoder, times(1)).matches("password123", "encodedPassword");
         }
 
         @Test
@@ -165,7 +166,7 @@ class UserLoginServiceTest {
         }
 
         @Test
-        @DisplayName("비밀번호가 틀리면 UnauthorizedException을 던진다")
+        @DisplayName("비밀번호가 틀리면 UnauthorizedException을 던지고 BCrypt 검증은 정확히 1회 실행된다")
         void login_throwsException_whenPasswordWrong() {
             when(userRepository.findByEmail("test@dgu.ac.kr")).thenReturn(Optional.of(activeUser));
             when(passwordEncoder.matches("wrongPw", "encodedPassword")).thenReturn(false);
@@ -174,6 +175,7 @@ class UserLoginServiceTest {
 
             assertThatThrownBy(() -> userLoginService.login(dto))
                     .isInstanceOf(UnauthorizedException.class);
+            verify(passwordEncoder, times(1)).matches("wrongPw", "encodedPassword");
         }
 
         @Test


### PR DESCRIPTION
#281 대체. login_success와 login_throwsException_whenPasswordWrong 테스트에 verify(passwordEncoder, times(1)) 추가.