### PR TITLE
fix: ResourceGroupService 중복 쿼리 및 System.out.println 제거 (#324)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/resourceGroups/service/ResourceGroupService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/resourceGroups/service/ResourceGroupService.java
@@ -31,20 +31,12 @@ public class ResourceGroupService {
 
         List<GpuRepository.GpuSummary> gpuSummaries = gpuRepository.findGpuSummary();
 
-        for (GpuRepository.GpuSummary summary : gpuSummaries) {
-            System.out.println(summary.getResourceGroupName());
-            System.out.println(summary.getRamGb());
-            System.out.println(summary.getDescription());
-            System.out.println(summary.getNodeCount());
-        }
-
         if (gpuSummaries.isEmpty()) {
             log.warn("[getGpuTypeResources] 조회된 GPU 기종별 리소스가 없습니다.");
             throw new BusinessException(ErrorCode.NO_AVAILABLE_RESOURCES);
         }
 
-        var summaries = gpuRepository.findGpuSummary();
-        var response = summaries.stream()
+        var response = gpuSummaries.stream()
                 .map(GpuTypeResponseDTO::fromSummary)
                 .toList();
 

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/resourceGroups/service/ResourceGroupServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/resourceGroups/service/ResourceGroupServiceTest.java
@@ -74,5 +74,23 @@ class ResourceGroupServiceTest {
             assertThatThrownBy(() -> resourceGroupService.getGpuTypeResources())
                     .isInstanceOf(BusinessException.class);
         }
+
+        @Test
+        @DisplayName("findGpuSummary는 한 번만 호출된다 (중복 쿼리 제거 검증)")
+        void getGpuTypeResources_callsFindGpuSummaryOnce() {
+            GpuRepository.GpuSummary summary = mock(GpuRepository.GpuSummary.class);
+            when(summary.getRamGb()).thenReturn(80);
+            when(summary.getDescription()).thenReturn("A100 x4");
+            when(summary.getResourceGroupName()).thenReturn("GPU-Server-A");
+            when(summary.getNodeCount()).thenReturn(4L);
+            when(summary.getRsgroupId()).thenReturn(1);
+            when(summary.getNodeId()).thenReturn("node-1");
+            when(summary.getServerName()).thenReturn("server-01");
+            when(gpuRepository.findGpuSummary()).thenReturn(List.of(summary));
+
+            resourceGroupService.getGpuTypeResources();
+
+            verify(gpuRepository, times(1)).findGpuSummary();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `getGpuTypeResources()`에서 `gpuRepository.findGpuSummary()`를 2회 호출하던 문제 수정 — 첫 번째 결과를 재사용하도록 변경
- 디버그용 `System.out.println` 4개 제거 (로그는 기존 `log.info/warn`으로 충분)

## Test plan
- [ ] `getGpuTypeResources_callsFindGpuSummaryOnce()`: findGpuSummary가 1회만 호출됨 검증
- [ ] `getGpuTypeResources_throwsException_whenEmpty()`: 결과 없을 때 예외 발생 검증 유지