### PR TITLE
fix: GroupService DB 저장 실패 경고 로그 추가 (#323)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
@@ -159,7 +159,12 @@ public class GroupService {
                 .ubuntuGid(assignedGid)
                 .build();
 
-        group = groupRepository.save(group);
+        try {
+            group = groupRepository.save(group);
+        } catch (Exception e) {
+            log.error("[createGroup] 인프라에 그룹 생성됨, DB 저장 실패 — 수동 정리 필요: groupName={}, gid={}", dto.groupName(), assignedGid, e);
+            throw new BusinessException(ErrorCode.GROUP_CREATION_FAILED);
+        }
         log.info("[createGroup] 그룹 생성 및 로컬 DB 저장 완료: id={}, name={}", group.getGroupId(), group.getGroupName());
 
         return GroupResponseDTO.fromEntity(group);

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupServiceTest.java
@@ -247,5 +247,24 @@ class GroupServiceTest {
                     .isInstanceOf(BusinessException.class);
             verify(groupRepository, never()).save(any(Group.class));
         }
+
+        @Test
+        @DisplayName("인프라 그룹 생성 후 DB 저장 실패 시 GROUP_CREATION_FAILED를 던진다")
+        void createGroup_throwsException_whenDbSaveFails() {
+            when(groupRepository.existsByGroupName("developers")).thenReturn(false);
+            when(groupRepository.existsByUbuntuGid(2000L)).thenReturn(false);
+
+            mockWebClientSuccess(new GroupService.ConfigServerGroupResponse(
+                    new GroupService.ConfigServerGroupInfo("developers", 2000L)));
+
+            when(groupRepository.save(any(Group.class))).thenThrow(new RuntimeException("DB connection lost"));
+
+            CreateGroupRequestDTO dto = new CreateGroupRequestDTO("developers", null);
+
+            assertThatThrownBy(() -> groupService.createGroup(dto, 1L))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.GROUP_CREATION_FAILED);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- 인프라 그룹 생성 성공 후 `groupRepository.save()` 실패 시 인프라↔DB 불일치 상태가 되는 문제 대응
- `save()` 호출을 try-catch로 감싸고, 실패 시 `[ERROR]` 레벨로 "수동 정리 필요" 로그 기록
- 이후 `GROUP_CREATION_FAILED` BusinessException을 반환하여 클라이언트에 오류 전달

## Test plan
- [ ] `createGroup_throwsException_whenDbSaveFails()`: DB 저장 실패 시 GROUP_CREATION_FAILED 예외 발생 검증
- [ ] 기존 성공 케이스 및 기타 실패 케이스 테스트 유지