### PR TITLE
fix: lombok.config 추가 — @Qualifier 생성자 파라미터 전파

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier


### PR DESCRIPTION
## Summary
- PR #318에서 `podWebClient` 빈이 추가되어 WebClient 빈이 2개(`configWebClient`, `podWebClient`)가 됨
- Lombok `@RequiredArgsConstructor`는 기본적으로 필드의 `@Qualifier`를 생성자 파라미터에 복사하지 않음
- 결과: Spring 컨텍스트 로드 시 `NoUniqueBeanDefinitionException` 발생 → 통합 테스트 7개 실패
- `lombok.config`에 `lombok.copyableAnnotations += Qualifier` 설정으로 해결

## Affected Services
- `GroupService`, `UbuntuAccountService`, `AdminRequestCommandService`, `PodService` — 모두 `private final @Qualifier(...) WebClient` 패턴 사용

## Test plan
- [ ] `./gradlew clean test` 전체 테스트 통과 확인 (특히 `RequestSchedulerServiceTest`, `UserSchedulerServiceTest`, `ActuatorHealthSecurityTest`)