### PR TITLE
fix: SlackApiService RestTemplate 타임아웃 설정

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/service/SlackApiService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/service/SlackApiService.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.Duration;
@@ -28,7 +29,14 @@ public class SlackApiService {
     @Value("${slack.bot-token}")
     private String botToken;
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate = createRestTemplate();
+
+    private static RestTemplate createRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3_000);
+        factory.setReadTimeout(5_000);
+        return new RestTemplate(factory);
+    }
     private final RedisTemplate<String, Object> redisTemplate;
 
     private static final String SLACK_USERS_CACHE_KEY = "slack:cache:users:list";


### PR DESCRIPTION
## Summary

Closes #337

`new RestTemplate()`은 타임아웃이 없어 Slack이 느리거나 무응답일 때 스레드를 무기한 점유 — 알림 큐 worker 스레드 고갈로 이어질 수 있음.

`SimpleClientHttpRequestFactory`로 커넥션 3초 / 읽기 5초 타임아웃 설정.

## Test plan

- [ ] Slack Webhook 정상 전송 확인
- [ ] Slack DM 정상 전송 확인