### PR TITLE
fix: Redis refresh token 만료 시 EXPIRED_REFRESH_TOKEN 반환

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/TokenService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/TokenService.java
@@ -66,6 +66,9 @@ public class TokenService {
         jwtProvider.validateRefreshToken(refreshToken);
 
         String storedRefreshToken = redisTemplate.opsForValue().get(redisKey);
+        if (storedRefreshToken == null) {
+            throw new UnauthorizedException(ErrorCode.EXPIRED_REFRESH_TOKEN);
+        }
         jwtProvider.equalsRefreshToken(refreshToken, storedRefreshToken);
 
         String newAccessToken = issueNewAccessToken(userId);

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/TokenServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/TokenServiceTest.java
@@ -17,6 +17,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import DGU_AI_LAB.admin_be.error.ErrorCode;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
@@ -146,6 +148,22 @@ class TokenServiceTest {
 
             assertThatThrownBy(() -> tokenService.reissue(dto))
                     .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("Redis에 리프레시 토큰이 없으면(만료/로그아웃) EXPIRED_REFRESH_TOKEN 예외를 던진다")
+        void reissue_throwsExpiredRefreshToken_whenRedisTokenIsNull() {
+            when(jwtProvider.getSubjectFromExpiredToken("accessToken")).thenReturn(1L);
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get("RT:1")).thenReturn(null);
+            doNothing().when(jwtProvider).validateRefreshToken("refreshToken");
+
+            UserTokenRequestDTO dto = new UserTokenRequestDTO("accessToken", "refreshToken");
+
+            assertThatThrownBy(() -> tokenService.reissue(dto))
+                    .isInstanceOf(UnauthorizedException.class)
+                    .satisfies(e -> assertThat(((UnauthorizedException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.EXPIRED_REFRESH_TOKEN));
         }
 
         @Test


### PR DESCRIPTION
## Summary
- `TokenService.reissue()`에서 Redis에 저장된 refresh token이 없을 때(로그아웃/만료) `storedRefreshToken`이 `null`이 되는 케이스에 대해 명시적 null 체크 추가
- 기존: `equalsRefreshToken("token", null)` → `NOT_MATCH_REFRESH_TOKEN` (의미 불일치)
- 변경: null이면 바로 `EXPIRED_REFRESH_TOKEN` 반환 (세션이 만료된 것이므로 재로그인 유도)

## Test plan
- [x] Redis에 토큰이 없을 때 `EXPIRED_REFRESH_TOKEN` 예외 던지는 테스트 추가 (`reissue_throwsExpiredRefreshToken_whenRedisTokenIsNull`)
- [x] 기존 TokenServiceTest 전체 통과 확인

Closes #329