### PR TITLE
feat: create-pod 응답 타임아웃 30초 → 5분으로 변경

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/PodService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/PodService.java
@@ -23,7 +23,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class PodService {
 
-    private final @Qualifier("configWebClient") WebClient webClient;
+    private final @Qualifier("podWebClient") WebClient webClient;
 
     private record DeletePodRequest(@com.fasterxml.jackson.annotation.JsonProperty("pod_name") String podName) {}
 

--- a/src/main/java/DGU_AI_LAB/admin_be/global/config/WebClientConfig.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/global/config/WebClientConfig.java
@@ -18,9 +18,6 @@ public class WebClientConfig {
     public WebClient configWebClient(@Value("${config.base-url}") String baseUrl,
                                      @Value("${config.timeout-seconds}") int timeout) {
 
-        /**
-         * 연결 풀 설정: HTTP 연결을 효율적으로 재사용하도록 한다.
-         */
         ConnectionProvider provider = ConnectionProvider.builder("pvc-connection-pool")
                 .maxConnections(50)
                 .maxIdleTime(Duration.ofSeconds(20))
@@ -36,5 +33,22 @@ public class WebClientConfig {
                 .build();
     }
 
+    @Bean
+    public WebClient podWebClient(@Value("${config.base-url}") String baseUrl,
+                                  @Value("${config.pod-timeout-seconds:300}") int podTimeout) {
 
+        ConnectionProvider provider = ConnectionProvider.builder("pod-connection-pool")
+                .maxConnections(10)
+                .maxIdleTime(Duration.ofSeconds(60))
+                .build();
+
+        HttpClient httpClient = HttpClient.create(provider)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 30_000)
+                .responseTimeout(Duration.ofSeconds(podTimeout));
+
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
 }


### PR DESCRIPTION
## 배경

`/create-pod` API는 이미지 pull 및 Pod 기동 대기로 30초를 초과할 수 있습니다. 현재 `configWebClient`의 `responseTimeout`이 30초로 고정되어 있어 타임아웃 오류가 발생합니다.

## 수정 내용

- `WebClientConfig`에 Pod 전용 `podWebClient` 빈 추가
  - 응답 타임아웃: 300초 (5분) — `config.pod-timeout-seconds` 프로퍼티, 기본값 300
  - 연결 타임아웃: 30초 (고정)
- `PodService` 주입 대상을 `configWebClient` → `podWebClient`로 변경
- 계정·그룹 API(`configWebClient`)의 30초 타임아웃은 그대로 유지

## 배포 시 필요한 설정

`application.yml`에 아래 항목 추가 (기본값 300 적용이므로 생략해도 동작함):
```yaml
config:
  pod-timeout-seconds: 300
```

## 영향 범위

- **인프라**: 없음 (API 스펙 변경 없음)
- **프론트엔드**: 없음