### PR TITLE
fix: 승인 이메일에 base64 비밀번호 대신 평문 발송

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SaveRequestRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SaveRequestRequestDTO.java
@@ -18,7 +18,9 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -78,12 +80,15 @@ public record SaveRequestRequestDTO(
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
+        // 클라이언트는 base64 인코딩된 값을 전송 — 평문은 디코딩해서 이메일 발송용으로 따로 보관
+        String plainPassword = new String(Base64.getDecoder().decode(ubuntuPasswordBase64), StandardCharsets.UTF_8);
+
         Request req = Request.builder()
                 .user(user)
                 .resourceGroup(resourceGroup)
                 .containerImage(image)
                 .ubuntuUsername(ubuntuUsername)
-                .ubuntuPassword(ubuntuPasswordBase64)
+                .ubuntuPassword(plainPassword)
                 .ubuntuPasswordBase64(ubuntuPasswordBase64)
                 .volumeSizeGiB(volumeSizeGiB)
                 .usagePurpose(usagePurpose)


### PR DESCRIPTION
## Summary
- 클라이언트는 base64 인코딩된 비밀번호를 `ubuntuPassword` 필드로 전송
- 기존: `ubuntuPassword` 컬럼(이메일용)에 base64 문자열이 그대로 저장됨 → 승인 이메일에 `c3Ryb25n...` 형태로 발송
- 수정: `toEntity()` 내에서 base64 디코딩 후 `ubuntuPassword`에 평문, `ubuntuPasswordBase64`에 base64 저장

## Test plan
- [x] 전체 테스트 스위트 통과

Closes #334