### PR TITLE
revert: helm values.yaml args 제거

### DIFF
--- a/helm/admin-prod/values.yaml
+++ b/helm/admin-prod/values.yaml
@@ -11,6 +11,3 @@ service:
   nodePort: 30083 # 외부 접속용 Port
 
 forceReload: "" # CI/CD에서 동적으로 넣어주는 값
-
-args:
-  - --config.base-url=http://containerssh-config-service.ailab-infra.svc.cluster.local:80


### PR DESCRIPTION
config.base-url은 secrets.APPLICATION으로 주입하므로 values.yaml args 불필요