### PR TITLE
test: 서비스 로직 변경에 맞게 실패 테스트 4종 수정

### DIFF
--- a/src/test/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/groups/service/GroupServiceTest.java
@@ -59,12 +59,13 @@ class GroupServiceTest {
         }
 
         @Test
-        @DisplayName("그룹이 없으면 BusinessException을 던진다")
-        void getAllGroups_throwsException_whenEmpty() {
+        @DisplayName("그룹이 없으면 빈 리스트를 반환한다")
+        void getAllGroups_returnsEmptyList_whenNoGroups() {
             when(groupRepository.findAll()).thenReturn(List.of());
 
-            assertThatThrownBy(() -> groupService.getAllGroups())
-                    .isInstanceOf(BusinessException.class);
+            List<GroupResponseDTO> result = groupService.getAllGroups();
+
+            assertThat(result).isEmpty();
         }
     }
 

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryServiceTest.java
@@ -1,8 +1,5 @@
 package DGU_AI_LAB.admin_be.domain.requests.service;
 
-import DGU_AI_LAB.admin_be.domain.pod.entity.PodExternalPort;
-import DGU_AI_LAB.admin_be.domain.pod.repository.PodExternalPortRepository;
-import DGU_AI_LAB.admin_be.domain.portRequests.repository.PortRequestRepository;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ChangeRequestResponseDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ContainerInfoDTO;
 import DGU_AI_LAB.admin_be.domain.requests.dto.response.ResourceUsageDTO;
@@ -22,7 +19,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,10 +34,7 @@ class AdminRequestQueryServiceTest {
     private ChangeRequestRepository changeRequestRepository;
 
     @Mock
-    private PortRequestRepository portRequestRepository;
-
-    @Mock
-    private PodExternalPortRepository podExternalPortRepository;
+    private RequestQueryService requestQueryService;
 
     @Nested
     @DisplayName("getAllRequests")
@@ -59,30 +52,18 @@ class AdminRequestQueryServiceTest {
         }
 
         @Test
-        @DisplayName("관리자 요청 조회 시 pod_external_ports를 배치 쿼리로 함께 반환한다")
-        void getAllRequests_returnsPodExternalPorts() {
-            Request request = mockRequest(1L);
-            PodExternalPort podExternalPort = PodExternalPort.builder()
-                    .request(request)
-                    .internalPort(22)
-                    .externalPort(30022)
-                    .usagePurpose("ssh")
-                    .build();
+        @DisplayName("요청 목록을 RequestQueryService에 위임하여 반환한다")
+        void getAllRequests_delegatesToRequestQueryService() {
+            Request request = mock(Request.class);
+            SaveRequestResponseDTO dto = mock(SaveRequestResponseDTO.class);
 
             when(requestRepository.findAll()).thenReturn(List.of(request));
-            when(portRequestRepository.findByRequestRequestIdIn(anyList())).thenReturn(List.of());
-            when(podExternalPortRepository.findByRequestRequestIdIn(anyList())).thenReturn(List.of(podExternalPort));
+            when(requestQueryService.toResponseDTOs(List.of(request))).thenReturn(List.of(dto));
 
             List<SaveRequestResponseDTO> result = adminRequestQueryService.getAllRequests();
 
             assertThat(result).hasSize(1);
-            assertThat(result.get(0).podExternalPorts()).hasSize(1);
-            assertThat(result.get(0).podExternalPorts().get(0).internalPort()).isEqualTo(22);
-            assertThat(result.get(0).podExternalPorts().get(0).externalPort()).isEqualTo(30022);
-            assertThat(result.get(0).podExternalPorts().get(0).usagePurpose()).isEqualTo("ssh");
-            // 배치 쿼리 1회만 호출되었는지 검증 (N+1 방지)
-            verify(portRequestRepository, times(1)).findByRequestRequestIdIn(anyList());
-            verify(podExternalPortRepository, times(1)).findByRequestRequestIdIn(anyList());
+            verify(requestQueryService, times(1)).toResponseDTOs(List.of(request));
         }
     }
 

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestCommandServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/RequestCommandServiceTest.java
@@ -179,7 +179,6 @@ class RequestCommandServiceTest {
             when(request.getUser()).thenReturn(owner);
             when(request.getStatus()).thenReturn(Status.FULFILLED);
             when(requestRepository.findById(12L)).thenReturn(Optional.of(request));
-            when(userRepository.findById(1L)).thenReturn(Optional.empty());
 
             // dto stubs 불필요 - userRepository.findById 에서 이미 예외 발생
             ModifyRequestDTO dto = mock(ModifyRequestDTO.class);

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/UserServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/UserServiceTest.java
@@ -196,7 +196,6 @@ class UserServiceTest {
 
             Request request = mock(Request.class);
             when(request.getUbuntuUsername()).thenReturn("testuser");
-            when(request.getUbuntuPasswordBase64()).thenReturn(passwordBase64);
             when(requestRepository.findByUbuntuUsernameAndUbuntuPasswordBase64("testuser", passwordBase64))
                     .thenReturn(Optional.of(request));
 


### PR DESCRIPTION
## 개요

최근 서비스 로직 변경(리팩토링, 버그 수정)으로 인해 기존 테스트 4개가 실패하는 상태를 수정합니다.

## 변경 내용

### GroupServiceTest
- `getAllGroups()` 빈 목록 시 `BusinessException` 발생 → `200 + []` 반환으로 동작이 변경됨 (#338)
- 테스트 기대값을 빈 리스트 반환으로 수정

### AdminRequestQueryServiceTest
- `AdminRequestQueryService`에 `RequestQueryService` 의존성이 추가됐으나 테스트에 mock 누락
- `@Mock RequestQueryService` 추가, 더 이상 직접 의존하지 않는 `PortRequestRepository` / `PodExternalPortRepository` mock 제거
- 배치 쿼리 검증 테스트를 `RequestQueryService` 위임 호출 검증으로 대체

### UserServiceTest
- `userAuth()` 내부에서 `request.getUbuntuPasswordBase64()` 직접 호출이 제거됨
- 불필요해진 stubbing 제거

### RequestCommandServiceTest
- `createModificationRequest()` 에서 `userRepository.findById()` 직접 호출이 제거됨
- 불필요해진 stubbing 제거

## 테스트 결과

315개 전체 통과