### PR TITLE
feat: 사용자 계정 Hard Delete 제거, Soft Delete 상태로 영구 보존

### DIFF
--- a/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/UserLifecycleTransactionalService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/UserLifecycleTransactionalService.java
@@ -60,18 +60,6 @@ public class UserLifecycleTransactionalService {
         }
     }
 
-    /**
-     * 특정 유저를 DB에서 완전 삭제(Hard Delete)합니다.
-     * 독립 트랜잭션으로 실행되어, 실패 시 다른 유저의 처리에 영향을 주지 않습니다.
-     */
-    @Transactional
-    public void hardDeleteUser(Long userId, String email) {
-        userRepository.findById(userId).ifPresent(user -> {
-            userRepository.delete(user);
-            log.info("계정 영구 삭제(Hard Delete) 완료: ID={}, Email={}", userId, email);
-        });
-    }
-
     private void sendWarningAlert(User user, long daysLeft, LocalDateTime deleteDate) {
         String dateStr = deleteDate.toLocalDate().toString();
         String subject = messageUtils.get("notification.user.delete-warning.subject", String.valueOf(daysLeft));

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/UserSchedulerService.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/scheduler/UserSchedulerService.java
@@ -20,7 +20,6 @@ public class UserSchedulerService {
     private final UserLifecycleTransactionalService userLifecycleService;
 
     private static final int INACTIVE_MONTHS = 3;
-    private static final int HARD_DELETE_YEARS = 1;
     // D-7 경고까지 포함하려면 (strict <) 기준일을 7+1=8일 앞당겨야 한다
     private static final int NOTIFICATION_LEAD_DAYS = 8;
 
@@ -31,7 +30,6 @@ public class UserSchedulerService {
         LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
 
         processInactiveUsers(now);
-        processHardDeleteUsers(now);
 
         log.info("👤 [스케줄러 종료]");
     }
@@ -46,20 +44,6 @@ public class UserSchedulerService {
                 userLifecycleService.processInactiveUser(user.getUserId(), now);
             } catch (Exception e) {
                 log.error("유저({}) 수명주기 처리 중 오류: {}", user.getEmail(), e.getMessage());
-            }
-        }
-    }
-
-    private void processHardDeleteUsers(LocalDateTime now) {
-        LocalDateTime hardDeleteThreshold = now.minusYears(HARD_DELETE_YEARS);
-        List<User> hardDeleteTargets = userRepository.findUsersForHardDelete(hardDeleteThreshold);
-
-        for (User user : hardDeleteTargets) {
-            try {
-                // 유저별 독립 트랜잭션으로 처리 — processInactiveUsers 결과에 영향 없음
-                userLifecycleService.hardDeleteUser(user.getUserId(), user.getEmail());
-            } catch (Exception e) {
-                log.error("Hard Delete 실패: {}", user.getEmail(), e);
             }
         }
     }

--- a/src/main/java/DGU_AI_LAB/admin_be/domain/users/repository/UserRepository.java
+++ b/src/main/java/DGU_AI_LAB/admin_be/domain/users/repository/UserRepository.java
@@ -32,11 +32,4 @@ public interface UserRepository extends JpaRepository<User,Long> {
             "  AND " +
             "  (MAX(r.expiresAt) IS NULL OR MAX(r.expiresAt) < :thresholdDate)")
     List<User> findInactiveUsers(@Param("thresholdDate") LocalDateTime thresholdDate);
