### PR TITLE
fix: admin-prod 재시작 시 DB 초기화 실패 방지 + 미사용 import 정리

### DIFF
--- a/helm/admin-prod/templates/deployment.yaml
+++ b/helm/admin-prod/templates/deployment.yaml
@@ -21,5 +21,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: 8080
+          env:
+            - name: SPRING_DATASOURCE_HIKARI_INITIALIZATION_FAIL_TIMEOUT
+              value: "-1"
           args:
             {{- toYaml .Values.args | nindent 12 }}

--- a/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserServiceTest.java
+++ b/src/test/java/DGU_AI_LAB/admin_be/domain/users/service/AdminUserServiceTest.java
@@ -2,7 +2,6 @@ package DGU_AI_LAB.admin_be.domain.users.service;
 
 import DGU_AI_LAB.admin_be.domain.alarm.service.AlarmService;
 import DGU_AI_LAB.admin_be.domain.containerImage.entity.ContainerImage;
-import DGU_AI_LAB.admin_be.domain.pod.entity.PodExternalPort;
 import DGU_AI_LAB.admin_be.domain.pod.repository.PodExternalPortRepository;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Request;
 import DGU_AI_LAB.admin_be.domain.requests.entity.Status;


### PR DESCRIPTION
## Summary
- Hikari `initialization-fail-timeout`을 -1로 설정해, 시작 시 DB 연결이 일시적으로 안 되더라도 애플리케이션이 바로 죽지 않고 재시도하도록 함
- AdminUserServiceTest의 미사용 import 제거

## Test plan
- [x] `./gradlew compileTestJava` 통과 확인