### PR TITLE
fix: soft-delete된 계정의 JWT 토큰 즉시 차단

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/global/auth/CustomUserDetailsService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/global/auth/CustomUserDetailsService.java
@@ -28,8 +28,12 @@ public class CustomUserDetailsService implements UserDetailsService {
      * JwtAuthenticationFilter에서 user 엔티티를 직접 가져올 때 사용
      */
     public User loadUserEntityById(Long userId) {
-        return userRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UnauthorizedException(ErrorCode.USER_NOT_FOUND));
+        if (!user.getIsActive()) {
+            throw new UnauthorizedException(ErrorCode.ACCOUNT_DISABLED);
+        }
+        return user;
     }
 }
 

--- a/src/test/java/DGU_AI_LAB/admin_be/global/auth/CustomUserDetailsServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/global/auth/CustomUserDetailsServiceTest.java
@@ -1,0 +1,98 @@
+package DGU_AI_LAB.admin_be.global.auth;
+
+import DGU_AI_LAB.admin_be.domain.users.entity.User;
+import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
+import DGU_AI_LAB.admin_be.error.exception.UnauthorizedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CustomUserDetailsService")
+class CustomUserDetailsServiceTest {
+
+    @InjectMocks
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User activeUser;
+    private User inactiveUser;
+
+    @BeforeEach
+    void setUp() {
+        activeUser = User.builder()
+                .email("active@dgu.ac.kr")
+                .password("encoded")
+                .name("활성유저")
+                .studentId("2021001111")
+                .phone("010-1111-1111")
+                .department("컴퓨터공학과")
+                .build();
+
+        inactiveUser = User.builder()
+                .email("inactive@dgu.ac.kr")
+                .password("encoded")
+                .name("비활성유저")
+                .studentId("2021002222")
+                .phone("010-2222-2222")
+                .department("컴퓨터공학과")
+                .build();
+        inactiveUser.withdraw(); // isActive = false, deletedAt 설정
+    }
+
+    @Nested
+    @DisplayName("loadUserEntityById")
+    class LoadUserEntityById {
+
+        @Test
+        @DisplayName("활성 계정은 정상 반환된다")
+        void loadUserEntityById_returnsUser_whenActive() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(activeUser));
+
+            User result = customUserDetailsService.loadUserEntityById(1L);
+
+            assertThat(result).isEqualTo(activeUser);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 userId면 UnauthorizedException을 던진다")
+        void loadUserEntityById_throwsUnauthorized_whenUserNotFound() {
+            when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> customUserDetailsService.loadUserEntityById(999L))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("soft-delete된 계정(isActive=false)은 UnauthorizedException을 던진다 — JWT 토큰이 유효해도 차단")
+        void loadUserEntityById_throwsUnauthorized_whenAccountInactive() {
+            when(userRepository.findById(2L)).thenReturn(Optional.of(inactiveUser));
+
+            assertThatThrownBy(() -> customUserDetailsService.loadUserEntityById(2L))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("관리자가 사용자를 삭제한 직후 해당 userId로 조회하면 UnauthorizedException이 발생한다")
+        void loadUserEntityById_throwsUnauthorized_afterAdminDeletesUser() {
+            // 관리자가 deleteUser() 호출 → user.withdraw() → isActive=false
+            when(userRepository.findById(3L)).thenReturn(Optional.of(inactiveUser));
+
+            assertThatThrownBy(() -> customUserDetailsService.loadUserEntityById(3L))
+                    .isInstanceOf(UnauthorizedException.class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `CustomUserDetailsService.loadUserEntityById()`에 `isActive` 검증 추가
- 관리자가 사용자를 삭제(`isActive=false`)한 직후부터 해당 사용자의 JWT 토큰을 즉시 차단
- 기존에는 삭제된 계정이 토큰 만료 시까지(최대 1시간) API를 계속 호출 가능했음

## 영향 범위
- **인프라**: 영향 없음 (JWT 필터 내부 로직만 변경)
- **프론트엔드**: 삭제된 계정의 API 호출이 기존 200 → 401로 변경됨. 프론트에서 401 처리 시 로그인 페이지로 리다이렉트되는지 확인 필요

## 변경 파일
- `CustomUserDetailsService.java`: `loadUserEntityById()`에 `isActive` false 시 `UnauthorizedException` 발생 추가
- `CustomUserDetailsServiceTest.java`: 활성/비활성/미존재 계정 케이스 테스트 4건 추가

## Test plan
- [ ] 활성 계정 JWT로 API 호출 → 200 정상 응답 확인
- [ ] 관리자가 계정 삭제 후 동일 JWT로 API 호출 → 401 즉시 반환 확인
- [ ] 단위 테스트 4건 통과 확인