### PR TITLE
[ refactor ] PROCESSING 상태 도입으로 승인 중 중복 요청 차단

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Request.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Request.java
@@ -134,6 +134,14 @@ public class Request extends BaseTimeEntity {
         }
     }
 
+    public void markAsProcessing() {
+        this.status = Status.PROCESSING;
+    }
+
+    public void revertToPending() {
+        this.status = Status.PENDING;
+    }
+
     public void approve(ContainerImage image, ResourceGroup resourceGroup, Long volumeSizeGiB, String adminComment) {
         this.containerImage = image;
         this.resourceGroup = resourceGroup;

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Status.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Status.java
@@ -1,5 +1,5 @@
 package DGU_AI_LAB.admin_be.domain.requests.entity;
 
 public enum Status {
-    PENDING, DENIED, FULFILLED, DELETED
+    PENDING, PROCESSING, DENIED, FULFILLED, DELETED
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
@@ -81,6 +81,7 @@ public class AdminRequestCommandService {
             if (req.getStatus() != Status.PENDING) {
                 throw new BusinessException(ErrorCode.INVALID_REQUEST_STATUS);
             }
+            req.markAsProcessing(); // 다른 관리자의 중복 승인 시도 차단
             usernameRef[0] = req.getUbuntuUsername();
             creationDtoRef[0] = new UserCreationRequestDTO(
                     req.getUbuntuUsername(),
@@ -93,15 +94,23 @@ public class AdminRequestCommandService {
         });
         String username = usernameRef[0];
 
-        // 2. 외부 HTTP 호출 (DB 커넥션 미보유)
-        UserCreationResponse userResponse = callUserCreationApi(creationDtoRef[0]);
+        // 2. 외부 HTTP 호출 (DB 커넥션 미보유, status=PROCESSING으로 중복 승인 차단된 상태)
+        UserCreationResponse userResponse;
+        try {
+            userResponse = callUserCreationApi(creationDtoRef[0]);
+        } catch (Exception e) {
+            log.warn("[보상 트랜잭션] 사용자 생성 실패 → 상태 복구 시작: {}", username);
+            revertRequestToPending(dto.requestId());
+            throw e;
+        }
 
         CreatePodResponseDTO podResponse;
         try {
             podResponse = podService.createPod(username);
         } catch (BusinessException e) {
-            log.warn("[보상 트랜잭션] Pod 생성 실패 → 계정 삭제 시작: {}", username);
+            log.warn("[보상 트랜잭션] Pod 생성 실패 → 계정 삭제 및 상태 복구 시작: {}", username);
             tryCompensateDeleteUser(username);
+            revertRequestToPending(dto.requestId());
             throw e;
         }
 
@@ -202,7 +211,7 @@ public class AdminRequestCommandService {
     public SaveRequestResponseDTO rejectRequest(RejectRequestDTO dto) {
         Request request = requestRepository.findById(dto.requestId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
-        if (!(request.getStatus() == Status.PENDING || request.getStatus() == Status.FULFILLED)) {
+        if (!(request.getStatus() == Status.PENDING || request.getStatus() == Status.PROCESSING || request.getStatus() == Status.FULFILLED)) {
             throw new BusinessException(ErrorCode.INVALID_REQUEST_STATUS);
         }
         request.reject(dto.adminComment());
@@ -288,7 +297,19 @@ public class AdminRequestCommandService {
         changeRequest.approve(admin, dto.adminComment());
     }
 
-    // ── 보상 트랜잭션 헬퍼 ──────────────────────────────────────────────
+    // ── 보상 트랜잭션 헬퍼 ─────────────────────────────────────────────
+
+    private void revertRequestToPending(Long requestId) {
+        try {
+            new TransactionTemplate(transactionManager).execute(status -> {
+                requestRepository.findById(requestId).ifPresent(Request::revertToPending);
+                return null;
+            });
+            log.info("[보상 트랜잭션 완료] 요청 상태 PENDING 복구: requestId={}", requestId);
+        } catch (Exception e) {
+            log.error("[보상 트랜잭션 실패] 요청 상태 복구 실패 — 수동 확인 필요: requestId={}", requestId, e);
+        }
+    }
 
     private void tryCompensateDeleteUser(String username) {
         try {

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/dashboard/service/DashboardServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/dashboard/service/DashboardServiceTest.java
@@ -141,7 +141,7 @@ class DashboardServiceTest {
                     .map(Enum::name)
                     .collect(Collectors.toSet());
 
-            assertThat(names).containsExactlyInAnyOrder("PENDING", "DENIED", "FULFILLED", "DELETED");
+            assertThat(names).containsExactlyInAnyOrder("PENDING", "PROCESSING", "DENIED", "FULFILLED", "DELETED");
             assertThat(names).doesNotContain("ALL");
         }
 

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandServiceTest.java
@@ -241,7 +241,7 @@ class AdminRequestCommandServiceTest {
     class PodCreationFailureCompensation {
 
         @Test
-        @DisplayName("createPod()가 BusinessException을 던지면 Ubuntu 계정 삭제가 호출된다")
+        @DisplayName("createPod()가 BusinessException을 던지면 Ubuntu 계정 삭제 및 상태 복구가 호출된다")
         void approveRequest_podThrowsBusinessException_compensatesWithAccountDeletion() {
             Long requestId = 10L;
             buildMockedRequest(requestId);
@@ -258,6 +258,8 @@ class AdminRequestCommandServiceTest {
                     .isEqualTo(ErrorCode.POD_CREATION_FAILED);
 
             verify(ubuntuAccountService).deleteUbuntuAccount("testuser");
+            // requestRepository.findById 재조회 후 revertToPending 호출 검증
+            verify(requestRepository, atLeast(2)).findById(requestId);
         }
 
         @Test
@@ -381,6 +383,17 @@ class AdminRequestCommandServiceTest {
             service.rejectRequest(dto);
 
             verify(request).reject("계정 정책 위반");
+        }
+
+        @Test
+        @DisplayName("PROCESSING 상태 요청도 거절 가능하다 (승인 진행 중 취소)")
+        void rejectRequest_success_whenStatusIsProcessing() {
+            Request request = buildMockedRequestWithStatus(34L, Status.PROCESSING);
+
+            RejectRequestDTO dto = new RejectRequestDTO(34L, "승인 취소");
+            service.rejectRequest(dto);
+
+            verify(request).reject("승인 취소");
         }
 
         @Test


### PR DESCRIPTION
## 변경 배경

`approveRequest()`는 외부 HTTP 호출(사용자 생성 API + Pod 생성 API)을 트랜잭션 밖에서 실행함(#350). 이 구간에서 다른 관리자가 동일 요청을 승인하면 외부 API가 중복 호출되는 Race Condition이 존재함.

## 변경 내용

### `Status.java`
- `PROCESSING` 상태 추가: 승인 API 호출이 진행 중임을 나타냄

### `Request.java`
- `markAsProcessing()`: PENDING → PROCESSING 전환
- `revertToPending()`: HTTP 호출 실패 시 PROCESSING → PENDING 복구

### `AdminRequestCommandService`

**승인 흐름:**
```
[검증 TX] PENDING 확인 → PROCESSING으로 커밋   ← 이 시점부터 중복 승인 차단
↓
사용자 생성 API (실패 시 → PENDING 복구)
↓
Pod 생성 API    (실패 시 → 계정 삭제 + PENDING 복구)
↓
[저장 TX] PROCESSING → FULFILLED
```

- `rejectRequest()`: PROCESSING 상태도 거절 허용 (승인 중 관리자 취소 지원)
- `revertRequestToPending()` 헬퍼 추가

### 테스트
- `AdminRequestCommandServiceTest`: 보상 트랜잭션 검증 강화
- `DashboardServiceTest`: Status enum 허용값에 PROCESSING 추가
- PROCESSING 상태 거절 테스트 추가

## 연관 이슈

Closes #222