-
-    /**
-     * [Hard Delete 대상 조회]
-     * 조건: Soft Delete 된 지 1년 지난 유저
-     */
-    @Query("SELECT u FROM User u WHERE u.isActive = false AND u.deletedAt < :hardDeleteThreshold")
-    List<User> findUsersForHardDelete(@Param("hardDeleteThreshold") LocalDateTime hardDeleteThreshold);
 }

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/scheduler/UserSchedulerServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/scheduler/UserSchedulerServiceTest.java
@@ -49,7 +49,7 @@ class UserSchedulerServiceTest {
 
 
     @Test
-    @DisplayName("유저 수명주기 통합 테스트: 알림(D-7, D-1), Soft Delete, Hard Delete, 활동 유저 보호")
+    @DisplayName("유저 수명주기 통합 테스트: 알림(D-7, D-1), Soft Delete, 활동 유저 보호")
     void userLifecycleScheduler_IntegrationTest() {
         // --- Given ---
         LocalDateTime now = LocalDateTime.now();
@@ -97,17 +97,6 @@ class UserSchedulerServiceTest {
         String softBody = messageUtils.get("notification.user.soft-delete.body", "SoftTarget");
 
 
-        // 6. [Hard Delete 대상]
-        User hardTarget = createUser("hard@test.com", "HardTarget");
-        hardTarget.withdraw();
-        updateDeletedAt(hardTarget, now.minusYears(1).minusDays(1));
-
-        // 7. [Hard Delete 미대상]
-        User hardSafe = createUser("hardsafe@test.com", "HardSafe");
-        hardSafe.withdraw();
-        updateDeletedAt(hardSafe, now.minusMonths(11));
-
-
         // --- When ---
         userSchedulerService.runUserLifecycleScheduler();
 
@@ -147,12 +136,6 @@ class UserSchedulerServiceTest {
                 eq(softSubject),
                 eq(softBody)
         );
-
-        // 6. [Hard Delete] 삭제 확인
-        assertThat(userRepository.findById(hardTarget.getUserId())).isEmpty();
-
-        // 7. [Hard Delete 미대상] 생존 확인
-        assertThat(userRepository.findById(hardSafe.getUserId())).isPresent();
     }
 
 
@@ -172,17 +155,6 @@ class UserSchedulerServiceTest {
     private void updateLastLogin(User user, LocalDateTime time) {
         try {
             var field = User.class.getDeclaredField("lastLoginAt");
-            field.setAccessible(true);
-            field.set(user, time);
-            userRepository.saveAndFlush(user);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private void updateDeletedAt(User user, LocalDateTime time) {
-        try {
-            var field = User.class.getDeclaredField("deletedAt");
             field.setAccessible(true);
             field.set(user, time);
             userRepository.saveAndFlush(user);

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/repository/UserRepositoryTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/repository/UserRepositoryTest.java
@@ -86,35 +86,4 @@ class UserRepositoryTest {
             assertThat(result).extracting(User::getEmail).contains("active@dgu.ac.kr");
         }
     }
-
-    @Nested
-    @DisplayName("findUsersForHardDelete")
-    class FindUsersForHardDelete {
-
-        @Test
-        @DisplayName("Soft delete 후 1년이 지나지 않은 유저는 Hard delete 대상이 아니다")
-        void findUsersForHardDelete_returnsEmpty_whenDeletedWithinOneYear() {
-            user1.withdraw();
-            userRepository.save(user1);
-            userRepository.flush();
-
-            List<User> result = userRepository.findUsersForHardDelete(LocalDateTime.now().minusYears(1));
-
-            assertThat(result).isEmpty();
-        }
-
-        @Test
-        @DisplayName("Soft delete된 지 1년이 지난 유저를 Hard delete 대상으로 조회한다")
-        void findUsersForHardDelete_returnsUser_whenDeletedBeforeOneYearThreshold() {
-            user1.withdraw();
-            ReflectionTestUtils.setField(user1, "deletedAt", LocalDateTime.now().minusYears(2));
-            userRepository.save(user1);
-            userRepository.flush();
-
-            List<User> result = userRepository.findUsersForHardDelete(LocalDateTime.now().minusYears(1));
-
-            assertThat(result).hasSize(1);
-            assertThat(result.get(0).getEmail()).isEqualTo("active@dgu.ac.kr");
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- 이력 보존을 위해 Soft Delete 1년 경과 후 사용자 row를 완전히 삭제하던 Hard Delete 단계를 스케줄러에서 제거
- 경고 이메일 발송, Soft Delete 처리는 그대로 유지. 이제 비활성화된 계정은 삭제되지 않고 영구 보존됨
- 더 이상 쓰이지 않는 hardDeleteUser(), findUsersForHardDelete() 제거, 관련 테스트 정리

## Test plan
- [x] ./gradlew test 통과 확인 (기존에도 실패하던 slack.bot-token 관련 7건 제외, 변경 전후 동일)
- [ ] 리뷰어 확인

Closes #379