### PR TITLE
feat: 관리자 신청/변경 요청 거절 시 사용자 이메일 발송 추가

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/service/AlarmService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/alarm/service/AlarmService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import DGU_AI_LAB.admin_be.domain.pod.entity.PodExternalPort;
 import DGU_AI_LAB.admin_be.domain.pod.repository.PodExternalPortRepository;
+import DGU_AI_LAB.admin_be.domain.requests.entity.ChangeRequest;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import DGU_AI_LAB.admin_be.global.util.MessageUtils;
@@ -218,6 +219,34 @@ public class AlarmService {
         return ports.stream()
                 .map(p -> p.getUsagePurpose() + "(" + p.getExternalPort() + ")")
                 .collect(Collectors.joining(", "));
+    }
+
+    public void sendRequestRejectedEmail(Request request, String adminComment) {
+        User user = request.getUser();
+        String serverName = request.getResourceGroup().getServerName();
+
+        String subject = messageUtils.get("email.request.rejected.subject", serverName);
+        String body = messageUtils.get("email.request.rejected.body",
+                user.getName(),    // {0}
+                serverName,        // {1}
+                adminComment);     // {2}
+
+        sendMailAlert(user.getEmail(), subject, body);
+        sendMonitoringLog(user.getName(), user.getEmail(), subject);
+    }
+
+    public void sendModificationRejectedEmail(ChangeRequest changeRequest, String adminComment) {
+        User user = changeRequest.getRequestedBy();
+        String changeType = changeRequest.getChangeType().name();
+
+        String subject = messageUtils.get("email.modification.rejected.subject", changeType);
+        String body = messageUtils.get("email.modification.rejected.body",
+                user.getName(),    // {0}
+                changeType,        // {1}
+                adminComment);     // {2}
+
+        sendMailAlert(user.getEmail(), subject, body);
+        sendMonitoringLog(user.getName(), user.getEmail(), subject);
     }
 
     public void sendAdminSlackNotification(String serverName, String message) {

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandService.java
@@ -219,6 +219,7 @@ public class AdminRequestCommandService {
             throw new BusinessException(ErrorCode.INVALID_REQUEST_STATUS);
         }
         request.reject(dto.adminComment());
+        alarmService.sendRequestRejectedEmail(request, dto.adminComment());
         return SaveRequestResponseDTO.fromEntity(request);
     }
 
@@ -236,6 +237,7 @@ public class AdminRequestCommandService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         changeRequest.deny(admin, dto.adminComment());
+        alarmService.sendModificationRejectedEmail(changeRequest, dto.adminComment());
     }
 
     @Transactional

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -124,6 +124,31 @@ email.container.created.body=\uC548\uB155\uD558\uC138\uC694 {0}\uB2D8, \uB3D9\uA
   \n\uB9C8\uC9C0\uB9C9\uC73C\uB85C, \uC0AC\uC6A9\uC790\uBD84\uC758 \uB370\uC774\uD130\uB294 \uC2DC\uC2A4\uD15C\uC5D0\uC11C \uBC31\uC5C5\uB418\uC9C0 \uC54A\uC2B5\uB2C8\uB2E4. \uAC1C\uC778\uC801\uC778 \uB370\uC774\uD130\uB294 \uBAA8\uB450 \uBC31\uC5C5\uD558\uC2DC\uAE30 \uBC14\uB78D\uB2C8\uB2E4. \uAC10\uC0AC\uD569\uB2C8\uB2E4!
 
 # ==============================================================================
