### PR TITLE
fix: AcceptInfoResponseDTO passwd_base64 develop 브랜치 반영 (backport)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/AcceptInfoResponseDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/AcceptInfoResponseDTO.java
@@ -23,7 +23,9 @@ public record AcceptInfoResponseDTO(
         @Schema(description = "GPU 노드 목록")
         List<GpuNodeDTO> gpu_nodes,
         @Schema(description = "추가 포트 목록")
-        List<AdditionalPortDTO> additional_ports
+        List<AdditionalPortDTO> additional_ports,
+        @Schema(description = "Base64 인코딩된 초기 비밀번호")
+        String passwd_base64
 ) {
     @Schema(description = "그룹 정보")
     @Builder
@@ -89,6 +91,7 @@ public record AcceptInfoResponseDTO(
                 .volume_size(request.getVolumeSizeGiB())
                 .gpu_nodes(gpuNodeDTOList)
                 .additional_ports(additionalPortDTOList)
+                .passwd_base64(request.getUbuntuPasswordBase64())
                 .build();
     }
 }


### PR DESCRIPTION
## 배경

`passwd_base64` 필드 추가(eb57dff)가 `main`에 직접 커밋되어 `develop` 브랜치에 반영되지 않았습니다.

`develop`에서 새 브랜치를 생성하면 `AcceptInfoResponseDTO`에 `passwd_base64`가 없는 상태가 되어, config-server가 `USER_PW` env var를 주입하지 못하고 컨테이너 SSH 비밀번호가 기본값(`ailab2260`)으로 고정되는 문제가 재발할 수 있습니다.

## 수정 내용

`eb57dff` 커밋을 `develop`으로 cherry-pick합니다.

## 영향 범위

- `AcceptInfoResponseDTO`에 `passwd_base64` 필드 추가 (API 스펙 변경)
- config-server 측은 이미 해당 필드를 처리하도록 구현되어 있음