### PR TITLE
fix: config-server K8s 서비스명/포트 오류 수정

### DIFF
--- a/helm/admin-prod/values.yaml
+++ b/helm/admin-prod/values.yaml
@@ -11,3 +11,6 @@ service:
   nodePort: 30083 # 외부 접속용 Port
 
 forceReload: "" # CI/CD에서 동적으로 넣어주는 값
+
+args:
+  - --config.base-url=http://containerssh-config-service.ailab-infra.svc.cluster.local:80


### PR DESCRIPTION
## Summary

Closes #345

승인 시 config-server가 요청을 받지 못하는 근본 원인 수정.

- `application.yml`의 `config.base-url`이 실제 K8s 서비스와 달라 DNS 조회 실패
- 서비스명: `containerssh-config-server` → `containerssh-config-service`
- 포트: `8000` → `80`
- `application.yml`은 gitignored이므로 `helm/admin-prod/values.yaml` args로 override

## Test plan

- [ ] 재배포 후 `PATCH /api/admin/requests/approve` 호출
- [ ] config-server 로그에서 `PUT /accounts/users` 수신 확인
- [ ] 승인 완료 후 응답 200 OK 확인