+# 9. \uC2E0\uCCAD \uAC70\uC808 \uC548\uB0B4 \uBA54\uC77C \u2014 email.request.rejected
+# ==============================================================================
+# subject: {0}: \uC11C\uBC84\uBA85
+email.request.rejected.subject=[DGU AILab] \uC11C\uBC84 \uC2E0\uCCAD \uAC70\uC808 \uC548\uB0B4 ({0})
+
+# {0}: \uC774\uB984, {1}: \uC11C\uBC84\uBA85, {2}: \uAC70\uC808 \uC0AC\uC720
+email.request.rejected.body=\uC548\uB155\uD558\uC138\uC694 {0}\uB2D8, \uB3D9\uAD6D\uB300\uD559\uAD50 \uC11C\uBC84\uAD00\uB9AC\uD300\uC785\uB2C8\uB2E4.\n\
+  \n\uC2E0\uCCAD\uD558\uC2E0 GPU \uC11C\uBC84 \uC0AC\uC6A9 \uC694\uCCAD\uC774 \uAC70\uC808\uB418\uC5C8\uC2B5\uB2C8\uB2E4.\n\
+  \n- \uC11C\uBC84: {1}\n\
+  - \uAC70\uC808 \uC0AC\uC720: {2}\n\
+  \n\uBB38\uC758\uAC00 \uC788\uC73C\uC2DC\uBA74 \uAD00\uB9AC\uC790\uC5D0\uAC8C \uBB38\uC758\uD574 \uC8FC\uC138\uC694.
+
+# ==============================================================================
+# 10. \uBCC0\uACBD \uC694\uCCAD \uAC70\uC808 \uC548\uB0B4 \uBA54\uC77C \u2014 email.modification.rejected
+# ==============================================================================
+# subject: {0}: \uBCC0\uACBD \uC720\uD615
+email.modification.rejected.subject=[DGU AILab] \uC11C\uBC84 \uBCC0\uACBD \uC694\uCCAD \uAC70\uC808 \uC548\uB0B4 ({0})
+
+# {0}: \uC774\uB984, {1}: \uBCC0\uACBD \uC720\uD615, {2}: \uAC70\uC808 \uC0AC\uC720
+email.modification.rejected.body=\uC548\uB155\uD558\uC138\uC694 {0}\uB2D8, \uB3D9\uAD6D\uB300\uD559\uAD50 \uC11C\uBC84\uAD00\uB9AC\uD300\uC785\uB2C8\uB2E4.\n\
+  \n\uC694\uCCAD\uD558\uC2E0 \uC11C\uBC84 \uBCC0\uACBD ({1}) \uC694\uCCAD\uC774 \uAC70\uC808\uB418\uC5C8\uC2B5\uB2C8\uB2E4.\n\
+  \n- \uAC70\uC808 \uC0AC\uC720: {2}\n\
+  \n\uBB38\uC758\uAC00 \uC788\uC73C\uC2DC\uBA74 \uAD00\uB9AC\uC790\uC5D0\uAC8C \uBB38\uC758\uD574 \uC8FC\uC138\uC694.
+
+# ==============================================================================
 # 7. \uAD00\uB9AC\uC790 \uC218\uB3D9 \uC0AD\uC81C \uC548\uB0B4 \uBA54\uC77C \u2014 email.container.deleted
 # ==============================================================================
 # subject {0}: \uC11C\uBC84\uBA85(FARM/LAB)

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/alarm/service/AlarmServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/alarm/service/AlarmServiceTest.java
@@ -1,10 +1,13 @@
 package DGU_AI_LAB.admin_be.domain.alarm.service;
 
 import DGU_AI_LAB.admin_be.domain.alarm.dto.SlackMessageDto;
+import DGU_AI_LAB.admin_be.domain.requests.entity.ChangeRequest;
+import DGU_AI_LAB.admin_be.domain.requests.entity.ChangeType;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.resourceGroups.entity.ResourceGroup;
 import DGU_AI_LAB.admin_be.domain.users.entity.User;
 import DGU_AI_LAB.admin_be.global.util.MessageUtils;
