### PR TITLE
fix: RequestExpiredEvent User 엔티티 참조 제거 (#322)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestExpiryService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestExpiryService.java
@@ -3,7 +3,6 @@ package DGU_AI_LAB.admin_be.domain.requests.service;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
 import DGU_AI_LAB.admin_be.domain.requests.repository.RequestRepository;
-import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import DGU_AI_LAB.admin_be.error.ErrorCode;
 import DGU_AI_LAB.admin_be.error.exception.EntityNotFoundException;
 import DGU_AI_LAB.admin_be.global.event.RequestExpiredEvent;
@@ -32,13 +31,14 @@ public class RequestExpiryService {
 
         String serverName = request.getResourceGroup().getServerName();
         String ubuntuUsername = request.getUbuntuUsername();
-        User user = request.getUser();
+        String userName = request.getUser().getName();
+        String userEmail = request.getUser().getEmail();
 
         podService.deletePod(request.getPodName());
         ubuntuAccountService.deleteUbuntuAccount(ubuntuUsername);
 
         request.deleteAfterCleanup();
-        eventPublisher.publishEvent(new RequestExpiredEvent(user, ubuntuUsername, serverName));
+        eventPublisher.publishEvent(new RequestExpiredEvent(userName, userEmail, ubuntuUsername, serverName));
         log.info("삭제 트랜잭션 성공: {}", ubuntuUsername);
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestEventListener.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestEventListener.java
@@ -1,7 +1,6 @@
 package DGU_AI_LAB.admin_be.domain.scheduler;
 
 import DGU_AI_LAB.admin_be.domain.alarm.service.AlarmService;
-import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import DGU_AI_LAB.admin_be.global.event.RequestExpiredEvent;
 import DGU_AI_LAB.admin_be.global.util.MessageUtils;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +24,8 @@ public class RequestEventListener {
     // DB 커밋이 완료된 후에만 실행됨
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleExpiredEvent(RequestExpiredEvent event) {
-        User user = event.user();
+        String userName = event.userName();
+        String userEmail = event.userEmail();
         String serverName = event.serverName();
         String username = event.ubuntuUsername();
 
@@ -33,9 +33,9 @@ public class RequestEventListener {
         try {
             String subject = messageUtils.get("notification.expired.detail.subject");
             String message = messageUtils.get("notification.expired.detail.body",
-                    user.getName(), serverName, username);
+                    userName, serverName, username);
 
-            alarmService.sendAllAlerts(user.getName(), user.getEmail(), subject, message);
+            alarmService.sendAllAlerts(userName, userEmail, subject, message);
         } catch (Exception e) {
             log.warn("사용자 삭제 알림 전송 실패: {}", e.getMessage());
         }

--- a/src/main/java/DGU_AI_LAB/admin_be/global/event/RequestExpiredEvent.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/global/event/RequestExpiredEvent.java
@@ -1,9 +1,8 @@
 package DGU_AI_LAB.admin_be.global.event;
 
-import DGU_AI_LAB.admin_be.domain.users.entity.User;
-
 public record RequestExpiredEvent(
-        User user,
+        String userName,
+        String userEmail,
         String ubuntuUsername,
-        String serverName // Lab/Farm 구분용
+        String serverName
 ) {}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestEventListenerTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/scheduler/RequestEventListenerTest.java
@@ -1,0 +1,65 @@
+package DGU_AI_LAB.admin_be.domain.scheduler;
+
+import DGU_AI_LAB.admin_be.domain.alarm.service.AlarmService;
+import DGU_AI_LAB.admin_be.global.event.RequestExpiredEvent;
+import DGU_AI_LAB.admin_be.global.util.MessageUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RequestEventListenerTest {
+
+    @InjectMocks
+    private RequestEventListener requestEventListener;
+
+    @Mock
+    private AlarmService alarmService;
+
+    @Mock
+    private MessageUtils messageUtils;
+
+    @Test
+    @DisplayName("이벤트에 포함된 userName/userEmail로 사용자 알림을 전송한다")
+    void handleExpiredEvent_sendsUserNotificationWithStringFields() {
+        RequestExpiredEvent event = new RequestExpiredEvent("홍길동", "hong@test.com", "user1", "server-lab");
+        when(messageUtils.get(any())).thenReturn("subject");
+        when(messageUtils.get(any(), any(), any(), any())).thenReturn("message body");
+
+        requestEventListener.handleExpiredEvent(event);
+
+        verify(alarmService).sendAllAlerts(eq("홍길동"), eq("hong@test.com"), any(), any());
+    }
+
+    @Test
+    @DisplayName("관리자 알림은 serverName으로 전송한다")
+    void handleExpiredEvent_sendsAdminNotificationWithServerName() {
+        RequestExpiredEvent event = new RequestExpiredEvent("홍길동", "hong@test.com", "user1", "server-lab");
+        when(messageUtils.get(any())).thenReturn("subject");
+        when(messageUtils.get(any(), any(), any(), any())).thenReturn("admin message");
+
+        requestEventListener.handleExpiredEvent(event);
+
+        verify(alarmService).sendAdminSlackNotification(eq("server-lab"), any());
+    }
+
+    @Test
+    @DisplayName("알림 전송 실패 시 예외가 전파되지 않는다")
+    void handleExpiredEvent_doesNotPropagateException_whenAlarmFails() {
+        RequestExpiredEvent event = new RequestExpiredEvent("홍길동", "hong@test.com", "user1", "server-lab");
+        when(messageUtils.get(any())).thenReturn("subject");
+        when(messageUtils.get(any(), any(), any(), any())).thenReturn("message");
+        doThrow(new RuntimeException("slack error")).when(alarmService).sendAllAlerts(any(), any(), any(), any());
+
+        requestEventListener.handleExpiredEvent(event);
+
+        verify(alarmService, times(1)).sendAllAlerts(any(), any(), any(), any());
+    }
+}


### PR DESCRIPTION
## Summary
- `@TransactionalEventListener(phase = AFTER_COMMIT)` 핸들러에서 `User` 엔티티를 lazy-load하면 트랜잭션이 이미 닫혀 `LazyInitializationException`이 발생할 수 있는 문제 수정
- `RequestExpiredEvent` 레코드에서 `User user` → `String userName`, `String userEmail`로 변경
- `RequestExpiryService`에서 이벤트 발행 전 트랜잭션 컨텍스트 안에서 값을 미리 추출
- `RequestEventListener`에서 엔티티 참조 제거

## Test plan
- [ ] `handleExpiredEvent_sendsUserNotificationWithStringFields()`: userName/userEmail로 sendAllAlerts 호출 검증
- [ ] `handleExpiredEvent_sendsAdminNotificationWithServerName()`: serverName으로 관리자 알림 전송 검증
- [ ] `handleExpiredEvent_doesNotPropagateException_whenAlarmFails()`: 알림 실패 시 예외 전파 안 됨 검증