### PR TITLE
[ refactor ] 신청 승인 트랜잭션 분리 — 외부 HTTP 호출 중 DB 커넥션 미보유

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
@@ -35,7 +35,10 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -63,28 +66,97 @@ public class AdminRequestCommandService {
     private final ObjectMapper objectMapper;
 
     private final @Qualifier("configWebClient") WebClient userCreationWebClient;
+    private final PlatformTransactionManager transactionManager;
 
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public SaveRequestResponseDTO approveRequest(ApproveRequestDTO dto) {
-        Request request = requestRepository.findById(dto.requestId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
-        if (request.getStatus() != Status.PENDING) {
-            throw new BusinessException(ErrorCode.INVALID_REQUEST_STATUS);
-        }
-        // 1. 사용자 생성 API 호출
-        UserCreationRequestDTO userCreationDto = new UserCreationRequestDTO(
-                request.getUbuntuUsername(),
-                request.getUbuntuPasswordBase64(),
-                request.getUser().getName(),
-                request.getUbuntuUsername(), // primary_group_name = username (Linux 관례)
-                false
-        );
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
 
-        UserCreationResponse userResponse;
+        // 1. 상태 검증 + HTTP 요청 데이터 추출 (짧은 트랜잭션, 이후 커넥션 반납)
+        final UserCreationRequestDTO[] creationDtoRef = {null};
+        final String[] usernameRef = {null};
+        tx.execute(status -> {
+            Request req = requestRepository.findById(dto.requestId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
+            if (req.getStatus() != Status.PENDING) {
+                throw new BusinessException(ErrorCode.INVALID_REQUEST_STATUS);
+            }
+            usernameRef[0] = req.getUbuntuUsername();
+            creationDtoRef[0] = new UserCreationRequestDTO(
+                    req.getUbuntuUsername(),
+                    req.getUbuntuPasswordBase64(),
+                    req.getUser().getName(),
+                    req.getUbuntuUsername(),
+                    false
+            );
+            return null;
+        });
+        String username = usernameRef[0];
+
+        // 2. 외부 HTTP 호출 (DB 커넥션 미보유)
+        UserCreationResponse userResponse = callUserCreationApi(creationDtoRef[0]);
+
+        CreatePodResponseDTO podResponse;
+        try {
+            podResponse = podService.createPod(username);
+        } catch (BusinessException e) {
+            log.warn("[보상 트랜잭션] Pod 생성 실패 → 계정 삭제 시작: {}", username);
+            tryCompensateDeleteUser(username);
+            throw e;
+        }
+
+        final CreatePodResponseDTO finalPodResponse = podResponse;
+        final UserCreationResponse finalUserResponse = userResponse;
+
+        // 3. DB 저장 (새 트랜잭션, HTTP 완료 후 짧게만 커넥션 보유)
+        final Request[] savedRequestRef = {null};
+        try {
+            tx.execute(status -> {
+                Request req = requestRepository.findById(dto.requestId())
+                        .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
+                ContainerImage image = containerImageRepository.findById(dto.imageId())
+                        .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
+                ResourceGroup rg = resourceGroupRepository.findById(dto.resourceGroupId())
+                        .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
+                req.assignUbuntuIds(finalUserResponse.uid(), finalUserResponse.gid());
+                req.approve(image, rg, dto.volumeSizeGiB(), dto.adminComment());
+                req.assignPodInfo(finalPodResponse.podName(), finalPodResponse.node());
+                for (CreatePodResponseDTO.PortInfo port : finalPodResponse.ports()) {
+                    podExternalPortRepository.save(PodExternalPort.builder()
+                            .request(req)
+                            .internalPort(port.internalPort())
+                            .externalPort(port.externalPort())
+                            .usagePurpose(port.usagePurpose())
+                            .build());
+                }
+                req.getUser().getEmail(); // lazy 연관 초기화 (트랜잭션 종료 후 이메일 발송 시 필요)
+                savedRequestRef[0] = req;
+                return null;
+            });
+        } catch (Exception e) {
+            log.error("[보상 트랜잭션] DB 업데이트 실패 → 전체 infra 리소스 삭제 시작: {}", username, e);
+            tryCompensateAll(username, finalPodResponse.podName());
+            throw e;
+        }
+
+        // 4. 이메일 발송 (트랜잭션 종료 후, 실패해도 Pod·계정은 이미 생성됨)
+        Request savedRequest = savedRequestRef[0];
+        try {
+            String sshPort = extractExternalPort(finalPodResponse, "ssh");
+            String jupyterPort = extractExternalPort(finalPodResponse, "jupyter");
+            alarmService.sendContainerCreatedEmail(savedRequest, sshPort, jupyterPort);
+            log.info("사용자 '{}'에게 컨테이너 배정 안내 메일을 발송했습니다.", savedRequest.getUser().getName());
+        } catch (Exception e) {
+            log.warn("사용자 '{}'에게 배정 안내 메일 발송 실패. (RequestId: {})",
+                    savedRequest.getUser().getName(), savedRequest.getRequestId(), e);
+        }
+        return SaveRequestResponseDTO.fromEntity(savedRequest);
+    }
+
+    private UserCreationResponse callUserCreationApi(UserCreationRequestDTO userCreationDto) {
         try {
             log.info("사용자 생성 API 호출 시작: {}", userCreationDto.username());
-
-            userResponse = userCreationWebClient.put()
+            UserCreationResponse userResponse = userCreationWebClient.put()
                     .uri("/accounts/users")
                     .bodyValue(userCreationDto)
                     .retrieve()
@@ -104,66 +176,18 @@ public class AdminRequestCommandService {
                     )
                     .bodyToMono(UserCreationResponse.class)
                     .block();
-
             log.info("사용자 생성 성공: {}", userResponse);
             if (userResponse == null || userResponse.uid() == null || userResponse.gid() == null) {
                 log.error("사용자 생성 API 응답에 UID/GID가 없습니다: {}", userResponse);
                 throw new BusinessException(ErrorCode.UID_ALLOCATION_FAILED);
             }
+            return userResponse;
         } catch (BusinessException e) {
             throw e;
         } catch (Exception e) {
             log.error("사용자 생성 API 호출 중 예기치 않은 오류 발생.", e);
             throw new BusinessException(ErrorCode.USER_CREATION_FAILED);
         }
-
-        String username = request.getUbuntuUsername();
-
-        // 2. Pod 생성 API 호출
-        CreatePodResponseDTO podResponse;
-        try {
-            podResponse = podService.createPod(username);
-        } catch (BusinessException e) {
-            log.warn("[보상 트랜잭션] Pod 생성 실패 → 계정 삭제 시작: {}", username);
-            tryCompensateDeleteUser(username);
-            throw e;
-        }
-
-        // 3. API 호출이 모두 성공한 후에 DB 업데이트
-        try {
-            ContainerImage image = containerImageRepository.findById(dto.imageId())
-                    .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
-            ResourceGroup rg = resourceGroupRepository.findById(dto.resourceGroupId())
-                    .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
-            request.assignUbuntuIds(userResponse.uid(), userResponse.gid());
-            request.approve(image, rg, dto.volumeSizeGiB(), dto.adminComment());
-            request.assignPodInfo(podResponse.podName(), podResponse.node());
-            for (CreatePodResponseDTO.PortInfo port : podResponse.ports()) {
-                podExternalPortRepository.save(PodExternalPort.builder()
-                        .request(request)
-                        .internalPort(port.internalPort())
-                        .externalPort(port.externalPort())
-                        .usagePurpose(port.usagePurpose())
-                        .build());
-            }
-        } catch (Exception e) {
-            log.error("[보상 트랜잭션] DB 업데이트 실패 → 전체 infra 리소스 삭제 시작: {}", username, e);
-            tryCompensateAll(username, podResponse.podName());
-            throw e;
-        }
-        // requestRepository.flush();
-
-        // 5. 사용자에게 컨테이너 배정 안내 메일 발송 (접속 정보 포함)
-        try {
-            String sshPort = extractExternalPort(podResponse, "ssh");
-            String jupyterPort = extractExternalPort(podResponse, "jupyter");
-            alarmService.sendContainerCreatedEmail(request, sshPort, jupyterPort);
-            log.info("사용자 '{}'에게 컨테이너 배정 안내 메일을 발송했습니다.", request.getUser().getName());
-        } catch (Exception e) {
-            log.warn("사용자 '{}'에게 배정 안내 메일 발송 실패. (RequestId: {})",
-                    request.getUser().getName(), request.getRequestId(), e);
-        }
-        return SaveRequestResponseDTO.fromEntity(request);
     }
 
     /** podResponse 포트 목록에서 usage_purpose가 일치하는 첫 외부 포트(문자열). 없으면 "". */

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandServiceTest.java
@@ -36,6 +36,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -65,6 +67,8 @@ class AdminRequestCommandServiceTest {
     @Mock private PodService podService;
     @Mock private UbuntuAccountService ubuntuAccountService;
     @Mock private WebClient mockWebClient;
+    @Mock private PlatformTransactionManager transactionManager;
+    @Mock private TransactionStatus transactionStatus;
 
     // WebClient 체이닝 mock
     @Mock private WebClient.RequestBodyUriSpec putUriSpec;
@@ -81,12 +85,14 @@ class AdminRequestCommandServiceTest {
 
     @BeforeEach
     void setUp() {
+        when(transactionManager.getTransaction(any())).thenReturn(transactionStatus);
+
         // @RequiredArgsConstructor 생성자 필드 선언 순서대로 주입
         service = new AdminRequestCommandService(
                 alarmService, requestRepository, userRepository, containerImageRepository,
                 resourceGroupRepository, changeRequestRepository,
                 groupRepository, podExternalPortRepository, podService, ubuntuAccountService, new ObjectMapper(),
-                mockWebClient
+                mockWebClient, transactionManager
         );
         // 공유 엔티티 기본 설정
         when(mockUser.getName()).thenReturn("테스트유저");


### PR DESCRIPTION
## 변경 배경

`approveRequest()`가 `@Transactional` 범위 내에서 외부 HTTP 호출(사용자 생성 API, Pod 생성 API)을 동기 블로킹으로 실행하고 있어 HikariCP 커넥션 풀 고갈 위험이 존재함.

- HikariCP 기본 풀 크기: 10개
- 외부 API 응답 지연(수백ms~수초) 동안 커넥션 유휴 점유
- 동시 요청 10건 → 풀 고갈 → 이후 요청 전부 `Connection is not available` 에러

## 변경 내용

### `AdminRequestCommandService`

- `approveRequest()` 어노테이션을 `@Transactional(propagation = NOT_SUPPORTED)`로 변경
- `TransactionTemplate`을 사용해 트랜잭션 범위를 두 구간으로 분리:
  1. **검증 트랜잭션**: 요청 상태 확인 + HTTP 요청용 데이터 추출 → 즉시 커넥션 반납
  2. **저장 트랜잭션**: 두 API 호출 완료 후에만 커넥션 획득 → DB 저장 후 반납
- `callUserCreationApi()` 메서드 분리로 HTTP 호출 코드 가독성 향상
- 이메일 발송은 저장 트랜잭션 종료 후 실행 (기존과 동일한 실패 격리 보장)
- `PlatformTransactionManager` 생성자 주입 추가

### `AdminRequestCommandServiceTest`

- `PlatformTransactionManager` 및 `TransactionStatus` mock 추가
- 생성자 인수 순서 업데이트

## 연관 이슈

Closes #231