+import org.springframework.mail.SimpleMailMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -246,6 +249,122 @@ class AlarmServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("sendRequestRejectedEmail")
+    class SendRequestRejectedEmail {
+
+        @Test
+        @DisplayName("사용자에게 거절 이메일이 발송된다")
+        void sendRequestRejectedEmail_sendsMailToUser() {
+            Request request = mockRequest("홍길동", "hong@dgu.ac.kr", "FARM");
+            when(messageUtils.get(anyString(), any())).thenReturn("[DGU AILab] 서버 신청 거절 안내 (FARM)");
+            when(messageUtils.get(anyString(), any(), any(), any())).thenReturn("거절 안내 본문");
+
+            alarmService.sendRequestRejectedEmail(request, "신청서 양식 미흡");
+
+            ArgumentCaptor<SimpleMailMessage> captor = ArgumentCaptor.forClass(SimpleMailMessage.class);
+            verify(mailSender).send(captor.capture());
+            assertThat(captor.getValue().getTo()).containsExactly("hong@dgu.ac.kr");
+            assertThat(captor.getValue().getSubject()).isEqualTo("[DGU AILab] 서버 신청 거절 안내 (FARM)");
+        }
+
+        @Test
+        @DisplayName("거절 이메일 발송 후 noti 채널에 모니터링 로그가 적재된다")
+        void sendRequestRejectedEmail_pushesMonitoringLogToNotiChannel() {
+            Request request = mockRequest("홍길동", "hong@dgu.ac.kr", "FARM");
+            when(messageUtils.get(anyString(), any())).thenReturn("제목");
+            when(messageUtils.get(anyString(), any(), any(), any())).thenReturn("로그");
+
+            alarmService.sendRequestRejectedEmail(request, "신청서 양식 미흡");
+
+            ArgumentCaptor<SlackMessageDto> captor = ArgumentCaptor.forClass(SlackMessageDto.class);
+            verify(listOperations).rightPush(eq(QUEUE_KEY), captor.capture());
+            assertThat(captor.getValue().getWebhookUrl()).isEqualTo(NOTI_WEBHOOK);
+            assertThat(captor.getValue().getType()).isEqualTo(SlackMessageDto.MessageType.WEBHOOK);
+        }
+
+        @Test
+        @DisplayName("메일 전송 실패 시 에러 Slack 알림이 발송된다")
+        void sendRequestRejectedEmail_sendsSlackError_whenMailFails() {
+            Request request = mockRequest("홍길동", "hong@dgu.ac.kr", "FARM");
+            when(messageUtils.get(anyString(), any())).thenReturn("제목");
+            when(messageUtils.get(anyString(), any(), any(), any())).thenReturn("로그");
+            doThrow(new RuntimeException("SMTP 오류")).when(mailSender).send(any(SimpleMailMessage.class));
+
+            alarmService.sendRequestRejectedEmail(request, "신청서 양식 미흡");
+
+            ArgumentCaptor<SlackMessageDto> captor = ArgumentCaptor.forClass(SlackMessageDto.class);
+            verify(listOperations, atLeastOnce()).rightPush(eq(QUEUE_KEY), captor.capture());
+            assertThat(captor.getAllValues()).anyMatch(dto ->
+                    dto.getWebhookUrl().equals(ERROR_WEBHOOK));
+        }
+    }
+
+    @Nested
+    @DisplayName("sendModificationRejectedEmail")
+    class SendModificationRejectedEmail {
+
+        @Test
+        @DisplayName("사용자에게 변경 요청 거절 이메일이 발송된다")
+        void sendModificationRejectedEmail_sendsMailToUser() {
+            ChangeRequest changeRequest = mockChangeRequest("이순신", "lee@dgu.ac.kr", ChangeType.EXPIRES_AT);
+            when(messageUtils.get(anyString(), any())).thenReturn("[DGU AILab] 서버 변경 요청 거절 안내 (EXPIRES_AT)");
+            when(messageUtils.get(anyString(), any(), any(), any())).thenReturn("변경 거절 안내 본문");
+
+            alarmService.sendModificationRejectedEmail(changeRequest, "변경 사유 불충분");
+
+            ArgumentCaptor<SimpleMailMessage> captor = ArgumentCaptor.forClass(SimpleMailMessage.class);
+            verify(mailSender).send(captor.capture());
+            assertThat(captor.getValue().getTo()).containsExactly("lee@dgu.ac.kr");
+            assertThat(captor.getValue().getSubject()).isEqualTo("[DGU AILab] 서버 변경 요청 거절 안내 (EXPIRES_AT)");
+        }
+
+        @Test
+        @DisplayName("변경 요청 거절 이메일 발송 후 noti 채널에 모니터링 로그가 적재된다")
+        void sendModificationRejectedEmail_pushesMonitoringLogToNotiChannel() {
+            ChangeRequest changeRequest = mockChangeRequest("이순신", "lee@dgu.ac.kr", ChangeType.EXPIRES_AT);
+            when(messageUtils.get(anyString(), any())).thenReturn("제목");
+            when(messageUtils.get(anyString(), any(), any(), any())).thenReturn("로그");
+
+            alarmService.sendModificationRejectedEmail(changeRequest, "변경 사유 불충분");
+
+            ArgumentCaptor<SlackMessageDto> captor = ArgumentCaptor.forClass(SlackMessageDto.class);
+            verify(listOperations).rightPush(eq(QUEUE_KEY), captor.capture());
+            assertThat(captor.getValue().getWebhookUrl()).isEqualTo(NOTI_WEBHOOK);
+        }
+
+        @Test
+        @DisplayName("변경 유형이 이메일 제목에 포함된다")
+        void sendModificationRejectedEmail_includesChangeTypeInSubject() {
+            ChangeRequest changeRequest = mockChangeRequest("김철수", "kim@dgu.ac.kr", ChangeType.VOLUME_SIZE);
+            when(messageUtils.get(eq("email.modification.rejected.subject"), eq("VOLUME_SIZE")))
+                    .thenReturn("[DGU AILab] 서버 변경 요청 거절 안내 (VOLUME_SIZE)");
+            when(messageUtils.get(anyString(), any(), any(), any())).thenReturn("본문");
+
+            alarmService.sendModificationRejectedEmail(changeRequest, "볼륨 변경 불가");
+
+            ArgumentCaptor<SimpleMailMessage> captor = ArgumentCaptor.forClass(SimpleMailMessage.class);
+            verify(mailSender).send(captor.capture());
+            assertThat(captor.getValue().getSubject()).contains("VOLUME_SIZE");
+        }
+
+        @Test
+        @DisplayName("메일 전송 실패 시 에러 Slack 알림이 발송된다")
+        void sendModificationRejectedEmail_sendsSlackError_whenMailFails() {
+            ChangeRequest changeRequest = mockChangeRequest("이순신", "lee@dgu.ac.kr", ChangeType.EXPIRES_AT);
+            when(messageUtils.get(anyString(), any())).thenReturn("제목");
+            when(messageUtils.get(anyString(), any(), any(), any())).thenReturn("로그");
+            doThrow(new RuntimeException("SMTP 오류")).when(mailSender).send(any(SimpleMailMessage.class));
+
+            alarmService.sendModificationRejectedEmail(changeRequest, "변경 사유 불충분");
+
+            ArgumentCaptor<SlackMessageDto> captor = ArgumentCaptor.forClass(SlackMessageDto.class);
+            verify(listOperations, atLeastOnce()).rightPush(eq(QUEUE_KEY), captor.capture());
+            assertThat(captor.getAllValues()).anyMatch(dto ->
+                    dto.getWebhookUrl().equals(ERROR_WEBHOOK));
+        }
+    }
+
     private Request mockRequest(String userName, String serverName) {
         User user = mock(User.class);
         when(user.getName()).thenReturn(userName);
@@ -255,5 +374,27 @@ class AlarmServiceTest {
         when(request.getUser()).thenReturn(user);
         when(request.getResourceGroup()).thenReturn(rg);
         return request;
+    }
+
+    private Request mockRequest(String userName, String email, String serverName) {
+        User user = mock(User.class);
+        when(user.getName()).thenReturn(userName);
+        when(user.getEmail()).thenReturn(email);
+        ResourceGroup rg = mock(ResourceGroup.class);
+        when(rg.getServerName()).thenReturn(serverName);
+        Request request = mock(Request.class);
+        when(request.getUser()).thenReturn(user);
+        when(request.getResourceGroup()).thenReturn(rg);
+        return request;
+    }
+
+    private ChangeRequest mockChangeRequest(String userName, String email, ChangeType changeType) {
+        User user = mock(User.class);
+        when(user.getName()).thenReturn(userName);
+        when(user.getEmail()).thenReturn(email);
+        ChangeRequest changeRequest = mock(ChangeRequest.class);
+        when(changeRequest.getRequestedBy()).thenReturn(user);
+        when(changeRequest.getChangeType()).thenReturn(changeType);
+        return changeRequest;
     }
 }

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/requests/service/AdminRequestCommandServiceTest.java
@@ -428,6 +428,41 @@ class AdminRequestCommandServiceTest {
             assertThatThrownBy(() -> service.rejectRequest(dto))
                     .isInstanceOf(BusinessException.class);
         }
