### PR TITLE
fix: DashboardService N+1 쿼리 제거 (#321)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/dashboard/service/DashboardService.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -41,6 +43,16 @@ public class DashboardService {
             requests = requestRepository.findByUserUserIdAndStatus(userId, status);
         }
 
+        Set<ResourceGroup> resourceGroups = requests.stream()
+                .map(Request::getResourceGroup)
+                .filter(rg -> rg != null)
+                .collect(Collectors.toSet());
+
+        Map<Integer, List<Node>> nodesByRsgroupId = nodeRepository
+                .findAllByResourceGroupIn(resourceGroups)
+                .stream()
+                .collect(Collectors.groupingBy(node -> node.getResourceGroup().getRsgroupId()));
+
         return requests.stream()
                 .map(request -> {
                     String serverAddress = (request.getStatus() == Status.FULFILLED) ? "TBD (서버 할당 후 표시)" : null;
@@ -53,7 +65,7 @@ public class DashboardService {
                     if (resourceGroup != null) {
                         resourceGroupName = resourceGroup.getDescription();
 
-                        List<Node> nodesInGroup = nodeRepository.findAllByResourceGroup(resourceGroup);
+                        List<Node> nodesInGroup = nodesByRsgroupId.getOrDefault(resourceGroup.getRsgroupId(), List.of());
                         if (!nodesInGroup.isEmpty()) {
                             Node representativeNode = nodesInGroup.get(0);
                             cpuCoreCount = representativeNode.getCpuCoreCount();

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/nodes/repository/NodeRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/nodes/repository/NodeRepository.java
@@ -5,9 +5,11 @@ import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 
 @Repository
 public interface NodeRepository extends JpaRepository<Node, String> {
     List<Node> findAllByResourceGroup(ResourceGroup resourceGroup);
+    List<Node> findAllByResourceGroupIn(Collection<ResourceGroup> resourceGroups);
 }

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/dashboard/service/DashboardServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/dashboard/service/DashboardServiceTest.java
@@ -1,10 +1,13 @@
 package DGU_AI_LAB.admin_be.domain.dashboard.service;
 
+import DGU_AI_LAB.admin_be.domain.nodes.entity.Node;
 import DGU_AI_LAB.admin_be.domain.nodes.repository.NodeRepository;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.UserServerResponseDTO;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
 import DGU_AI_LAB.admin_be.domain.requests.entity.StatusFilter;
 import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
+import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -41,6 +44,7 @@ class DashboardServiceTest {
         @DisplayName("StatusFilter.ALL이면 userId의 모든 요청을 반환한다")
         void getUserServers_returnsAllRequests_whenStatusAll() {
             when(requestRepository.findAllByUser_UserId(1L)).thenReturn(List.of());
+            when(nodeRepository.findAllByResourceGroupIn(anySet())).thenReturn(List.of());
 
             List<UserServerResponseDTO> result = dashboardService.getUserServers(1L, StatusFilter.ALL);
 
@@ -53,6 +57,7 @@ class DashboardServiceTest {
         @DisplayName("StatusFilter.FULFILLED이면 FULFILLED 요청만 반환한다")
         void getUserServers_returnsFulfilledRequests_whenStatusFulfilled() {
             when(requestRepository.findByUserUserIdAndStatus(1L, Status.FULFILLED)).thenReturn(List.of());
+            when(nodeRepository.findAllByResourceGroupIn(anySet())).thenReturn(List.of());
 
             List<UserServerResponseDTO> result = dashboardService.getUserServers(1L, StatusFilter.FULFILLED);
 
@@ -64,11 +69,64 @@ class DashboardServiceTest {
         @DisplayName("StatusFilter.PENDING이면 PENDING 요청만 반환한다")
         void getUserServers_returnsPendingRequests_whenStatusPending() {
             when(requestRepository.findByUserUserIdAndStatus(1L, Status.PENDING)).thenReturn(List.of());
+            when(nodeRepository.findAllByResourceGroupIn(anySet())).thenReturn(List.of());
 
             List<UserServerResponseDTO> result = dashboardService.getUserServers(1L, StatusFilter.PENDING);
 
             assertThat(result).isEmpty();
             verify(requestRepository).findByUserUserIdAndStatus(1L, Status.PENDING);
+        }
+
+        @Test
+        @DisplayName("요청이 여러 개여도 노드 조회는 findAllByResourceGroupIn 한 번만 호출한다 (N+1 방지)")
+        void getUserServers_callsBatchNodeQuery_onceForAllResourceGroups() {
+            ResourceGroup rg = new ResourceGroup(1, "rg-name", "desc", "server1");
+            Request req1 = Request.builder().resourceGroup(rg).ubuntuUsername("user1").build();
+            Request req2 = Request.builder().resourceGroup(rg).ubuntuUsername("user2").build();
+            Node node = Node.builder().nodeId("node-1").resourceGroup(rg).cpuCoreCount(8).memorySizeGB(32).build();
+
+            when(requestRepository.findAllByUser_UserId(1L)).thenReturn(List.of(req1, req2));
+            when(nodeRepository.findAllByResourceGroupIn(anySet())).thenReturn(List.of(node));
+
+            List<UserServerResponseDTO> result = dashboardService.getUserServers(1L, StatusFilter.ALL);
+
+            assertThat(result).hasSize(2);
+            verify(nodeRepository, times(1)).findAllByResourceGroupIn(anySet());
+            verify(nodeRepository, never()).findAllByResourceGroup(any());
+        }
+
+        @Test
+        @DisplayName("노드 정보를 DTO에 올바르게 매핑한다")
+        void getUserServers_mapsNodeInfoToDTO() {
+            ResourceGroup rg = new ResourceGroup(1, "rg-name", "desc", "server1");
+            Request req = Request.builder().resourceGroup(rg).ubuntuUsername("user1").build();
+            Node node = Node.builder().nodeId("node-1").resourceGroup(rg).cpuCoreCount(16).memorySizeGB(64).build();
+
+            when(requestRepository.findAllByUser_UserId(1L)).thenReturn(List.of(req));
+            when(nodeRepository.findAllByResourceGroupIn(anySet())).thenReturn(List.of(node));
+
+            List<UserServerResponseDTO> result = dashboardService.getUserServers(1L, StatusFilter.ALL);
+
+            assertThat(result).hasSize(1);
+            UserServerResponseDTO dto = result.get(0);
+            assertThat(dto.cpuCoreCount()).isEqualTo(16);
+            assertThat(dto.memoryGB()).isEqualTo(64);
+            assertThat(dto.resourceGroupName()).isEqualTo("desc");
+        }
+
+        @Test
+        @DisplayName("ResourceGroup이 없는 요청도 정상 처리된다")
+        void getUserServers_handlesNullResourceGroup() {
+            Request req = Request.builder().ubuntuUsername("user1").resourceGroup(null).build();
+
+            when(requestRepository.findAllByUser_UserId(1L)).thenReturn(List.of(req));
+            when(nodeRepository.findAllByResourceGroupIn(anySet())).thenReturn(List.of());
+
+            List<UserServerResponseDTO> result = dashboardService.getUserServers(1L, StatusFilter.ALL);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).cpuCoreCount()).isNull();
+            assertThat(result.get(0).memoryGB()).isNull();
         }
     }
 


### PR DESCRIPTION
## Summary
- `getUserServers()`에서 각 Request의 ResourceGroup마다 `nodeRepository.findAllByResourceGroup()`을 개별 호출하던 N+1 문제 수정
- `NodeRepository`에 `findAllByResourceGroupIn()` 배치 쿼리 메서드 추가
- 배치 조회 후 `Map<rsgroupId, List<Node>>`로 그룹핑하여 스트림 내에서 O(1) 룩업으로 대체

## Test plan
- [ ] `DashboardServiceTest.getUserServers_callsBatchNodeQuery_onceForAllResourceGroups()`: 요청이 여러 개여도 노드 조회는 1회만 호출됨 검증
- [ ] `getUserServers_mapsNodeInfoToDTO()`: 노드의 CPU/메모리 정보가 DTO에 올바르게 매핑됨 검증
- [ ] `getUserServers_handlesNullResourceGroup()`: ResourceGroup이 null인 요청도 NPE 없이 처리됨 검증
- [ ] 기존 StatusFilter 분기 테스트 유지