### PR TITLE
fix: SingleChangeRequestDTO ObjectMapper 불필요한 인스턴스 생성 제거 (#326)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SingleChangeRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SingleChangeRequestDTO.java
@@ -37,6 +37,8 @@ public record SingleChangeRequestDTO(
         String reason
 ) {
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     /**
      * 기존 Request에서 oldValue를 추출하고 ChangeRequest 엔티티 생성
      */
@@ -141,8 +143,7 @@ public record SingleChangeRequestDTO(
                     LocalDateTime.parse(newValue.trim());
                 }
                 case GROUP -> {
-                    ObjectMapper mapper = new ObjectMapper();
-                    Set<Long> groupIds = mapper.readValue(newValue, mapper.getTypeFactory().constructCollectionType(Set.class, Long.class));
+                    Set<Long> groupIds = OBJECT_MAPPER.readValue(newValue, OBJECT_MAPPER.getTypeFactory().constructCollectionType(Set.class, Long.class));
                     if (groupIds.isEmpty()) {
                         throw new BusinessException("그룹 ID 목록은 비어있을 수 없습니다.", ErrorCode.INVALID_INPUT_VALUE);
                     }
@@ -160,9 +161,8 @@ public record SingleChangeRequestDTO(
                     }
                 }
                 case PORT -> {
-                    ObjectMapper mapper = new ObjectMapper();
-                    List<PortRequestDTO> portRequests = mapper.readValue(newValue,
-                        mapper.getTypeFactory().constructCollectionType(List.class, PortRequestDTO.class));
+                    List<PortRequestDTO> portRequests = OBJECT_MAPPER.readValue(newValue,
+                        OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, PortRequestDTO.class));
 
                     // Validate each port request
                     for (PortRequestDTO portRequest : portRequests) {

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SingleChangeRequestDTOTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SingleChangeRequestDTOTest.java
@@ -1,0 +1,51 @@
+package DGU_AI_LAB.admin_be.domain.requests.dto.request;
+
+import DGU_AI_LAB.admin_be.domain.requests.entity.ChangeType;
+import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SingleChangeRequestDTOTest {
+
+    @Test
+    @DisplayName("GROUP 타입에 빈 JSON 배열을 전달하면 BusinessException을 던진다")
+    void createValidatedChangeRequest_group_emptyList_throws() {
+        SingleChangeRequestDTO dto = new SingleChangeRequestDTO(ChangeType.GROUP, "[]", "reason");
+
+        assertThatThrownBy(() ->
+                SingleChangeRequestDTO.createValidatedChangeRequest(dto, null, null, null, null))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("GROUP 타입에 잘못된 JSON을 전달하면 BusinessException을 던진다")
+    void createValidatedChangeRequest_group_invalidJson_throws() {
+        SingleChangeRequestDTO dto = new SingleChangeRequestDTO(ChangeType.GROUP, "not-json", "reason");
+
+        assertThatThrownBy(() ->
+                SingleChangeRequestDTO.createValidatedChangeRequest(dto, null, null, null, null))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("PORT 타입에 잘못된 JSON을 전달하면 BusinessException을 던진다")
+    void createValidatedChangeRequest_port_invalidJson_throws() {
+        SingleChangeRequestDTO dto = new SingleChangeRequestDTO(ChangeType.PORT, "not-json", "reason");
+
+        assertThatThrownBy(() ->
+                SingleChangeRequestDTO.createValidatedChangeRequest(dto, null, null, null, null))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("VOLUME_SIZE 타입에 음수를 전달하면 BusinessException을 던진다")
+    void createValidatedChangeRequest_volumeSize_negative_throws() {
+        SingleChangeRequestDTO dto = new SingleChangeRequestDTO(ChangeType.VOLUME_SIZE, "-1", "reason");
+
+        assertThatThrownBy(() ->
+                SingleChangeRequestDTO.createValidatedChangeRequest(dto, null, null, null, null))
+                .isInstanceOf(BusinessException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- `validateValueFormat()`의 GROUP/PORT 케이스에서 매 검증 호출마다 `new ObjectMapper()`를 생성하던 문제 수정
- `private static final ObjectMapper OBJECT_MAPPER` 클래스 레벨 공유 인스턴스로 교체 (ObjectMapper는 thread-safe)

## Test plan
- [ ] `createValidatedChangeRequest_group_emptyList_throws()`: GROUP 타입 빈 배열 → BusinessException 검증
- [ ] `createValidatedChangeRequest_group_invalidJson_throws()`: GROUP 타입 잘못된 JSON → BusinessException 검증
- [ ] `createValidatedChangeRequest_port_invalidJson_throws()`: PORT 타입 잘못된 JSON → BusinessException 검증
- [ ] `createValidatedChangeRequest_volumeSize_negative_throws()`: 음수 볼륨 → BusinessException 검증