### PR TITLE
fix: Refresh Token Redis TTL TimeUnit 불일치 수정 (#M-NEW-1)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/UserLoginService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/UserLoginService.java
@@ -11,6 +11,7 @@ import DGU_AI_LAB.admin_be.error.exception.UnauthorizedException;
 import DGU_AI_LAB.admin_be.global.auth.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -28,7 +29,8 @@ public class UserLoginService {
     private final JwtProvider jwtProvider;
     private final RedisTemplate<String, String> redisTemplate;
 
-    private final long REFRESH_TOKEN_EXPIRE_TIME = 60 * 60 * 24 * 7;
+    @Value("${jwt.refresh-token-expire-time}")
+    private long REFRESH_TOKEN_EXPIRE_TIME;
 
     /** 회원가입 */
     @Transactional
@@ -72,7 +74,7 @@ public class UserLoginService {
         String refreshToken = jwtProvider.getIssueToken(user.getUserId(), false);
 
         redisTemplate.opsForValue().set(
-                "RT:" + user.getUserId(), refreshToken, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.SECONDS
+                "RT:" + user.getUserId(), refreshToken, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.MILLISECONDS
         );
 
         return UserTokenResponseDTO.of(accessToken, refreshToken);

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/UserLoginServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/UserLoginServiceTest.java
@@ -20,7 +20,10 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import org.springframework.test.util.ReflectionTestUtils;
+
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -52,6 +55,9 @@ class UserLoginServiceTest {
 
     @BeforeEach
     void setUp() {
+        // @Value 필드는 Mockito가 주입하지 않으므로 직접 설정 (604800000ms = 7일)
+        ReflectionTestUtils.setField(userLoginService, "REFRESH_TOKEN_EXPIRE_TIME", 604800000L);
+
         activeUser = User.builder()
                 .email("test@dgu.ac.kr")
                 .password("encodedPassword")
@@ -131,6 +137,7 @@ class UserLoginServiceTest {
             assertThat(result.accessToken()).isEqualTo("accessToken");
             assertThat(result.refreshToken()).isEqualTo("refreshToken");
             verify(passwordEncoder, times(1)).matches("password123", "encodedPassword");
+            verify(valueOperations).set(anyString(), eq("refreshToken"), eq(604800000L), eq(TimeUnit.MILLISECONDS));
         }
 
         @Test


### PR DESCRIPTION
## 문제

`UserLoginService.login()`에서 Refresh Token을 Redis에 저장할 때 `TimeUnit.SECONDS`와 하드코딩된 604800(7일)을 사용합니다. 반면 `TokenService`는 `@Value("${jwt.refresh-token-expire-time}")` + `TimeUnit.MILLISECONDS`(604800000ms)를 사용합니다.

현재 결과값은 우연히 동일(7일)하지만, 단위 불일치로 인해 `application.yml`의 `jwt.refresh-token-expire-time` 값을 변경해도 `UserLoginService`에는 반영되지 않는 문제가 있습니다.

## 수정 내용

- `REFRESH_TOKEN_EXPIRE_TIME` 하드코딩 제거 → `@Value("${jwt.refresh-token-expire-time}")` 주입으로 변경
- `TimeUnit.SECONDS` → `TimeUnit.MILLISECONDS`로 통일

## 영향 범위

- **인프라**: 없음
- **프론트엔드**: 없음 (Refresh Token 만료 동작 동일)

## 테스트

- `UserLoginServiceTest`: MILLISECONDS와 604800000L로 Redis 저장 검증 추가