### PR TITLE
fix: lazy 연관 사전 초기화 및 open-in-view 비활성화 (#354 #355)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
@@ -129,7 +129,11 @@ public class AdminRequestCommandService {
                             .usagePurpose(port.usagePurpose())
                             .build());
                 }
-                req.getUser().getEmail(); // lazy 연관 초기화 (트랜잭션 종료 후 이메일 발송 시 필요)
+                // 트랜잭션 종료 후 사용되는 모든 lazy 연관 초기화
+                req.getUser().getEmail();
+                req.getContainerImage().getImageName();
+                req.getResourceGroup().getServerName();
+                req.getRequestGroups().size();
                 savedRequestRef[0] = req;
                 return null;
             });


### PR DESCRIPTION
## 문제

### #354 — LazyInitializationException 잠재 위험
`AdminRequestCommandService.acceptRequest()` 내 `TransactionTemplate` 스코프에서 `req.getUser().getEmail()`만 초기화하고, `getContainerImage()`, `getResourceGroup()`, `getRequestGroups()`는 초기화하지 않았습니다.

트랜잭션 종료 후 `AlarmService.sendContainerCreatedEmail()`과 `SaveRequestResponseDTO.fromEntity()`에서 이 연관들을 사용하므로, `open-in-view: false` 설정 시 `LazyInitializationException`이 발생합니다.

### #355 — open-in-view: true (기본값)
Spring Boot 기본값인 `open-in-view: true`는 HTTP 응답 직전까지 Hibernate 세션을 유지합니다. 이로 인해 서비스 레이어 밖에서 lazy 로딩이 가능해져 N+1 문제가 잠복하고, 커넥션 보유 시간이 늘어납니다.

## 수정 내용

### #354
TransactionTemplate 스코프 내에서 트랜잭션 종료 후 사용될 모든 lazy 연관을 사전 초기화합니다.
```java
req.getUser().getEmail();
req.getContainerImage().getImageName();  // 추가
req.getResourceGroup().getServerName(); // 추가
req.getRequestGroups().size();          // 추가
```

### #355
`application.yml`은 `.gitignore`에 포함되어 있어 **GitHub Secret `APPLICATION`에서 직접 추가**가 필요합니다.

```yaml
spring:
  jpa:
    open-in-view: false
```

> **액션 필요**: PR 머지 후 GitHub Secret `APPLICATION`에 `spring.jpa.open-in-view: false` 추가 후 재배포

## 영향 범위

- 백엔드 내부 변경 (API 스펙 변화 없음)
- 프론트엔드, 인프라 영향 없음
- `open-in-view: false` 적용 전에 #354가 먼저 배포되어야 안전

Closes #354
Closes #355