### PR TITLE
feat: 비활성화 사용자 재활성화 API 추가

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/controller/AdminUserController.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/controller/AdminUserController.java
@@ -37,4 +37,9 @@ public class AdminUserController implements AdminUserApi {
         adminUserService.deleteUbuntuAccount(username);
         return SuccessResponse.ok(null);
     }
+
+    @PatchMapping("/{id}/reactivate")
+    public ResponseEntity<SuccessResponse<?>> reactivateUser(@PathVariable Long id) {
+        return SuccessResponse.ok(adminUserService.reactivateUser(id));
+    }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/controller/docs/AdminUserApi.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/controller/docs/AdminUserApi.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "3. 관리자 유저 관리", description = "사용자 계정 조회 및 삭제 API")
@@ -43,5 +44,17 @@ public interface AdminUserApi {
     @DeleteMapping("/ubuntu/{username}")
     ResponseEntity<SuccessResponse<?>> deleteUbuntuAccount(
             @PathVariable @Parameter(description = "우분투 계정명") String username
+    );
+
+    @Operation(
+            summary = "비활성화 사용자 재활성화",
+            description = "비활성화(isActive=false) 처리된 사용자 계정을 재활성화합니다. deletedAt을 초기화하고 isActive를 true로 전환합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "성공")
+    @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    @ApiResponse(responseCode = "409", description = "이미 활성화된 사용자")
+    @PatchMapping("/{id}/reactivate")
+    ResponseEntity<SuccessResponse<?>> reactivateUser(
+            @PathVariable @Parameter(description = "사용자 ID") Long id
     );
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/entity/User.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/entity/User.java
@@ -89,4 +89,9 @@ public class User extends BaseTimeEntity {
         this.isActive = false;
         this.deletedAt = LocalDateTime.now();
     }
+
+    public void reactivate() {
+        this.isActive = true;
+        this.deletedAt = null;
+    }
 }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserService.java
@@ -10,6 +10,7 @@ import DGU_AI_LAB.admin_be.domain.users.dto.response.UserSummaryDTO;
 import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
 import DGU_AI_LAB.admin_be.error.ErrorCode;
+import DGU_AI_LAB.admin_be.error.exception.ConflictException;
 import DGU_AI_LAB.admin_be.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -91,6 +92,25 @@ public class AdminUserService {
         request.deleteAfterCleanup();
         requestRepository.save(request);
         log.info("[deleteUbuntuAccount] {} 계정 삭제 및 DB 상태 업데이트 완료", username);
+    }
+
+    /**
+     * 비활성화된 유저 재활성화
+     */
+    @Transactional
+    public UserSummaryDTO reactivateUser(Long userId) {
+        log.info("[reactivateUser] userId={} 재활성화 시도", userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getIsActive()) {
+            log.warn("[reactivateUser] userId={} 이미 활성화 상태", userId);
+            throw new ConflictException(ErrorCode.USER_ALREADY_ACTIVE);
+        }
+
+        user.reactivate();
+        log.info("[reactivateUser] userId={} 재활성화 완료", userId);
+        return UserSummaryDTO.fromEntity(user);
     }
 
     /**

--- a/src/main/java/DGU_AI_LAB/admin_be/error/ErrorCode.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/error/ErrorCode.java
@@ -81,6 +81,7 @@ public enum ErrorCode {
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "사용자 인증에 실패하였습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 가입된 사용자입니다."),
+    USER_ALREADY_ACTIVE(HttpStatus.CONFLICT, "이미 활성화된 사용자입니다."),
     DUPLICATE_NAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),
     INVALID_LOGIN_INFO(HttpStatus.BAD_REQUEST, "잘못된 로그인 입력값입니다."),
     INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "올바르지 않은 인증 코드입니다."),

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/controller/AdminUserControllerTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/controller/AdminUserControllerTest.java
@@ -5,6 +5,7 @@ import DGU_AI_LAB.admin_be.domain.users.dto.response.UserSummaryDTO;
 import DGU_AI_LAB.admin_be.domain.users.service.AdminUserService;
 import DGU_AI_LAB.admin_be.domain.users.service.UserService;
 import DGU_AI_LAB.admin_be.error.ErrorCode;
+import DGU_AI_LAB.admin_be.error.exception.ConflictException;
 import DGU_AI_LAB.admin_be.error.exception.EntityNotFoundException;
 import DGU_AI_LAB.admin_be.support.WebMvcTestSupport;
 import org.junit.jupiter.api.DisplayName;
@@ -108,6 +109,49 @@ class AdminUserControllerTest extends WebMvcTestSupport {
 
             mockMvc.perform(delete("/api/admin/users/99").contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/admin/users/{id}/reactivate")
+    class ReactivateUser {
+
+        private final UserSummaryDTO reactivatedUser = UserSummaryDTO.builder()
+                .userId(1L).name("홍길동").email("test@dgu.ac.kr")
+                .role("USER").studentId("2021001234").phone("010-1111-2222")
+                .department("컴퓨터공학과").isActive(true)
+                .createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now())
+                .build();
+
+        @Test
+        @DisplayName("비활성화 유저를 재활성화하면 200 OK와 사용자 정보를 반환한다")
+        void reactivateUser_returns200() throws Exception {
+            when(adminUserService.reactivateUser(1L)).thenReturn(reactivatedUser);
+
+            mockMvc.perform(patch("/api/admin/users/1/reactivate").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.isActive").value(true))
+                    .andExpect(jsonPath("$.data.name").value("홍길동"));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저면 404 Not Found를 반환한다")
+        void reactivateUser_returns404_whenNotFound() throws Exception {
+            when(adminUserService.reactivateUser(99L))
+                    .thenThrow(new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+            mockMvc.perform(patch("/api/admin/users/99/reactivate").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("이미 활성화된 유저면 409 Conflict를 반환한다")
+        void reactivateUser_returns409_whenAlreadyActive() throws Exception {
+            when(adminUserService.reactivateUser(1L))
+                    .thenThrow(new ConflictException(ErrorCode.USER_ALREADY_ACTIVE));
+
+            mockMvc.perform(patch("/api/admin/users/1/reactivate").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isConflict());
         }
     }
 }

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserServiceTest.java
@@ -11,6 +11,8 @@ import DGU_AI_LAB.admin_be.domain.users.dto.response.UserResponseDTO;
 import DGU_AI_LAB.admin_be.domain.users.dto.response.UserSummaryDTO;
 import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import DGU_AI_LAB.admin_be.domain.users.repository.UserRepository;
+import DGU_AI_LAB.admin_be.error.ErrorCode;
+import DGU_AI_LAB.admin_be.error.exception.ConflictException;
 import DGU_AI_LAB.admin_be.error.exception.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -215,6 +217,43 @@ class AdminUserServiceTest {
             verify(pending).delete();
             verify(deleted, never()).delete();
             verify(deleted, never()).deleteAfterCleanup();
+        }
+    }
+
+    @Nested
+    @DisplayName("reactivateUser")
+    class ReactivateUser {
+
+        @Test
+        @DisplayName("비활성화된 유저를 재활성화하면 isActive가 true, deletedAt이 null이 된다")
+        void reactivateUser_success() {
+            mockUser.withdraw();
+            when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+
+            UserSummaryDTO result = adminUserService.reactivateUser(1L);
+
+            assertThat(mockUser.getIsActive()).isTrue();
+            assertThat(mockUser.getDeletedAt()).isNull();
+            assertThat(result.isActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저면 EntityNotFoundException을 던진다")
+        void reactivateUser_throwsWhenUserNotFound() {
+            when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> adminUserService.reactivateUser(99L))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("이미 활성화된 유저면 ConflictException을 던진다")
+        void reactivateUser_throwsWhenAlreadyActive() {
+            when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+
+            assertThatThrownBy(() -> adminUserService.reactivateUser(1L))
+                    .isInstanceOf(ConflictException.class)
+                    .hasMessageContaining(ErrorCode.USER_ALREADY_ACTIVE.getMessage());
         }
     }
 


### PR DESCRIPTION
## Summary

- `PATCH /api/admin/users/{id}/reactivate` 엔드포인트 추가
- 비활성화(`isActive=false`) 처리된 사용자를 관리자가 재활성화할 수 있는 API
- `User.reactivate()` 메서드로 `isActive=true`, `deletedAt=null` 처리
- 이미 활성화된 사용자 요청 시 `409 Conflict` 반환 (`USER_ALREADY_ACTIVE`)

## Test plan

- [ ] `AdminUserServiceTest` — `reactivateUser` 3건 통과 확인
  - 비활성화 유저 재활성화 시 `isActive=true`, `deletedAt=null`
  - 존재하지 않는 유저 → `EntityNotFoundException`
  - 이미 활성화된 유저 → `ConflictException`
- [ ] `AdminUserControllerTest` — `PATCH /api/admin/users/{id}/reactivate` 3건 통과 확인
  - 정상 재활성화 → 200 OK
  - 없는 유저 → 404 Not Found
  - 이미 활성 유저 → 409 Conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)