### PR TITLE
refactor: UserSchedulerService +8일 여유 로직 상수로 명시

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/UserSchedulerService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/UserSchedulerService.java
@@ -21,6 +21,8 @@ public class UserSchedulerService {
 
     private static final int INACTIVE_MONTHS = 3;
     private static final int HARD_DELETE_YEARS = 1;
+    // D-7 경고까지 포함하려면 (strict <) 기준일을 7+1=8일 앞당겨야 한다
+    private static final int NOTIFICATION_LEAD_DAYS = 8;
 
     // 매일 오전 09:00 실행
     @Scheduled(cron = "0 0 9 * * ?", zone = "Asia/Seoul")
@@ -35,7 +37,7 @@ public class UserSchedulerService {
     }
 
     private void processInactiveUsers(LocalDateTime now) {
-        LocalDateTime searchThreshold = now.plusDays(8).minusMonths(INACTIVE_MONTHS);
+        LocalDateTime searchThreshold = now.plusDays(NOTIFICATION_LEAD_DAYS).minusMonths(INACTIVE_MONTHS);
         List<User> inactiveCandidates = userRepository.findInactiveUsers(searchThreshold);
 
         for (User user : inactiveCandidates) {


### PR DESCRIPTION
## Summary
- `processInactiveUsers()`에서 `now.plusDays(8)` 하드코딩을 `NOTIFICATION_LEAD_DAYS = 8` 상수로 추출
- 상수 선언부에 주석으로 의도 명시: D-7 경고 대상을 strict `<` 쿼리에 포함시키려면 기준일을 7+1=8일 앞당겨야 함

## Test plan
- [x] 기존 `UserSchedulerServiceTest` 통합 테스트 통과 (D-7, D-1, Soft Delete, Hard Delete 시나리오 포함)

Closes #330