### PR TITLE
refactor: 도달 불가 코드 및 중복 DB 조회 제거

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestCommandService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestCommandService.java
@@ -66,8 +66,7 @@ public class RequestCommandService {
             throw new BusinessException(ErrorCode.INVALID_REQUEST_STATUS);
         }
 
-        User requestedBy = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        User requestedBy = originalRequest.getUser();
 
         // 저장공간 크기 변경
         if (dto.requestedVolumeSizeGiB() != null) {
@@ -134,8 +133,7 @@ public class RequestCommandService {
             throw new BusinessException(ErrorCode.INVALID_REQUEST_STATUS);
         }
 
-        User requestedBy = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        User requestedBy = originalRequest.getUser();
 
         // DTO 팩토리 메서드를 사용하여 검증된 ChangeRequest 생성 및 저장
         ChangeRequest changeRequest = SingleChangeRequestDTO.createValidatedChangeRequest(

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/UbuntuAccountService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/UbuntuAccountService.java
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
 import java.util.Map;
@@ -51,10 +50,8 @@ public class UbuntuAccountService {
                     .block();
             log.info("사용자 삭제 성공: {}", username);
         } catch (Exception e) {
-            if (!(e instanceof WebClientResponseException && ((WebClientResponseException)e).getStatusCode() == HttpStatus.NOT_FOUND)) {
-                log.error("사용자 삭제 API 호출 중 예기치 않은 오류: {}", username, e);
-                throw new BusinessException("사용자 삭제 API 호출 오류", ErrorCode.INTERNAL_SERVER_ERROR);
-            }
+            log.error("사용자 삭제 API 호출 중 예기치 않은 오류: {}", username, e);
+            throw new BusinessException("사용자 삭제 API 호출 오류", ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/UserService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/UserService.java
@@ -64,22 +64,12 @@ public class UserService {
         String passwordBase64 = dto.passwordBase64();
         log.debug("비밀번호를 확인합니다. username: {}", dto.username());
 
-        // 3. 사용자 및 비밀번호 일치 여부 확인
         Request request = requestRepository.findByUbuntuUsernameAndUbuntuPasswordBase64(dto.username(), passwordBase64)
                 .orElseThrow(() -> {
-                    // 3-1. 사용자 정보를 찾을 수 없을 때의 로그
                     log.warn("사용자 '{}'를 찾을 수 없거나 비밀번호가 일치하지 않습니다.", dto.username());
                     return new UnauthorizedException(ErrorCode.USER_NOT_FOUND);
                 });
 
-        // 4. 추가 비밀번호 일치 확인 (Optional: Optional로 처리되었기 때문에 이중 확인)
-        if (!passwordBase64.equals(request.getUbuntuPasswordBase64())) {
-            // 4-1. 비밀번호 불일치 로그
-            log.error("사용자 '{}'에 대해 데이터베이스 비밀번호와 암호화된 비밀번호가 일치하지 않습니다. (내부 로직 오류 가능성)", dto.username());
-            throw new UnauthorizedException(ErrorCode.INVALID_LOGIN_INFO);
-        }
-
-        // 5. 인증 성공 로그
         log.info("사용자 '{}'의 인증이 성공적으로 완료되었습니다.", dto.username());
 
         return new UserAuthResponseDTO(true, request.getUbuntuUsername());


### PR DESCRIPTION
## Summary

Closes #335

- `UserService.userAuth()`: `findByUbuntuUsernameAndUbuntuPasswordBase64` 쿼리가 이미 비밀번호 일치를 보장하므로 이중 확인 블록 제거 (L75-80)
- `UbuntuAccountService.deleteUbuntuAccount()`: `onStatus`가 404를 `Mono.empty()`로 처리하므로 catch 내 `WebClientResponseException NOT_FOUND` 분기는 도달 불가 — 제거 및 unused import 정리
- `RequestCommandService.createModificationRequest/createSingleChangeRequest`: userId 소유권 검증 직후에 `originalRequest.getUser()`로 동일 User를 얻을 수 있으므로 `userRepository.findById(userId)` 재조회 제거

## Test plan

- [ ] `UserService.userAuth()`: username/password 불일치 시 `USER_NOT_FOUND` 반환 확인
- [ ] `UbuntuAccountService.deleteUbuntuAccount()`: 404 응답 시 예외 없이 정상 종료 확인, 500 응답 시 `BusinessException` 발생 확인
- [ ] `RequestCommandService.createModificationRequest`: 정상 변경 요청 생성 확인