+
+        @Test
+        @DisplayName("거절 성공 시 alarmService.sendRequestRejectedEmail이 호출된다")
+        void rejectRequest_sendsRejectionEmail_onSuccess() {
+            Request request = buildMockedRequestWithStatus(35L, Status.PENDING);
+            RejectRequestDTO dto = new RejectRequestDTO(35L, "신청서 양식 미흡");
+
+            service.rejectRequest(dto);
+
+            verify(alarmService).sendRequestRejectedEmail(request, "신청서 양식 미흡");
+        }
+
+        @Test
+        @DisplayName("거절 사유가 이메일 발송 메서드에 그대로 전달된다")
+        void rejectRequest_passesAdminCommentToEmail() {
+            Request request = buildMockedRequestWithStatus(36L, Status.PENDING);
+            String comment = "서버 정원 초과로 인한 거절";
+            RejectRequestDTO dto = new RejectRequestDTO(36L, comment);
+
+            service.rejectRequest(dto);
+
+            verify(alarmService).sendRequestRejectedEmail(request, comment);
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 상태로 거절 시 이메일이 발송되지 않는다")
+        void rejectRequest_doesNotSendEmail_whenStatusIsInvalid() {
+            buildMockedRequestWithStatus(37L, Status.DENIED);
+            RejectRequestDTO dto = new RejectRequestDTO(37L, "사유");
+
+            assertThatThrownBy(() -> service.rejectRequest(dto))
+                    .isInstanceOf(BusinessException.class);
+
+            verify(alarmService, never()).sendRequestRejectedEmail(any(), anyString());
+        }
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -489,6 +524,47 @@ class AdminRequestCommandServiceTest {
 
             assertThatThrownBy(() -> service.rejectModification(999L, dto))
                     .isInstanceOf(BusinessException.class);
+        }
+
+        @Test
+        @DisplayName("변경 요청 거절 성공 시 alarmService.sendModificationRejectedEmail이 호출된다")
+        void rejectModification_sendsRejectionEmail_onSuccess() {
+            ChangeRequest changeRequest = mock(ChangeRequest.class);
+            when(changeRequest.getStatus()).thenReturn(Status.PENDING);
+            when(changeRequestRepository.findById(10L)).thenReturn(Optional.of(changeRequest));
+            when(userRepository.findById(100L)).thenReturn(Optional.of(mockUser));
+
+            RejectModificationDTO dto = new RejectModificationDTO(10L, "변경 사유 불충분");
+            service.rejectModification(100L, dto);
+
+            verify(alarmService).sendModificationRejectedEmail(changeRequest, "변경 사유 불충분");
+        }
+
+        @Test
+        @DisplayName("거절 사유가 이메일 발송 메서드에 그대로 전달된다")
+        void rejectModification_passesAdminCommentToEmail() {
+            ChangeRequest changeRequest = mock(ChangeRequest.class);
+            when(changeRequest.getStatus()).thenReturn(Status.PENDING);
+            when(changeRequestRepository.findById(11L)).thenReturn(Optional.of(changeRequest));
+            when(userRepository.findById(100L)).thenReturn(Optional.of(mockUser));
+            String comment = "리소스 여유 없음";
+
+            service.rejectModification(100L, new RejectModificationDTO(11L, comment));
+
+            verify(alarmService).sendModificationRejectedEmail(changeRequest, comment);
+        }
+
+        @Test
+        @DisplayName("PENDING이 아닌 상태에서 거절 시 이메일이 발송되지 않는다")
+        void rejectModification_doesNotSendEmail_whenStatusIsNotPending() {
+            ChangeRequest changeRequest = mock(ChangeRequest.class);
+            when(changeRequest.getStatus()).thenReturn(Status.FULFILLED);
+            when(changeRequestRepository.findById(12L)).thenReturn(Optional.of(changeRequest));
+
+            assertThatThrownBy(() -> service.rejectModification(100L, new RejectModificationDTO(12L, "사유")))
+                    .isInstanceOf(BusinessException.class);
+
+            verify(alarmService, never()).sendModificationRejectedEmail(any(), anyString());
         }
     }
 


### PR DESCRIPTION
## Summary

- 관리자가 신청을 거절하면 사용자에게 서버명·거절 사유가 담긴 이메일 발송
- 관리자가 변경 요청을 거절하면 사용자에게 변경 유형·거절 사유가 담긴 이메일 발송

## 변경 파일

- `AlarmService`: `sendRequestRejectedEmail`, `sendModificationRejectedEmail` 메서드 추가
- `AdminRequestCommandService`: `rejectRequest`, `rejectModification`에서 이메일 발송 호출
- `messages.properties`: 거절 안내 메일 템플릿 추가 (항목 9, 10)

## Test plan

- [ ] 관리자 페이지에서 신청 거절 후 해당 사용자 이메일 수신 확인
- [ ] 관리자 페이지에서 변경 요청 거절 후 해당 사용자 이메일 수신 확인
- [ ] 거절 사유가 이메일 본문에 정확히 포함되는지 확인
- [ ] Slack noti 채널에 발송 로그 기록되는지 확인

Closes #375