### PR TITLE
fix: Base64 디코딩 실패 시 400 반환 처리 (#353)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SaveRequestRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SaveRequestRequestDTO.java
@@ -80,7 +80,12 @@ public record SaveRequestRequestDTO(
         }
 
         // 클라이언트는 base64 인코딩된 값을 전송 — 평문은 디코딩해서 이메일 발송용으로 따로 보관
-        String plainPassword = new String(Base64.getDecoder().decode(ubuntuPasswordBase64), StandardCharsets.UTF_8);
+        String plainPassword;
+        try {
+            plainPassword = new String(Base64.getDecoder().decode(ubuntuPasswordBase64), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
+        }
 
         Request req = Request.builder()
                 .user(user)


### PR DESCRIPTION
## 문제

`SaveRequestRequestDTO.toEntity()`에서 `Base64.getDecoder().decode()`가 유효하지 않은 입력에 대해 `IllegalArgumentException`을 던졌으며, 이를 처리하는 코드가 없어 500 에러로 전파되었습니다.

## 수정 내용

`IllegalArgumentException`을 catch해 `BusinessException(ErrorCode.INVALID_INPUT_VALUE)`(400)으로 변환합니다.

## 영향 범위

- 백엔드 내부 변경만 해당 (API 응답 상태 코드 400 → 기존에 500이던 것 수정)
- 프론트엔드, 인프라 영향 없음

Closes #353