### PR TITLE
fix: AdminUserService self-invocation 제거 및 상태별 Request 처리 (#H-NEW-5)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/UbuntuAccountService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/UbuntuAccountService.java
@@ -8,8 +8,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
@@ -27,7 +25,6 @@ public class UbuntuAccountService {
 
     private final @Qualifier("configWebClient") WebClient webClient;
 
-    @Transactional(propagation = Propagation.MANDATORY)
     public void deleteUbuntuAccount(String username) {
 
         try {

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserService.java
@@ -1,24 +1,20 @@
 package DGU_AI_LAB.admin_be.domain.users.service;
 
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
 import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import DGU_AI_LAB.admin_be.domain.requests.service.UbuntuAccountService;
 import DGU_AI_LAB.admin_be.domain.users.dto.request.UserUpdateRequestDTO;
 import DGU_AI_LAB.admin_be.domain.users.dto.response.UserResponseDTO;
 import DGU_AI_LAB.admin_be.domain.users.dto.response.UserSummaryDTO;
 import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
 import DGU_AI_LAB.admin_be.error.ErrorCode;
-import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import DGU_AI_LAB.admin_be.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
 
@@ -30,7 +26,7 @@ public class AdminUserService {
 
     private final UserRepository userRepository;
     private final RequestRepository requestRepository;
-    private final @Qualifier("configWebClient") WebClient userWebClient;
+    private final UbuntuAccountService ubuntuAccountService;
 
     /**
      * 전체 유저 조회
@@ -58,15 +54,37 @@ public class AdminUserService {
 
         List<Request> userRequests = requestRepository.findAllByUser(user);
 
-        if (!userRequests.isEmpty()) {
-            userRequests.forEach(request -> deleteUbuntuAccount(request.getUbuntuUsername()));
-            log.info("[deleteUser] userId={}와 연결된 모든 Request의 외부 계정 삭제 요청 완료", userId);
-        } else {
-            log.info("[deleteUser] userId={}와 연결된 Request가 없습니다. 외부 계정 삭제 요청을 건너뜁니다.", userId);
+        for (Request request : userRequests) {
+            if (request.getStatus() == Status.FULFILLED) {
+                ubuntuAccountService.deleteUbuntuAccount(request.getUbuntuUsername());
+                request.deleteAfterCleanup();
+                requestRepository.save(request);
+            } else if (request.getStatus() != Status.DELETED) {
+                request.delete();
+            }
         }
+        log.info("[deleteUser] userId={}와 연결된 Request 정리 완료", userId);
 
         user.updateUserInfo(null, false);
         log.info("[deleteUser] userId={} 논리적 삭제 완료 (isActive=false)", userId);
+    }
+
+    /**
+     * 단독 우분투 계정 삭제 (컨트롤러 엔드포인트용)
+     * FULFILLED 상태인 Request를 username으로 찾아 외부 계정 삭제 후 DB 상태를 DELETED로 변경한다.
+     */
+    @Transactional
+    public void deleteUbuntuAccount(String username) {
+        log.warn("[deleteUbuntuAccount] 우분투 계정 삭제 시도: {}", username);
+        Request request = requestRepository.findByUbuntuUsername(username)
+                .orElseThrow(() -> {
+                    log.warn("[deleteUbuntuAccount] {}에 해당하는 Request가 없습니다.", username);
+                    return new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND);
+                });
+        ubuntuAccountService.deleteUbuntuAccount(username);
+        request.deleteAfterCleanup();
+        requestRepository.save(request);
+        log.info("[deleteUbuntuAccount] {} 계정 삭제 및 DB 상태 업데이트 완료", username);
     }
 
     /**
@@ -82,49 +100,4 @@ public class AdminUserService {
         return UserResponseDTO.fromEntity(user);
     }
 
-    /**
-     * username으로 우분투 계정 삭제
-     * Config Server에 요청을 보내 실제로 ubuntu 계정을 삭제하고, DB의 Request 엔티티 Status를 DELETED로 변경합니다.
-     */
-    public void deleteUbuntuAccount(String username) {
-        log.warn("[deleteUbuntuAccount] 우분투 계정 삭제 시도: {}", username);
-
-        Request request = requestRepository.findByUbuntuUsername(username)
-                .orElseThrow(() -> {
-                    log.warn("[deleteUbuntuAccount] {}에 해당하는 Request가 없습니다.", username);
-                    return new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND);
-                });
-
-        try {
-            log.info("Starting Config Server API call to delete ubuntu account: {}", username);
-            userWebClient.delete()
-                    .uri("/accounts/users/{username}", username)
-                    .retrieve()
-                    .onStatus(HttpStatus.BAD_REQUEST::equals, clientResponse ->
-                            Mono.error(new BusinessException(ErrorCode.INVALID_USERNAME_FORMAT))
-                    )
-                    .onStatus(HttpStatus.NOT_FOUND::equals, clientResponse -> {
-                        log.warn("외부 서버에 {} 계정이 이미 존재하지 않아 삭제가 불필요합니다.", username);
-                        return Mono.empty();
-                    })
-                    .onStatus(HttpStatusCode::isError, clientResponse ->
-                            clientResponse.bodyToMono(String.class)
-                                    .flatMap(body -> Mono.error(new BusinessException("우분투 계정 삭제 실패: " + body, ErrorCode.UBUNTU_USER_DELETION_FAILED)))
-                    )
-                    .toBodilessEntity()
-                    .block();
-
-            log.info("Config Server's deletion successful for account: {}", username);
-
-            request.deleteAfterCleanup();
-            requestRepository.save(request);
-            log.info("[deleteUbuntuAccount] {}에 대한 Request 정보 상태를 DELETED로 변경 완료", username);
-
-        } catch (BusinessException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("An unexpected error occurred during Config Server's account deletion.", e);
-            throw new BusinessException("우분투 계정 삭제 중 예기치 않은 오류 발생.", ErrorCode.UBUNTU_USER_DELETION_FAILED);
-        }
-    }
 }

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserServiceTest.java
@@ -1,13 +1,16 @@
 package DGU_AI_LAB.admin_be.domain.users.service;
 
+import DGU_AI_LAB.admin_be.domain.containerImage.entity.ContainerImage;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
 import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import DGU_AI_LAB.admin_be.domain.requests.service.UbuntuAccountService;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
 import DGU_AI_LAB.admin_be.domain.users.dto.request.UserUpdateRequestDTO;
 import DGU_AI_LAB.admin_be.domain.users.dto.response.UserResponseDTO;
 import DGU_AI_LAB.admin_be.domain.users.dto.response.UserSummaryDTO;
 import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
-import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import DGU_AI_LAB.admin_be.error.exception.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,23 +20,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 class AdminUserServiceTest {
 
     @InjectMocks
@@ -46,15 +42,7 @@ class AdminUserServiceTest {
     private RequestRepository requestRepository;
 
     @Mock
-    private WebClient userWebClient;
-
-    // WebClient DELETE 체이닝 mock
-    @Mock
-    private WebClient.RequestHeadersUriSpec<?> deleteUriSpec;
-    @Mock
-    private WebClient.RequestHeadersSpec<?> deleteHeadersSpec;
-    @Mock
-    private WebClient.ResponseSpec deleteResponseSpec;
+    private UbuntuAccountService ubuntuAccountService;
 
     private User mockUser;
 
@@ -144,6 +132,7 @@ class AdminUserServiceTest {
             adminUserService.deleteUser(1L);
 
             assertThat(mockUser.getIsActive()).isFalse();
+            verifyNoInteractions(ubuntuAccountService);
         }
 
         @Test
@@ -154,68 +143,134 @@ class AdminUserServiceTest {
             assertThatThrownBy(() -> adminUserService.deleteUser(99L))
                     .isInstanceOf(EntityNotFoundException.class);
         }
+
+        @Test
+        @DisplayName("FULFILLED 상태 Request가 있으면 외부 계정 삭제 후 deleteAfterCleanup을 호출한다")
+        void deleteUser_withFulfilledRequest_callsUbuntuDelete() {
+            Request fulfilledRequest = mock(Request.class);
+            when(fulfilledRequest.getStatus()).thenReturn(Status.FULFILLED);
+            when(fulfilledRequest.getUbuntuUsername()).thenReturn("testuser");
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+            when(requestRepository.findAllByUser(mockUser)).thenReturn(List.of(fulfilledRequest));
+
+            adminUserService.deleteUser(1L);
+
+            verify(ubuntuAccountService).deleteUbuntuAccount("testuser");
+            verify(fulfilledRequest).deleteAfterCleanup();
+            assertThat(mockUser.getIsActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("PENDING 상태 Request가 있으면 delete()를 호출한다 (외부 API 미호출)")
+        void deleteUser_withPendingRequest_callsDelete() {
+            Request pendingRequest = mock(Request.class);
+            when(pendingRequest.getStatus()).thenReturn(Status.PENDING);
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+            when(requestRepository.findAllByUser(mockUser)).thenReturn(List.of(pendingRequest));
+
+            adminUserService.deleteUser(1L);
+
+            verify(pendingRequest).delete();
+            verifyNoInteractions(ubuntuAccountService);
+        }
+
+        @Test
+        @DisplayName("DELETED 상태 Request는 아무 처리도 하지 않는다")
+        void deleteUser_withDeletedRequest_skips() {
+            Request deletedRequest = mock(Request.class);
+            when(deletedRequest.getStatus()).thenReturn(Status.DELETED);
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+            when(requestRepository.findAllByUser(mockUser)).thenReturn(List.of(deletedRequest));
+
+            adminUserService.deleteUser(1L);
+
+            verify(deletedRequest, never()).delete();
+            verify(deletedRequest, never()).deleteAfterCleanup();
+            verifyNoInteractions(ubuntuAccountService);
+        }
+
+        @Test
+        @DisplayName("여러 상태의 Request가 혼합되면 각각 적절히 처리한다")
+        void deleteUser_withMixedRequests_handlesEachCorrectly() {
+            Request fulfilled = mock(Request.class);
+            when(fulfilled.getStatus()).thenReturn(Status.FULFILLED);
+            when(fulfilled.getUbuntuUsername()).thenReturn("fuser");
+
+            Request pending = mock(Request.class);
+            when(pending.getStatus()).thenReturn(Status.PENDING);
+
+            Request deleted = mock(Request.class);
+            when(deleted.getStatus()).thenReturn(Status.DELETED);
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+            when(requestRepository.findAllByUser(mockUser)).thenReturn(List.of(fulfilled, pending, deleted));
+
+            adminUserService.deleteUser(1L);
+
+            verify(ubuntuAccountService).deleteUbuntuAccount("fuser");
+            verify(fulfilled).deleteAfterCleanup();
+            verify(pending).delete();
+            verify(deleted, never()).delete();
+            verify(deleted, never()).deleteAfterCleanup();
+        }
     }
 
     @Nested
-    @DisplayName("deleteUbuntuAccount")
+    @DisplayName("deleteUbuntuAccount (단독 엔드포인트용)")
     class DeleteUbuntuAccount {
 
-        @SuppressWarnings("unchecked")
-        private void stubDeleteSuccess() {
-            when(userWebClient.delete()).thenReturn((WebClient.RequestHeadersUriSpec) deleteUriSpec);
-            when(deleteUriSpec.uri(anyString(), anyString())).thenReturn((WebClient.RequestHeadersSpec) deleteHeadersSpec);
-            when(deleteHeadersSpec.retrieve()).thenReturn(deleteResponseSpec);
-            when(deleteResponseSpec.onStatus(any(), any())).thenReturn(deleteResponseSpec);
-            when(deleteResponseSpec.toBodilessEntity()).thenReturn(Mono.empty());
+        private Request buildFulfilledRequest() {
+            ResourceGroup rg = ResourceGroup.builder()
+                    .resourceGroupName("Server A")
+                    .description("desc")
+                    .serverName("server-01")
+                    .build();
+            ContainerImage image = ContainerImage.builder()
+                    .imageName("pytorch")
+                    .imageVersion("2.1.0")
+                    .cudaVersion("11.8")
+                    .description("desc")
+                    .build();
+            Request req = Request.builder()
+                    .ubuntuUsername("testuser")
+                    .ubuntuPassword("pw")
+                    .ubuntuPasswordBase64("base64pw")
+                    .volumeSizeGiB(50L)
+                    .expiresAt(LocalDateTime.now().plusDays(30))
+                    .usagePurpose("연구")
+                    .formAnswers("{}")
+                    .user(mockUser)
+                    .resourceGroup(rg)
+                    .containerImage(image)
+                    .build();
+            req.approve(image, rg, 100L, null);
+            return req;
         }
 
         @Test
-        @DisplayName("DELETE /accounts/users/{username}으로 요청을 전송한다")
-        void deleteUbuntuAccount_sendsDELETERequest() {
-            Request mockRequest = mock(Request.class);
-            when(requestRepository.findByUbuntuUsername("testuser")).thenReturn(Optional.of(mockRequest));
-            stubDeleteSuccess();
+        @DisplayName("FULFILLED Request가 있으면 외부 API 호출 후 DB 상태를 DELETED로 변경한다")
+        void deleteUbuntuAccount_success() {
+            Request request = buildFulfilledRequest();
+            when(requestRepository.findByUbuntuUsername("testuser")).thenReturn(Optional.of(request));
 
             adminUserService.deleteUbuntuAccount("testuser");
 
-            verify(userWebClient).delete();
-            verify(deleteUriSpec).uri("/accounts/users/{username}", "testuser");
+            verify(ubuntuAccountService).deleteUbuntuAccount("testuser");
+            assertThat(request.getStatus()).isEqualTo(Status.DELETED);
         }
 
         @Test
-        @DisplayName("config-server가 400을 응답하면 INVALID_USERNAME_FORMAT BusinessException을 던진다")
-        void deleteUbuntuAccount_throws_whenBadRequest() {
-            Request mockRequest = mock(Request.class);
-            when(requestRepository.findByUbuntuUsername("baduser")).thenReturn(Optional.of(mockRequest));
+        @DisplayName("해당 username의 Request가 없으면 EntityNotFoundException을 던진다")
+        void deleteUbuntuAccount_throwsWhenNotFound() {
+            when(requestRepository.findByUbuntuUsername("nobody")).thenReturn(Optional.empty());
 
-            when(userWebClient.delete()).thenReturn((WebClient.RequestHeadersUriSpec) deleteUriSpec);
-            when(deleteUriSpec.uri(anyString(), anyString())).thenReturn((WebClient.RequestHeadersSpec) deleteHeadersSpec);
-            when(deleteHeadersSpec.retrieve()).thenReturn(deleteResponseSpec);
-            when(deleteResponseSpec.onStatus(any(), any())).thenAnswer(inv -> {
-                java.util.function.Predicate<org.springframework.http.HttpStatusCode> predicate = inv.getArgument(0);
-                if (predicate.test(HttpStatus.BAD_REQUEST)) {
-                    org.springframework.web.reactive.function.client.ClientResponse clientResponse =
-                            mock(org.springframework.web.reactive.function.client.ClientResponse.class);
-                    when(inv.<java.util.function.Function<org.springframework.web.reactive.function.client.ClientResponse, reactor.core.publisher.Mono<? extends Throwable>>>getArgument(1)
-                            .apply(clientResponse))
-                            .thenReturn(Mono.error(new BusinessException(DGU_AI_LAB.admin_be.error.ErrorCode.INVALID_USERNAME_FORMAT)));
-                }
-                return deleteResponseSpec;
-            });
-            when(deleteResponseSpec.toBodilessEntity())
-                    .thenReturn(Mono.error(new BusinessException(DGU_AI_LAB.admin_be.error.ErrorCode.INVALID_USERNAME_FORMAT)));
-
-            assertThatThrownBy(() -> adminUserService.deleteUbuntuAccount("baduser"))
-                    .isInstanceOf(BusinessException.class);
-        }
-
-        @Test
-        @DisplayName("Request가 없으면 EntityNotFoundException을 던진다")
-        void deleteUbuntuAccount_throws_whenRequestNotFound() {
-            when(requestRepository.findByUbuntuUsername("unknown")).thenReturn(Optional.empty());
-
-            assertThatThrownBy(() -> adminUserService.deleteUbuntuAccount("unknown"))
+            assertThatThrownBy(() -> adminUserService.deleteUbuntuAccount("nobody"))
                     .isInstanceOf(EntityNotFoundException.class);
+
+            verifyNoInteractions(ubuntuAccountService);
         }
     }
 }


### PR DESCRIPTION
## 문제

`AdminUserService.deleteUser()` 내에서 `this.deleteUbuntuAccount()`를 호출하는 self-invocation 패턴이 Spring AOP 프록시를 우회하여, 해당 메서드에 `@Transactional` 애노테이션이 있더라도 트랜잭션이 적용되지 않는 문제가 있었습니다.

또한 기존 `AdminUserService.deleteUbuntuAccount()`는 Request 상태와 무관하게 `deleteAfterCleanup()`을 호출하여, PENDING/DENIED 상태의 Request에 대해 `IllegalStateException`이 발생할 수 있었습니다.

`UbuntuAccountService`에는 `@Transactional(propagation = Propagation.MANDATORY)` 애노테이션이 있었으나, 해당 메서드는 외부 API 호출만 수행하고 DB 작업이 없으므로 MANDATORY는 잘못된 설정이었습니다.

## 수정 내용

- `UbuntuAccountService`에서 `@Transactional(propagation = Propagation.MANDATORY)` 제거
- `AdminUserService`에 `UbuntuAccountService` 주입
- `deleteUser()` 내 Request 처리를 상태별로 분기:
  - `FULFILLED`: `ubuntuAccountService.deleteUbuntuAccount()` 호출 후 `deleteAfterCleanup()`
  - `PENDING`/`DENIED`: `delete()` (외부 API 미호출)
  - `DELETED`: 스킵
- 컨트롤러 `DELETE /ubuntu/{username}` 엔드포인트용 `AdminUserService.deleteUbuntuAccount()`는 유지하되, 실제 외부 API 호출은 `UbuntuAccountService`에 위임

## 영향 범위

- **인프라**: 없음 (외부 API 호출 방식 동일)
- **프론트엔드**: 없음 (API 스펙 변경 없음)

## 테스트

- `AdminUserServiceTest`: FULFILLED/PENDING/DELETED 혼합 시나리오 포함 총 9개 테스트 추가/수정