### PR TITLE
chore: 배포 워크플로우 액션 버전 업데이트

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: 📦 소스 코드 체크아웃
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: ☕️ JDK 17 설정
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'


### PR DESCRIPTION
## Summary
- actions/checkout@v4 → v7
- actions/setup-java@v4 → v5
- 지난 배포(main #165) 로그에 뜬 Node.js 20 지원 종료 경고 해소

Closes #386

## Test plan
- [x] YAML 문법 검증
- [ ] main에 반영된 뒤 다음 배포 시 경고 없이 통과하는지 확인 (develop에는 이 워크플로우가 트리거되지 않으므로 여기서는 실행 검증 불가)