### PR TITLE
hotfix: EXPIRES_AT 변경요청 생성 불가 수정 — newValue JSON 인코딩 (#367)

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SingleChangeRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SingleChangeRequestDTO.java
@@ -46,11 +46,17 @@ public record SingleChangeRequestDTO(
         try {
             String oldValue = extractOldValue(originalRequest, dto.changeType(), objectMapper, portRequestService);
 
+            // new_value는 MySQL json 컬럼이고 승인 로직은 readValue(String.class)로 읽는다.
+            // EXPIRES_AT의 생 날짜 문자열은 유효한 JSON이 아니므로 저장 직전에 JSON 인코딩한다. (#367)
+            String storedNewValue = dto.changeType() == ChangeType.EXPIRES_AT
+                    ? objectMapper.writeValueAsString(dto.newValue().trim())
+                    : dto.newValue();
+
             return ChangeRequest.builder()
                     .request(originalRequest)
                     .changeType(dto.changeType())
                     .oldValue(oldValue)
-                    .newValue(dto.newValue())
+                    .newValue(storedNewValue)
                     .reason(dto.reason())
                     .requestedBy(requestedBy)
                     .build();

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SingleChangeRequestDTOTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SingleChangeRequestDTOTest.java
@@ -1,10 +1,17 @@
 package DGU_AI_LAB.admin_be.domain.requests.dto.request;
 
+import DGU_AI_LAB.admin_be.domain.requests.entity.ChangeRequest;
 import DGU_AI_LAB.admin_be.domain.requests.entity.ChangeType;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SingleChangeRequestDTOTest {
@@ -47,5 +54,41 @@ class SingleChangeRequestDTOTest {
         assertThatThrownBy(() ->
                 SingleChangeRequestDTO.createValidatedChangeRequest(dto, null, null, null, null))
                 .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("EXPIRES_AT의 생 날짜 문자열은 JSON 인코딩되어 저장되고 승인 파서와 round-trip 된다 (#367)")
+    void createValidatedChangeRequest_expiresAt_storesJsonEncodedValue() throws Exception {
+        // 운영에서는 Spring 주입 ObjectMapper에 JavaTimeModule이 등록돼 있다
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        Request originalRequest = Request.builder()
+                .expiresAt(LocalDateTime.of(2026, 7, 14, 23, 59, 59))
+                .build();
+        SingleChangeRequestDTO dto = new SingleChangeRequestDTO(ChangeType.EXPIRES_AT, "2026-07-28T23:59:59", "reason");
+
+        ChangeRequest changeRequest = SingleChangeRequestDTO.createValidatedChangeRequest(
+                dto, originalRequest, null, objectMapper, null);
+
+        // MySQL json 컬럼 제약 — 저장 값은 따옴표 포함 유효 JSON이어야 한다
+        assertThat(changeRequest.getNewValue()).isEqualTo("\"2026-07-28T23:59:59\"");
+        // 승인 로직(AdminRequestCommandService.EXPIRES_AT)과 동일한 파싱으로 round-trip
+        LocalDateTime parsed = LocalDateTime.parse(objectMapper.readValue(changeRequest.getNewValue(), String.class));
+        assertThat(parsed).isEqualTo(LocalDateTime.of(2026, 7, 28, 23, 59, 59));
+    }
+
+    @Test
+    @DisplayName("EXPIRES_AT 이외 타입의 newValue는 그대로 저장된다")
+    void createValidatedChangeRequest_volumeSize_keepsRawNewValue() {
+        // 운영에서는 Spring 주입 ObjectMapper에 JavaTimeModule이 등록돼 있다
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        Request originalRequest = Request.builder()
+                .volumeSizeGiB(20L)
+                .build();
+        SingleChangeRequestDTO dto = new SingleChangeRequestDTO(ChangeType.VOLUME_SIZE, "100", "reason");
+
+        ChangeRequest changeRequest = SingleChangeRequestDTO.createValidatedChangeRequest(
+                dto, originalRequest, null, objectMapper, null);
+
+        assertThat(changeRequest.getNewValue()).isEqualTo("100");
     }
 }


### PR DESCRIPTION
Closes #367

## 문제

사용 기간 연장(EXPIRES_AT) 변경요청 제출 시 항상 409 "이미 존재하는 리소스입니다". 원인은 중복이 아니라 `change_request.new_value`(MySQL json 컬럼)에 생 날짜 문자열이 들어가 insert가 Invalid JSON text(22032)로 실패하고, `DataIntegrityViolationException` 핸들러가 이를 CONFLICT로 변환한 것. 상세 분석은 #367 참조.

## 수정

`SingleChangeRequestDTO.toEntity`에서 EXPIRES_AT에 한해 저장 직전 `objectMapper.writeValueAsString`으로 JSON 인코딩. 1곳 수정, FE 무변경.

- 생성 검증(`validateValueFormat`의 raw `LocalDateTime.parse`) 무변경.
- 승인 로직(`AdminRequestCommandService`의 `readValue(String.class)` → parse)과 정합 — 이 파서가 요구하는 저장 형식이 원래 JSON-quoted였음.
- `oldValue`는 기존부터 `writeValueAsString` 저장이라 대칭 유지.
- 타 changeType(VOLUME_SIZE/GROUP/PORT 등)은 이미 유효 JSON이라 pass-through 유지.

## 테스트

- 신규: EXPIRES_AT 저장 값이 따옴표 포함 유효 JSON인지 + 승인 파서와 round-trip, VOLUME_SIZE raw 유지.
- `SingleChangeRequestDTOTest`(6/6) · `AdminRequestCommandServiceTest` · `AdminRequestChangeControllerTest` · `RequestCommandServiceTest` 전부 PASS (temurin 17).

## 후속 (별도 PR 후보)

- FE `ChangeRequestManagementPage`의 `APPROVAL_BLOCK_REASON`에서 EXPIRES_AT 승인 차단 해제 (admin_fe).
- 사용자 재현 확인: 연장 모달 제출 → 변경요청 목록 PENDING 생성 → 관리자 승인 → 만료일 갱신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)