### PR TITLE
fix: GET /api/groups 빈 목록 시 200+[] 반환

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupService.java
@@ -44,11 +44,6 @@ public class GroupService {
         log.info("[getAllGroups] 모든 그룹 정보 조회 시작");
         var groups = groupRepository.findAll();
 
-        if (groups.isEmpty()) {
-            log.warn("[getAllGroups] 조회된 그룹 정보가 없습니다.");
-            throw new BusinessException(ErrorCode.NO_AVAILABLE_GROUPS);
-        }
-
         var response = groups.stream()
                 .map(GroupResponseDTO::fromEntity)
                 .toList();


### PR DESCRIPTION
## Summary

Closes #338

`getAllGroups()`에서 그룹이 없으면 `NO_AVAILABLE_GROUPS` (404)를 던졌음.
빈 컬렉션은 에러가 아니므로 빈 리스트(`[]`)를 200으로 반환하도록 수정.

그룹이 없는 초기 환경에서 프론트엔드 신청 폼이 즉시 오류 화면을 보이는 문제가 해결됨.

## Test plan

- [ ] 그룹이 없을 때 `GET /api/groups` → `200 OK`, body `[]`
- [ ] 그룹이 있을 때 `GET /api/groups` → `200 OK`, body `[{...}, ...]`