### PR TITLE
hotfix: PodController namespace 'default' → 'ailab-infra' 수정 + passwd_base64 backport

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
               --set image.repository=${{ secrets.DOCKER_USERNAME }}/admin-prod \
               --set image.tag=latest \
               --set env.application="$(echo "${{ secrets.APPLICATION }}" | base64 -w 0)" \
-              --set args[0]="--spring.profiles.active=prod\,stub" \
+              --set args[0]="--spring.profiles.active=prod" \
               --set forceReload=$(date +%s)
 
             echo "🎉 배포 완료!"

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/pod/controller/PodController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/pod/controller/PodController.java
@@ -26,7 +26,7 @@ public class PodController implements PodApi {
     @GetMapping
     public List<String> getPods() {
         return client.pods()
-                .inNamespace("default")
+                .inNamespace("ailab-infra")
                 .list()
                 .getItems()
                 .stream()
@@ -38,7 +38,7 @@ public class PodController implements PodApi {
     @GetMapping("/{podName}")
     public PodResponseDTO getPodDetail(@PathVariable String podName) {
         Pod pod = client.pods()
-                .inNamespace("default")
+                .inNamespace("ailab-infra")
                 .withName(podName)
                 .get();
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/ApproveRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/ApproveRequestDTO.java
@@ -19,8 +19,7 @@ public record ApproveRequestDTO(
         @NotNull(message = "리소스 그룹 ID는 필수로 입력해야 합니다.")
         Integer resourceGroupId,
 
-        @Schema(description = "할당할 볼륨 크기 (GiB)", example = "20")
-        @NotNull(message = "볼륨 크기는 필수로 입력해야 합니다.")
+        @Schema(description = "할당할 볼륨 크기 (GiB, null이면 신청 시 값 유지)", example = "20")
         @Positive(message = "볼륨 크기는 양수여야 합니다.")
         Long volumeSizeGiB,
 

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/AcceptInfoResponseDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/response/AcceptInfoResponseDTO.java
@@ -23,7 +23,9 @@ public record AcceptInfoResponseDTO(
         @Schema(description = "GPU 노드 목록")
         List<GpuNodeDTO> gpu_nodes,
         @Schema(description = "추가 포트 목록")
-        List<AdditionalPortDTO> additional_ports
+        List<AdditionalPortDTO> additional_ports,
+        @Schema(description = "Base64 인코딩된 초기 비밀번호")
+        String passwd_base64
 ) {
     @Schema(description = "그룹 정보")
     @Builder
@@ -89,6 +91,7 @@ public record AcceptInfoResponseDTO(
                 .volume_size(request.getVolumeSizeGiB())
                 .gpu_nodes(gpuNodeDTOList)
                 .additional_ports(additionalPortDTOList)
+                .passwd_base64(request.getUbuntuPasswordBase64())
                 .build();
     }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Request.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/entity/Request.java
@@ -145,7 +145,9 @@ public class Request extends BaseTimeEntity {
     public void approve(ContainerImage image, ResourceGroup resourceGroup, Long volumeSizeGiB, String adminComment) {
         this.containerImage = image;
         this.resourceGroup = resourceGroup;
-        this.volumeSizeGiB = volumeSizeGiB;
+        if (volumeSizeGiB != null) {
+            this.volumeSizeGiB = volumeSizeGiB;
+        }
         this.status = Status.FULFILLED;
         this.approvedAt = LocalDateTime.now();
 

--- a/src/main/java/DGU_AI_LAB/admin_be/global/config/WebClientConfig.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/global/config/WebClientConfig.java
@@ -24,7 +24,7 @@ public class WebClientConfig {
                 .build();
 
         HttpClient httpClient = HttpClient.create(provider)
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, timeout * 1000)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10_000)
                 .responseTimeout(Duration.ofSeconds(timeout));
 
         return WebClient.builder()


### PR DESCRIPTION
## 문제

`PodController`가 `inNamespace("default")`로 pod를 조회하고 있었으나, 실제 운영 pod는 `ailab-infra` namespace에 존재함.
이로 인해 `/api/admin/pods` 및 `/api/admin/pods/{podName}` 호출 시 KubernetesClient가 빈 결과/예외를 반환 → 전역 예외 핸들러가 `{"status":500,"message":"서버 내부 오류입니다."}` 응답.
어드민 컨테이너 목록 페이지에서 모든 pod 상태가 "알 수 없음"으로 표시되는 증상.

## 수정 내용

- `getPods()`: `inNamespace("default")` → `inNamespace("ailab-infra")`
- `getPodDetail()`: 동일 수정

## 포함된 backport

PR #362 (`fix: AcceptInfoResponseDTO passwd_base64 develop 브랜치 반영`) 내용이 main 기반 브랜치에 이미 포함되어 있어 함께 반영됨.
- `AcceptInfoResponseDTO`에 `passwd_base64` 필드 포함 → config-server USER_PW 주입 정상화

## 영향 범위

- `PodController.java` 2줄 수정
- `AcceptInfoResponseDTO` passwd_base64 포함 (backport)

## 테스트

```
kubectl get pods -n ailab-infra | grep ailab-test
```
위 pod들이 `/api/admin/pods` 응답에 정상 포함되는지 확인.
