### PR TITLE
fix: PortRequests.activatePortRequest() isActive 설정 누락 수정 (#325)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/portRequests/entity/PortRequests.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/portRequests/entity/PortRequests.java
@@ -54,4 +54,7 @@ public class PortRequests extends BaseTimeEntity {
         this.resourceGroup = resourceGroup;
     }
 
+    public void activate() {
+        this.isActive = true;
+    }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/portRequests/service/PortRequestService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/portRequests/service/PortRequestService.java
@@ -94,6 +94,7 @@ public class PortRequestService {
         PortRequests portRequest = portRequestRepository.findById(portRequestId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
+        portRequest.activate();
         log.info("Port request {} activated", portRequestId);
     }
 }

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/portRequests/service/PortRequestServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/portRequests/service/PortRequestServiceTest.java
@@ -91,4 +91,30 @@ class PortRequestServiceTest {
         assertThatThrownBy(() -> portRequestService.createPortRequest(request, resourceGroup, 8888, "jupyter"))
                 .isInstanceOf(BusinessException.class);
     }
+
+    @Test
+    @DisplayName("activatePortRequest는 isActive를 true로 변경한다")
+    void activatePortRequest_setsIsActiveTrue() {
+        PortRequests portRequest = PortRequests.builder()
+                .portNumber(30001)
+                .internalPort(8888)
+                .usagePurpose("jupyter")
+                .build();
+        assertThat(portRequest.getIsActive()).isFalse();
+
+        when(portRequestRepository.findById(1L)).thenReturn(Optional.of(portRequest));
+
+        portRequestService.activatePortRequest(1L);
+
+        assertThat(portRequest.getIsActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("activatePortRequest에서 존재하지 않는 ID 요청 시 BusinessException을 던진다")
+    void activatePortRequest_throwsException_whenNotFound() {
+        when(portRequestRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> portRequestService.activatePortRequest(999L))
+                .isInstanceOf(BusinessException.class);
+    }
 }


### PR DESCRIPTION
## Summary
- `activatePortRequest()`가 로그만 출력하고 `isActive` 필드를 `true`로 변경하지 않는 버그 수정
- `PortRequests` 엔티티에 `activate()` 비즈니스 메서드를 추가 (`@NoArgsConstructor(PROTECTED)` 우회)
- 서비스에서 `portRequest.activate()` 호출 추가

## Test plan
- [ ] `activatePortRequest_setsIsActiveTrue()`: 활성화 후 isActive가 true로 변경됨 검증
- [ ] `activatePortRequest_throwsException_whenNotFound()`: 존재하지 않는 ID 요청 시 BusinessException 검증