### PR TITLE
fix: AdminRequestQueryService N+1 쿼리 제거 (#M-NEW-2)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryService.java
@@ -1,13 +1,15 @@
 package DGU_AI_LAB.admin_be.domain.requests.service;
 
-import DGU_AI_LAB.admin_be.domain.portRequests.service.PortRequestService;
 import DGU_AI_LAB.admin_be.domain.pod.repository.PodExternalPortRepository;
+import DGU_AI_LAB.admin_be.domain.portRequests.entity.PortRequests;
+import DGU_AI_LAB.admin_be.domain.portRequests.repository.PortRequestRepository;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ChangeRequestResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ContainerInfoDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.PodExternalPortResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.PortMappingDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ResourceUsageDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.SaveRequestResponseDTO;
+import DGU_AI_LAB.admin_be.domain.pod.entity.PodExternalPort;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
 import DGU_AI_LAB.admin_be.domain.requests.repository.ChangeRequestRepository;
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,32 +29,47 @@ public class AdminRequestQueryService {
 
     private final RequestRepository requestRepository;
     private final ChangeRequestRepository changeRequestRepository;
-    private final PortRequestService portRequestService;
+    private final PortRequestRepository portRequestRepository;
     private final PodExternalPortRepository podExternalPortRepository;
 
     public List<SaveRequestResponseDTO> getAllRequests() {
-        return requestRepository.findAll().stream()
-                .map(this::createResponseDTOWithPortMappings)
-                .collect(Collectors.toList());
+        List<Request> requests = requestRepository.findAll();
+        return buildResponseDTOs(requests);
     }
 
     public List<SaveRequestResponseDTO> getNewRequests() {
-        return requestRepository.findAllByStatus(Status.PENDING).stream()
-                .map(this::createResponseDTOWithPortMappings)
-                .collect(Collectors.toList());
+        List<Request> requests = requestRepository.findAllByStatus(Status.PENDING);
+        return buildResponseDTOs(requests);
     }
 
-    private SaveRequestResponseDTO createResponseDTOWithPortMappings(Request request) {
-        List<PortMappingDTO> portMappings = portRequestService.getPortRequestsByRequestId(request.getRequestId())
-                .stream()
-                .map(PortMappingDTO::fromEntity)
-                .toList();
-        List<PodExternalPortResponseDTO> podExternalPorts = podExternalPortRepository.findByRequestRequestId(request.getRequestId())
-                .stream()
-                .map(PodExternalPortResponseDTO::fromEntity)
-                .toList();
+    private List<SaveRequestResponseDTO> buildResponseDTOs(List<Request> requests) {
+        if (requests.isEmpty()) return List.of();
 
-        return SaveRequestResponseDTO.fromEntityWithPorts(request, portMappings, podExternalPorts);
+        List<Long> requestIds = requests.stream().map(Request::getRequestId).toList();
+
+        Map<Long, List<PortMappingDTO>> portMappingsByRequestId = portRequestRepository
+                .findByRequestRequestIdIn(requestIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        pr -> pr.getRequest().getRequestId(),
+                        Collectors.mapping(PortMappingDTO::fromEntity, Collectors.toList())
+                ));
+
+        Map<Long, List<PodExternalPortResponseDTO>> podPortsByRequestId = podExternalPortRepository
+                .findByRequestRequestIdIn(requestIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        pp -> pp.getRequest().getRequestId(),
+                        Collectors.mapping(PodExternalPortResponseDTO::fromEntity, Collectors.toList())
+                ));
+
+        return requests.stream()
+                .map(request -> SaveRequestResponseDTO.fromEntityWithPorts(
+                        request,
+                        portMappingsByRequestId.getOrDefault(request.getRequestId(), List.of()),
+                        podPortsByRequestId.getOrDefault(request.getRequestId(), List.of())
+                ))
+                .toList();
     }
 
     public List<ResourceUsageDTO> getAllFulfilledResourceUsage() {

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryServiceTest.java
@@ -1,8 +1,8 @@
 package DGU_AI_LAB.admin_be.domain.requests.service;
 
-import DGU_AI_LAB.admin_be.domain.portRequests.service.PortRequestService;
 import DGU_AI_LAB.admin_be.domain.pod.entity.PodExternalPort;
 import DGU_AI_LAB.admin_be.domain.pod.repository.PodExternalPortRepository;
+import DGU_AI_LAB.admin_be.domain.portRequests.repository.PortRequestRepository;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ChangeRequestResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ContainerInfoDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ResourceUsageDTO;
@@ -22,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,7 +38,7 @@ class AdminRequestQueryServiceTest {
     private ChangeRequestRepository changeRequestRepository;
 
     @Mock
-    private PortRequestService portRequestService;
+    private PortRequestRepository portRequestRepository;
 
     @Mock
     private PodExternalPortRepository podExternalPortRepository;
@@ -58,7 +59,7 @@ class AdminRequestQueryServiceTest {
         }
 
         @Test
-        @DisplayName("관리자 요청 조회 시 pod_external_ports를 함께 반환한다")
+        @DisplayName("관리자 요청 조회 시 pod_external_ports를 배치 쿼리로 함께 반환한다")
         void getAllRequests_returnsPodExternalPorts() {
             Request request = mockRequest(1L);
             PodExternalPort podExternalPort = PodExternalPort.builder()
@@ -69,8 +70,8 @@ class AdminRequestQueryServiceTest {
                     .build();
 
             when(requestRepository.findAll()).thenReturn(List.of(request));
-            when(portRequestService.getPortRequestsByRequestId(1L)).thenReturn(List.of());
-            when(podExternalPortRepository.findByRequestRequestId(1L)).thenReturn(List.of(podExternalPort));
+            when(portRequestRepository.findByRequestRequestIdIn(anyList())).thenReturn(List.of());
+            when(podExternalPortRepository.findByRequestRequestIdIn(anyList())).thenReturn(List.of(podExternalPort));
 
             List<SaveRequestResponseDTO> result = adminRequestQueryService.getAllRequests();
 
@@ -79,6 +80,9 @@ class AdminRequestQueryServiceTest {
             assertThat(result.get(0).podExternalPorts().get(0).internalPort()).isEqualTo(22);
             assertThat(result.get(0).podExternalPorts().get(0).externalPort()).isEqualTo(30022);
             assertThat(result.get(0).podExternalPorts().get(0).usagePurpose()).isEqualTo("ssh");
+            // 배치 쿼리 1회만 호출되었는지 검증 (N+1 방지)
+            verify(portRequestRepository, times(1)).findByRequestRequestIdIn(anyList());
+            verify(podExternalPortRepository, times(1)).findByRequestRequestIdIn(anyList());
         }
     }
 


### PR DESCRIPTION
## 문제

`getAllRequests()`와 `getNewRequests()`에서 Request N건이 조회될 때마다 각 Request에 대해 PortRequests 조회와 PodExternalPort 조회가 추가로 발생해 총 `2N+1`번의 쿼리가 실행됩니다.

## 수정 내용

- `PortRequestService` 의존 제거 → `PortRequestRepository` 직접 주입
- `findByRequestRequestIdIn(requestIds)` 배치 쿼리로 PortRequests 전체 1회 조회
- `findByRequestRequestIdIn(requestIds)` 배치 쿼리로 PodExternalPort 전체 1회 조회
- `groupingBy(requestId)` Map으로 구성 후 DTO 생성 → 쿼리 총 3회로 고정

## 영향 범위

- **인프라/프론트엔드**: 없음 (API 응답 구조 동일)

## 테스트

- `AdminRequestQueryServiceTest`: 배치 쿼리 1회만 호출되는지 검증 추가