### PR TITLE
refactor: DTO 변환 중복 코드 제거

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/SaveRequestResponseDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/SaveRequestResponseDTO.java
@@ -117,45 +117,7 @@ public record SaveRequestResponseDTO(
     }
 
     public static SaveRequestResponseDTO fromEntity(Request request) {
-
-        if (request.getResourceGroup() == null) {
-            throw new BusinessException(ErrorCode.RESOURCE_GROUP_NOT_FOUND);
-        }
-        if (request.getUser() == null) {
-            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
-        }
-        if (request.getContainerImage() == null) {
-            throw new BusinessException(ErrorCode.RESOURCE_NOT_FOUND);
-        }
-
-        return SaveRequestResponseDTO.builder()
-                .requestId(request.getRequestId())
-                .resourceGroupId(request.getResourceGroup().getRsgroupId())
-                .resourceGroup(AdminResourceGroupInfo.fromEntity(request.getResourceGroup()))
-                .user(AdminUserInfo.fromEntity(request.getUser()))
-                .imageId(request.getContainerImage().getImageId())
-                .imageName(request.getContainerImage().getImageName())
-                .imageVersion(request.getContainerImage().getImageVersion())
-                .ubuntuUsername(request.getUbuntuUsername())
-                .ubuntuUid(request.getUbuntuUid())
-                .ubuntuGid(request.getUbuntuGid())
-                .ubuntuGids(
-                        request.getRequestGroups().stream()
-                                .map(rg -> rg.getGroup().getUbuntuGid())
-                                .toList()
-                )
-                .volumeSizeGiB(request.getVolumeSizeGiB())
-                .usagePurpose(request.getUsagePurpose())
-                .formAnswers(request.getFormAnswers())
-                .expiresAt(request.getExpiresAt())
-                .status(request.getStatus())
-                .approvedAt(request.getApprovedAt())
-                .comment(request.getAdminComment())
-                .portMappings(List.of())
-                .podExternalPorts(List.of())
-                .createdAt(request.getCreatedAt())
-                .updatedAt(request.getUpdatedAt())
-                .build();
+        return fromEntityWithPorts(request, List.of(), List.of());
     }
 
     public static SaveRequestResponseDTO fromEntityWithPortMappings(Request request, List<PortMappingDTO> portMappings) {

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryService.java
@@ -1,15 +1,9 @@
 package DGU_AI_LAB.admin_be.domain.requests.service;
 
-import DGU_AI_LAB.admin_be.domain.pod.repository.PodExternalPortRepository;
-import DGU_AI_LAB.admin_be.domain.portRequests.entity.PortRequests;
-import DGU_AI_LAB.admin_be.domain.portRequests.repository.PortRequestRepository;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ChangeRequestResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ContainerInfoDTO;
-import DGU_AI_LAB.admin_be.domain.requests.dto.response.PodExternalPortResponseDTO;
-import DGU_AI_LAB.admin_be.domain.requests.dto.response.PortMappingDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ResourceUsageDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.SaveRequestResponseDTO;
-import DGU_AI_LAB.admin_be.domain.pod.entity.PodExternalPort;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Status;
 import DGU_AI_LAB.admin_be.domain.requests.repository.ChangeRequestRepository;
@@ -19,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -29,47 +22,16 @@ public class AdminRequestQueryService {
 
     private final RequestRepository requestRepository;
     private final ChangeRequestRepository changeRequestRepository;
-    private final PortRequestRepository portRequestRepository;
-    private final PodExternalPortRepository podExternalPortRepository;
+    private final RequestQueryService requestQueryService;
 
     public List<SaveRequestResponseDTO> getAllRequests() {
         List<Request> requests = requestRepository.findAll();
-        return buildResponseDTOs(requests);
+        return requestQueryService.toResponseDTOs(requests);
     }
 
     public List<SaveRequestResponseDTO> getNewRequests() {
         List<Request> requests = requestRepository.findAllByStatus(Status.PENDING);
-        return buildResponseDTOs(requests);
-    }
-
-    private List<SaveRequestResponseDTO> buildResponseDTOs(List<Request> requests) {
-        if (requests.isEmpty()) return List.of();
-
-        List<Long> requestIds = requests.stream().map(Request::getRequestId).toList();
-
-        Map<Long, List<PortMappingDTO>> portMappingsByRequestId = portRequestRepository
-                .findByRequestRequestIdIn(requestIds)
-                .stream()
-                .collect(Collectors.groupingBy(
-                        pr -> pr.getRequest().getRequestId(),
-                        Collectors.mapping(PortMappingDTO::fromEntity, Collectors.toList())
-                ));
-
-        Map<Long, List<PodExternalPortResponseDTO>> podPortsByRequestId = podExternalPortRepository
-                .findByRequestRequestIdIn(requestIds)
-                .stream()
-                .collect(Collectors.groupingBy(
-                        pp -> pp.getRequest().getRequestId(),
-                        Collectors.mapping(PodExternalPortResponseDTO::fromEntity, Collectors.toList())
-                ));
-
-        return requests.stream()
-                .map(request -> SaveRequestResponseDTO.fromEntityWithPorts(
-                        request,
-                        portMappingsByRequestId.getOrDefault(request.getRequestId(), List.of()),
-                        podPortsByRequestId.getOrDefault(request.getRequestId(), List.of())
-                ))
-                .toList();
+        return requestQueryService.toResponseDTOs(requests);
     }
 
     public List<ResourceUsageDTO> getAllFulfilledResourceUsage() {

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestQueryService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestQueryService.java
@@ -45,7 +45,7 @@ public class RequestQueryService {
     }
 
     /** 목록 단위 배치 로딩으로 N+1 방지: portRequests, podExternalPorts를 IN절 1회씩 조회 */
-    private List<SaveRequestResponseDTO> toResponseDTOs(List<Request> requests) {
+    List<SaveRequestResponseDTO> toResponseDTOs(List<Request> requests) {
         if (requests.isEmpty()) return List.of();
 
         List<Long> ids = requests.stream().map(Request::getRequestId).toList();


### PR DESCRIPTION
## Summary

Closes #336

- `SaveRequestResponseDTO.fromEntity()`: `fromEntityWithPorts(request, List.of(), List.of())`에 위임하여 40줄 중복 빌더 블록 제거
- `RequestQueryService.toResponseDTOs()`: `private` → package-private으로 변경하여 같은 패키지 내 공유 가능
- `AdminRequestQueryService.buildResponseDTOs()`: `RequestQueryService.toResponseDTOs()`에 위임하고 중복 필드(`portRequestRepository`, `podExternalPortRepository`) 및 동일 로직 제거

## Test plan

- [ ] `GET /api/admin/requests` — 목록 조회 정상 동작 (portMappings, podExternalPorts 포함)
- [ ] `GET /api/admin/requests/new` — PENDING 목록 정상 동작
- [ ] `POST /api/requests` — 신청 생성 응답에 portMappings: [], podExternalPorts: [] 포함 확인