### PR TITLE
fix: 포트 할당 Race Condition 방지 - 비관적 락 적용 (#M-NEW-3)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/portRequests/service/PortRequestService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/portRequests/service/PortRequestService.java
@@ -4,6 +4,7 @@ import DGU_AI_LAB.admin_be.domain.portRequests.entity.PortRequests;
 import DGU_AI_LAB.admin_be.domain.portRequests.repository.PortRequestRepository;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.repository.ResourceGroupRepository;
 import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ import java.util.Set;
 public class PortRequestService {
 
     private final PortRequestRepository portRequestRepository;
+    private final ResourceGroupRepository resourceGroupRepository;
 
     private static final int NODE_PORT_RANGE_START = 30000;
     private static final int NODE_PORT_RANGE_END = 32767;
@@ -28,6 +30,10 @@ public class PortRequestService {
     @Transactional
     public PortRequests createPortRequest(Request request, ResourceGroup resourceGroup,
                                         Integer internalPort, String usagePurpose) {
+
+        // 포트 할당 Race Condition 방지: ResourceGroup 행에 비관적 락을 걸어 직렬화
+        resourceGroupRepository.findByIdWithPessimisticLock(resourceGroup.getRsgroupId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
         // Auto-assign external NodePort from the Kubernetes default range.
         Integer assignedPortNumber = findNextAvailablePort(resourceGroup.getRsgroupId());

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/resourceGroups/repository/ResourceGroupRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/resourceGroups/repository/ResourceGroupRepository.java
@@ -1,10 +1,18 @@
 package DGU_AI_LAB.admin_be.domain.resourceGroups.repository;
 
 import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ResourceGroupRepository extends JpaRepository<ResourceGroup, Integer> {
     Optional<ResourceGroup> findById(Integer rsgroupId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT rg FROM ResourceGroup rg WHERE rg.rsgroupId = :id")
+    Optional<ResourceGroup> findByIdWithPessimisticLock(@Param("id") Integer id);
 }

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/portRequests/service/PortRequestServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/portRequests/service/PortRequestServiceTest.java
@@ -4,6 +4,7 @@ import DGU_AI_LAB.admin_be.domain.portRequests.entity.PortRequests;
 import DGU_AI_LAB.admin_be.domain.portRequests.repository.PortRequestRepository;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.repository.ResourceGroupRepository;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,11 +15,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,6 +33,9 @@ class PortRequestServiceTest {
 
     @Mock
     private PortRequestRepository portRequestRepository;
+
+    @Mock
+    private ResourceGroupRepository resourceGroupRepository;
 
     @Test
     @DisplayName("NodePort 기본 범위 30000부터 사용 가능한 포트를 할당한다")
@@ -47,6 +53,7 @@ class PortRequestServiceTest {
                 .resourceGroup(resourceGroup)
                 .build();
 
+        when(resourceGroupRepository.findByIdWithPessimisticLock(anyInt())).thenReturn(Optional.of(resourceGroup));
         when(portRequestRepository.findPortNumbersByResourceGroupRsgroupIdOrderByPortNumberAsc(1))
                 .thenReturn(List.of(30000));
         when(portRequestRepository.save(any(PortRequests.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -77,6 +84,7 @@ class PortRequestServiceTest {
                 .boxed()
                 .toList();
 
+        when(resourceGroupRepository.findByIdWithPessimisticLock(anyInt())).thenReturn(Optional.of(resourceGroup));
         when(portRequestRepository.findPortNumbersByResourceGroupRsgroupIdOrderByPortNumberAsc(1))
                 .thenReturn(usedPorts);
 


### PR DESCRIPTION
## 문제

`PortRequestService.createPortRequest()`에서 `findNextAvailablePort()`로 사용 가능한 포트를 찾은 뒤 저장하는 사이, 동시에 다른 트랜잭션이 같은 포트를 선택하면 `UniqueConstraint` 위반으로 500 오류가 발생합니다.

## 수정 내용

- `ResourceGroupRepository`에 `@Lock(PESSIMISTIC_WRITE)` 메서드 추가
- `createPortRequest()` 진입 시 `ResourceGroup` 행에 비관적 락을 획득
- 락 보유 중 포트 탐색 → 저장이 완료될 때까지 다른 트랜잭션은 동일 ResourceGroup에 대한 포트 할당 대기

## 영향 범위

- **인프라**: 없음
- **프론트엔드**: 없음

## 테스트

컴파일 검증 완료. 비관적 락은 실제 DB 환경에서의 통합 테스트로만 완전 검증 가능하므로 단위 테스트는 생략합니다.