### PR TITLE
fix: EXPIRES_AT 변경요청 newValue JSON 인코딩 백포트

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SingleChangeRequestDTO.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SingleChangeRequestDTO.java
@@ -46,11 +46,17 @@ public record SingleChangeRequestDTO(
         try {
             String oldValue = extractOldValue(originalRequest, dto.changeType(), objectMapper, portRequestService);
 
+            // new_value는 MySQL json 컬럼이고 승인 로직은 readValue(String.class)로 읽는다.
+            // EXPIRES_AT의 생 날짜 문자열은 유효한 JSON이 아니므로 저장 직전에 JSON 인코딩한다. (#367)
+            String storedNewValue = dto.changeType() == ChangeType.EXPIRES_AT
+                    ? objectMapper.writeValueAsString(dto.newValue().trim())
+                    : dto.newValue();
+
             return ChangeRequest.builder()
                     .request(originalRequest)
                     .changeType(dto.changeType())
                     .oldValue(oldValue)
-                    .newValue(dto.newValue())
+                    .newValue(storedNewValue)
                     .reason(dto.reason())
                     .requestedBy(requestedBy)
                     .build();

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SingleChangeRequestDTOTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/dto/request/SingleChangeRequestDTOTest.java
@@ -1,10 +1,17 @@
 package DGU_AI_LAB.admin_be.domain.requests.dto.request;
 
+import DGU_AI_LAB.admin_be.domain.requests.entity.ChangeRequest;
 import DGU_AI_LAB.admin_be.domain.requests.entity.ChangeType;
+import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.error.exception.BusinessException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SingleChangeRequestDTOTest {
@@ -47,5 +54,41 @@ class SingleChangeRequestDTOTest {
         assertThatThrownBy(() ->
                 SingleChangeRequestDTO.createValidatedChangeRequest(dto, null, null, null, null))
                 .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("EXPIRES_AT의 생 날짜 문자열은 JSON 인코딩되어 저장되고 승인 파서와 round-trip 된다 (#367)")
+    void createValidatedChangeRequest_expiresAt_storesJsonEncodedValue() throws Exception {
+        // 운영에서는 Spring 주입 ObjectMapper에 JavaTimeModule이 등록돼 있다
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        Request originalRequest = Request.builder()
+                .expiresAt(LocalDateTime.of(2026, 7, 14, 23, 59, 59))
+                .build();
+        SingleChangeRequestDTO dto = new SingleChangeRequestDTO(ChangeType.EXPIRES_AT, "2026-07-28T23:59:59", "reason");
+
+        ChangeRequest changeRequest = SingleChangeRequestDTO.createValidatedChangeRequest(
+                dto, originalRequest, null, objectMapper, null);
+
+        // MySQL json 컬럼 제약 — 저장 값은 따옴표 포함 유효 JSON이어야 한다
+        assertThat(changeRequest.getNewValue()).isEqualTo("\"2026-07-28T23:59:59\"");
+        // 승인 로직(AdminRequestCommandService.EXPIRES_AT)과 동일한 파싱으로 round-trip
+        LocalDateTime parsed = LocalDateTime.parse(objectMapper.readValue(changeRequest.getNewValue(), String.class));
+        assertThat(parsed).isEqualTo(LocalDateTime.of(2026, 7, 28, 23, 59, 59));
+    }
+
+    @Test
+    @DisplayName("EXPIRES_AT 이외 타입의 newValue는 그대로 저장된다")
+    void createValidatedChangeRequest_volumeSize_keepsRawNewValue() {
+        // 운영에서는 Spring 주입 ObjectMapper에 JavaTimeModule이 등록돼 있다
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        Request originalRequest = Request.builder()
+                .volumeSizeGiB(20L)
+                .build();
+        SingleChangeRequestDTO dto = new SingleChangeRequestDTO(ChangeType.VOLUME_SIZE, "100", "reason");
+
+        ChangeRequest changeRequest = SingleChangeRequestDTO.createValidatedChangeRequest(
+                dto, originalRequest, null, objectMapper, null);
+
+        assertThat(changeRequest.getNewValue()).isEqualTo("100");
     }
 }


### PR DESCRIPTION
## Summary

- main 브랜치의 `fix/expires-at-change-request-json` (#367) 를 develop에 백포트
- cherry-pick 대상: `fadc4a3`

## 변경 내용

`change_request.new_value`는 MySQL JSON 컬럼인데, EXPIRES_AT 변경요청 생성 시 날짜 문자열을 raw로 저장해 SQLState 22032 (Invalid JSON text) 오류 발생 → `DataIntegrityViolationException` → 409 응답으로 표면화되던 버그 수정.

`SingleChangeRequestDTO.toEntity()`에서 `EXPIRES_AT`에 한해 `writeValueAsString()`으로 JSON 인코딩 후 저장.

## Test plan

- [ ] `SingleChangeRequestDTOTest` — EXPIRES_AT JSON 인코딩 round-trip 검증 통과 확인
- [ ] EXPIRES_AT 이외 타입은 raw 값 그대로 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)