### PR TITLE
fix: FULFILLED 상태 요청 조회 N+1 쿼리 제거 (#356)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/repository/RequestRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/repository/RequestRepository.java
@@ -29,6 +29,15 @@ public interface RequestRepository extends JpaRepository<Request, Long> {
     @Query("SELECT r.ubuntuUsername FROM Request r WHERE r.status = :status")
     List<String> findUbuntuUsernamesByStatus(@Param("status") Status status);
 
+    @Query("SELECT DISTINCT r FROM Request r " +
+           "JOIN FETCH r.user " +
+           "LEFT JOIN FETCH r.resourceGroup " +
+           "LEFT JOIN FETCH r.containerImage " +
+           "LEFT JOIN FETCH r.requestGroups rg " +
+           "LEFT JOIN FETCH rg.group " +
+           "WHERE r.status = :status")
+    List<Request> findAllByStatusWithAssociations(@Param("status") Status status);
+
     @Query("SELECT r FROM Request r JOIN FETCH r.user JOIN FETCH r.resourceGroup WHERE r.expiresAt BETWEEN :start AND :end AND r.status = :status")
     List<Request> findAllByExpiresAtBetweenAndStatus(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end, @Param("status") Status status);
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestQueryService.java
@@ -35,13 +35,13 @@ public class AdminRequestQueryService {
     }
 
     public List<ResourceUsageDTO> getAllFulfilledResourceUsage() {
-        return requestRepository.findAllByStatus(Status.FULFILLED).stream()
+        return requestRepository.findAllByStatusWithAssociations(Status.FULFILLED).stream()
                 .map(ResourceUsageDTO::fromEntity)
                 .toList();
     }
 
     public List<ContainerInfoDTO> getAllActiveContainers() {
-        return requestRepository.findAllByStatus(Status.FULFILLED).stream()
+        return requestRepository.findAllByStatusWithAssociations(Status.FULFILLED).stream()
                 .map(ContainerInfoDTO::fromEntity)
                 .toList();
     }


### PR DESCRIPTION
## 문제

`AdminRequestQueryService`의 `getAllFulfilledResourceUsage()`와 `getAllActiveContainers()`에서 `findAllByStatus(Status.FULFILLED)`로 N건의 Request를 로딩한 뒤, DTO 변환 시마다 lazy 연관(`user`, `resourceGroup`, `containerImage`, `requestGroups`, `group`)을 개별 조회해 **1 + 4N 쿼리**가 발생했습니다.

활성 컨테이너가 10건이면 최대 41번의 DB 쿼리, 100건이면 401번이 됩니다.

## 수정 내용

`RequestRepository`에 `findAllByStatusWithAssociations` 메서드를 추가했습니다.

```java
@Query("SELECT DISTINCT r FROM Request r " +
       "JOIN FETCH r.user " +
       "LEFT JOIN FETCH r.resourceGroup " +
       "LEFT JOIN FETCH r.containerImage " +
       "LEFT JOIN FETCH r.requestGroups rg " +
       "LEFT JOIN FETCH rg.group " +
       "WHERE r.status = :status")
List<Request> findAllByStatusWithAssociations(@Param("status") Status status);
```

두 서비스 메서드가 이 쿼리를 사용하도록 변경했습니다. 이제 **단일 JOIN 쿼리** 1회로 모든 데이터를 로딩합니다.

## 영향 범위

- 백엔드 내부 변경만 해당 (API 스펙, 프론트엔드, 인프라 영향 없음)
- 기존 `findAllByStatus`는 다른 용도로 사용 중이므로 제거하지 않음

Closes #356