### PR TITLE
chore: develop → main (PR #331, #332)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/UserSchedulerService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/UserSchedulerService.java
@@ -21,6 +21,8 @@ public class UserSchedulerService {
 
     private static final int INACTIVE_MONTHS = 3;
     private static final int HARD_DELETE_YEARS = 1;
+    // D-7 경고까지 포함하려면 (strict <) 기준일을 7+1=8일 앞당겨야 한다
+    private static final int NOTIFICATION_LEAD_DAYS = 8;
 
     // 매일 오전 09:00 실행
     @Scheduled(cron = "0 0 9 * * ?", zone = "Asia/Seoul")
@@ -35,7 +37,7 @@ public class UserSchedulerService {
     }
 
     private void processInactiveUsers(LocalDateTime now) {
-        LocalDateTime searchThreshold = now.plusDays(8).minusMonths(INACTIVE_MONTHS);
+        LocalDateTime searchThreshold = now.plusDays(NOTIFICATION_LEAD_DAYS).minusMonths(INACTIVE_MONTHS);
         List<User> inactiveCandidates = userRepository.findInactiveUsers(searchThreshold);
 
         for (User user : inactiveCandidates) {

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/TokenService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/TokenService.java
@@ -66,6 +66,9 @@ public class TokenService {
         jwtProvider.validateRefreshToken(refreshToken);
 
         String storedRefreshToken = redisTemplate.opsForValue().get(redisKey);
+        if (storedRefreshToken == null) {
+            throw new UnauthorizedException(ErrorCode.EXPIRED_REFRESH_TOKEN);
+        }
         jwtProvider.equalsRefreshToken(refreshToken, storedRefreshToken);
 
         String newAccessToken = issueNewAccessToken(userId);

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/TokenServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/TokenServiceTest.java
@@ -17,6 +17,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import DGU_AI_LAB.admin_be.error.ErrorCode;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
@@ -146,6 +148,22 @@ class TokenServiceTest {
 
             assertThatThrownBy(() -> tokenService.reissue(dto))
                     .isInstanceOf(UnauthorizedException.class);
+        }
+
+        @Test
+        @DisplayName("Redis에 리프레시 토큰이 없으면(만료/로그아웃) EXPIRED_REFRESH_TOKEN 예외를 던진다")
+        void reissue_throwsExpiredRefreshToken_whenRedisTokenIsNull() {
+            when(jwtProvider.getSubjectFromExpiredToken("accessToken")).thenReturn(1L);
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.get("RT:1")).thenReturn(null);
+            doNothing().when(jwtProvider).validateRefreshToken("refreshToken");
+
+            UserTokenRequestDTO dto = new UserTokenRequestDTO("accessToken", "refreshToken");
+
+            assertThatThrownBy(() -> tokenService.reissue(dto))
+                    .isInstanceOf(UnauthorizedException.class)
+                    .satisfies(e -> assertThat(((UnauthorizedException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.EXPIRED_REFRESH_TOKEN));
         }
 
         @Test


### PR DESCRIPTION
## Summary
- **#331** `TokenService.reissue()`: Redis refresh token 없을 때 `EXPIRED_REFRESH_TOKEN` 반환 (세션 만료 케이스 명시적 처리)
- **#332** `UserSchedulerService`: `+8일` 하드코딩을 `NOTIFICATION_LEAD_DAYS = 8` 상수로 추출 및 주석 명시

## Test plan
- [x] 전체 테스트 스위트 통과 확인 (`./gradlew test`)