### PR TITLE
fix: deleteUbuntuAccount DELETED 상태 요청 시 500 → 404 반환 (#M-NEW-4)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserService.java
@@ -81,6 +81,12 @@ public class AdminUserService {
                     log.warn("[deleteUbuntuAccount] {}에 해당하는 Request가 없습니다.", username);
                     return new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND);
                 });
+
+        if (request.getStatus() == Status.DELETED) {
+            log.warn("[deleteUbuntuAccount] {}은 이미 DELETED 상태입니다.", username);
+            throw new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND);
+        }
+
         ubuntuAccountService.deleteUbuntuAccount(username);
         request.deleteAfterCleanup();
         requestRepository.save(request);
@@ -99,5 +105,4 @@ public class AdminUserService {
         log.info("[updateUser] userId={} 정보 수정 완료", userId);
         return UserResponseDTO.fromEntity(user);
     }
-
 }


### PR DESCRIPTION
## 문제

`DELETE /api/admin/users/ubuntu/{username}` 호출 시, 해당 Request가 이미 DELETED 상태인 경우 `findByUbuntuUsername()`이 DELETED 레코드를 반환하고, `deleteAfterCleanup()`에서 상태 검증 실패로 `BusinessException`이 발생합니다. 이것이 500으로 노출됩니다.

## 수정 내용

- `deleteUbuntuAccount()`에서 Request 상태가 `DELETED`이면 `EntityNotFoundException`(→ 404)를 던지도록 수정

## 영향 범위

- **인프라**: 없음
- **프론트엔드**: 없음 (이미 DELETED된 username에 대한 요청 응답이 500 → 404로 변경됨)